### PR TITLE
feat: add publish workflow to publish after every change in the main

### DIFF
--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -55,3 +55,12 @@ jobs:
           else
             echo "✅ Catalog is up-to-date."
           fi
+
+      - name: 📤 Upload artifacts for publish (only on main)
+        if: github.ref == 'refs/heads/main'
+        uses: actions/upload-artifact@v4
+        with:
+          name: built-catalog
+          path: |
+            packages/camel-catalog/dist/
+            catalog/

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,41 @@
+name: 🚀 Publish npm Package
+
+on:
+  workflow_run:
+    workflows: [ "📦 Build npm Package" ]
+    types:
+      - completed
+
+jobs:
+  publish:
+    if: >
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.head_branch == 'main'
+
+    runs-on: ubuntu-latest
+    steps:
+      - name: 🛎️ Checkout source code
+        uses: actions/checkout@v4
+
+      - name: 🧰 Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22.x'
+          registry-url: 'https://registry.npmjs.org'
+          scope: '@kaoto'
+          cache: 'yarn'
+
+      - name: 📦 Install deps & build
+        run: |
+          yarn
+
+      - name: 📥 Download built catalog
+        uses: actions/download-artifact@v4
+        with:
+          name: built-catalog
+
+      - name: 🚀 Publish
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.KAOTO_NPM_TOKEN }}
+        run: yarn publish


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automate the publishing of an npm package when the build workflow completes successfully. 

