### PR TITLE
chore: Add Citrus to 4.10.1

### DIFF
--- a/catalog/citrus/4.10.1/citrus-agent-configuration.json
+++ b/catalog/citrus/4.10.1/citrus-agent-configuration.json
@@ -1,0 +1,151 @@
+{
+  "$schema" : "http://json-schema.org/draft-07/schema#",
+  "type" : "object",
+  "properties" : {
+    "configClass" : {
+      "type" : "string",
+      "title" : "ConfigClass",
+      "description" : "Fully qualified configuration class name loaded as a Java bean configuration."
+    },
+    "defaultProperties" : {
+      "type" : "object",
+      "title" : "DefaultProperties",
+      "description" : "Sets default properties",
+      "additionalProperties" : {
+        "type" : "string",
+        "title" : "DefaultProperties",
+        "description" : "Sets default properties"
+      }
+    },
+    "dependencies" : {
+      "title" : "Dependencies",
+      "description" : "Set of additional Maven dependencies that should be loaded with the agent.",
+      "type" : "array",
+      "items" : {
+        "type" : "string",
+        "title" : "Dependencies",
+        "description" : "Set of additional Maven dependencies that should be loaded with the agent."
+      }
+    },
+    "engine" : {
+      "type" : "string",
+      "title" : "Engine",
+      "description" : "The test engine to use when running tests",
+      "default" : "junit5"
+    },
+    "includes" : {
+      "title" : "Includes",
+      "description" : "Test name patterns that specify which tests to include in the test run. Used when scanning packages for tests.",
+      "type" : "array",
+      "items" : {
+        "type" : "string",
+        "title" : "Includes",
+        "description" : "Test name patterns that specify which tests to include in the test run. Used when scanning packages for tests."
+      }
+    },
+    "inspectCode" : {
+      "type" : "boolean",
+      "title" : "InspectCode",
+      "description" : "When enabled the source code gets analyzed for required modules and dependencies that are added to the classpath."
+    },
+    "modules" : {
+      "title" : "Modules",
+      "description" : "Set of additional Citrus modules that should be loaded with the agent.",
+      "type" : "array",
+      "items" : {
+        "type" : "string",
+        "title" : "Modules",
+        "description" : "Set of additional Citrus modules that should be loaded with the agent."
+      }
+    },
+    "offline" : {
+      "type" : "boolean",
+      "title" : "Offline",
+      "description" : "When enabled there will be no attempts to resolve Maven artifacts via internet connection.",
+      "default" : "true"
+    },
+    "packages" : {
+      "title" : "Packages",
+      "description" : "List of package names to search for tests. All tests found in these packages are executed.",
+      "type" : "array",
+      "items" : {
+        "type" : "string",
+        "title" : "Packages",
+        "description" : "List of package names to search for tests. All tests found in these packages are executed."
+      }
+    },
+    "port" : {
+      "type" : "integer",
+      "title" : "Port",
+      "description" : "The Http port the agent service is listening on.",
+      "default" : "4567"
+    },
+    "reset" : {
+      "type" : "boolean",
+      "title" : "Reset",
+      "description" : "When enabled the Citrus context instance is reset after the test.",
+      "default" : "true"
+    },
+    "skipTests" : {
+      "type" : "boolean",
+      "title" : "SkipTests",
+      "description" : "When enabled no tests are run on application startup."
+    },
+    "systemExit" : {
+      "type" : "boolean",
+      "title" : "SystemExit",
+      "description" : "When enabled the application exits with an exit code after tests are run."
+    },
+    "testJar" : {
+      "type" : "string",
+      "title" : "TestJar",
+      "description" : "Set the test jar holding tests to execute. Jar file is used to perform package scans for test cases to run."
+    },
+    "testSources" : {
+      "title" : "TestSources",
+      "description" : "List of test sources to run. A test source represents a source code file in one of the supported languages (.java, .xml, .groovy, .yaml, .feature)",
+      "type" : "array",
+      "items" : {
+        "type" : "object",
+        "properties" : {
+          "filePath" : {
+            "type" : "string",
+            "title" : "FilePath",
+            "description" : "The source file path."
+          },
+          "name" : {
+            "type" : "string",
+            "title" : "Name",
+            "description" : "The source file name."
+          },
+          "type" : {
+            "type" : "string",
+            "title" : "Type",
+            "description" : "The test source type."
+          }
+        },
+        "additionalProperties" : false,
+        "title" : "TestSources",
+        "description" : "List of test sources to run. A test source represents a source code file in one of the supported languages (.java, .xml, .groovy, .yaml, .feature)"
+      }
+    },
+    "timeToLive" : {
+      "type" : "integer",
+      "title" : "TimeToLive",
+      "description" : "Set time to live for the Citrus application. When set the application terminates automatically when time is over."
+    },
+    "verbose" : {
+      "type" : "boolean",
+      "title" : "Verbose",
+      "description" : "When enabled the test run prints verbose messages.",
+      "default" : "true"
+    },
+    "workDir" : {
+      "type" : "string",
+      "title" : "WorkDir",
+      "description" : "Set custom working directory. File system based test engines may use this directory to read files from."
+    }
+  },
+  "required" : [ "engine", "port" ],
+  "additionalProperties" : false
+}

--- a/catalog/citrus/4.10.1/citrus-catalog-aggregate-endpoints.json
+++ b/catalog/citrus/4.10.1/citrus-catalog-aggregate-endpoints.json
@@ -1,0 +1,3307 @@
+{
+  "kubernetes-client": {
+    "kind": "testEndpoint",
+    "version": "4.10.1",
+    "name": "kubernetes-client",
+    "group": "kubernetes",
+    "module": "citrus-kubernetes",
+    "title": "KubernetesClient",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "certFile": {
+          "type": "string",
+          "title": "CertFile",
+          "description": "Sets the client certificate.",
+          "$comment": "group:security"
+        },
+        "client": {
+          "type": "string",
+          "title": "Client",
+          "description": "Sets the reference to the Kubernetes client implementation.",
+          "$comment": "group:advanced"
+        },
+        "messageConverter": {
+          "type": "string",
+          "title": "MessageConverter",
+          "description": "Sets the message converter as a bean reference.",
+          "$comment": "group:advanced"
+        },
+        "name": {
+          "type": "string",
+          "title": "Name",
+          "description": "The name of the endpoint"
+        },
+        "namespace": {
+          "type": "string",
+          "title": "Namespace",
+          "description": "Sets the namespace on the cluster."
+        },
+        "oAuthToken": {
+          "type": "string",
+          "title": "OAuthToken",
+          "description": "Sets the OAuth token used to connect to the Kubernetes cluster.",
+          "$comment": "group:security"
+        },
+        "objectMapper": {
+          "type": "string",
+          "title": "ObjectMapper",
+          "description": "Sets the object mapper.",
+          "$comment": "group:advanced"
+        },
+        "password": {
+          "type": "string",
+          "title": "Password",
+          "description": "Sets the user password used to connect to the Kubernetes cluster.",
+          "$comment": "group:security"
+        },
+        "url": {
+          "type": "string",
+          "title": "Url",
+          "description": "Sets the master URL in the client configuration.",
+          "$comment": "group:advanced"
+        },
+        "username": {
+          "type": "string",
+          "title": "Username",
+          "description": "Sets the user name used to connect to the Kubernetes cluster.",
+          "$comment": "group:security"
+        },
+        "version": {
+          "type": "string",
+          "title": "Version",
+          "description": "Sets the Kubernetes client version.",
+          "$comment": "group:advanced"
+        }
+      },
+      "additionalProperties": false    }
+  },
+  "context-messageStore": {
+    "kind": "testEndpoint",
+    "version": "4.10.1",
+    "name": "context-messageStore",
+    "group": "context",
+    "module": "citrus-base",
+    "title": "ContextMessageStore",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "messageName": {
+          "type": "string",
+          "title": "MessageName",
+          "description": "The message name."
+        },
+        "name": {
+          "type": "string",
+          "title": "Name",
+          "description": "The name of the endpoint"
+        },
+        "timeout": {
+          "type": "integer",
+          "title": "Timeout",
+          "description": "The timeout when receiving messages from the message store."
+        }
+      },
+      "additionalProperties": false    }
+  },
+  "kafka-synchronous": {
+    "kind": "testEndpoint",
+    "version": "4.10.1",
+    "name": "kafka-synchronous",
+    "group": "kafka",
+    "module": "citrus-kafka",
+    "title": "KafkaSynchronous",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "autoCommit": {
+          "type": "boolean",
+          "title": "AutoCommit",
+          "description": "Sets auto commit handling for this endpoint.",
+          "$comment": "group:consume"
+        },
+        "autoCommitInterval": {
+          "type": "integer",
+          "title": "AutoCommitInterval",
+          "description": "Sets the auto commit interval.",
+          "$comment": "group:consume"
+        },
+        "clientId": {
+          "type": "string",
+          "title": "ClientId",
+          "description": "Sets the client id used to connect to the Kafka server.",
+          "$comment": "group:advanced"
+        },
+        "consumerGroup": {
+          "type": "string",
+          "title": "ConsumerGroup",
+          "description": "Sets the consumer group used by the endpoint.",
+          "$comment": "group:consume"
+        },
+        "consumerProperties": {
+          "type": "object",
+          "title": "ConsumerProperties",
+          "description": "Sets the Kafka consumer properties.",
+          "$comment": "group:consume"
+        },
+        "headerMapper": {
+          "type": "string",
+          "title": "HeaderMapper",
+          "description": "Sets the Kafka header mapper.",
+          "$comment": "group:advanced"
+        },
+        "keyDeserializer": {
+          "type": "string",
+          "title": "KeyDeserializer",
+          "description": "Sets the fully qualified key deserializer type class name.",
+          "$comment": "group:deserialize"
+        },
+        "keySerializer": {
+          "type": "string",
+          "title": "KeySerializer",
+          "description": "Sets the fully qualified key serializer type class name.",
+          "$comment": "group:serialize"
+        },
+        "messageConverter": {
+          "type": "string",
+          "title": "MessageConverter",
+          "description": "Sets the message converter as a bean reference.",
+          "$comment": "group:advanced"
+        },
+        "name": {
+          "type": "string",
+          "title": "Name",
+          "description": "The name of the endpoint"
+        },
+        "offsetReset": {
+          "type": "string",
+          "title": "OffsetReset",
+          "description": "Sets the offset reset.",
+          "$comment": "group:consume"
+        },
+        "partition": {
+          "type": "integer",
+          "title": "Partition",
+          "description": "Sets the Kafka topic partition."
+        },
+        "producerProperties": {
+          "type": "object",
+          "title": "ProducerProperties",
+          "description": "Sets the Kafka producer properties.",
+          "$comment": "group:produce"
+        },
+        "server": {
+          "type": "string",
+          "title": "Server",
+          "description": "Sets the Kafka bootstrap server."
+        },
+        "timeout": {
+          "type": "integer",
+          "title": "Timeout",
+          "description": "Sets the Kafka consumer timeout.",
+          "$comment": "group:consume"
+        },
+        "topic": {
+          "type": "string",
+          "title": "Topic",
+          "description": "Sets the Kafka topic."
+        },
+        "valueDeserializer": {
+          "type": "string",
+          "title": "ValueDeserializer",
+          "description": "Sets the fully qualified value deserializer type class name.",
+          "$comment": "group:deserialize"
+        },
+        "valueSerializer": {
+          "type": "string",
+          "title": "ValueSerializer",
+          "description": "Sets the fully qualified value serializer type class name.",
+          "$comment": "group:serialize"
+        }
+      },
+      "additionalProperties": false    }
+  },
+  "scp-server": {
+    "kind": "testEndpoint",
+    "version": "4.10.1",
+    "name": "scp-server",
+    "group": "scp",
+    "module": "citrus-ftp",
+    "title": "ScpServer",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "allowedKeyPath": {
+          "type": "string",
+          "title": "AllowedKeyPath",
+          "description": "Sets the allowed key certificate path.",
+          "$comment": "group:security"
+        },
+        "autoConnect": {
+          "type": "boolean",
+          "title": "AutoConnect",
+          "description": "When enabled the server uses automatic connect mode."
+        },
+        "autoLogin": {
+          "type": "boolean",
+          "title": "AutoLogin",
+          "description": "When enabled the server uses automatic login mode."
+        },
+        "autoStart": {
+          "type": "boolean",
+          "title": "AutoStart",
+          "description": "When enabled the server is automatically started after creation."
+        },
+        "debugLogging": {
+          "type": "boolean",
+          "title": "DebugLogging",
+          "description": "When enabled the server prints debug logging output.",
+          "$comment": "group:advanced"
+        },
+        "endpointAdapter": {
+          "type": "string",
+          "title": "EndpointAdapter",
+          "description": "Sets a custom endpoint adapter to handle requests.",
+          "$comment": "group:advanced"
+        },
+        "hostKeyPath": {
+          "type": "string",
+          "title": "HostKeyPath",
+          "description": "Sets the host key certificate path.",
+          "$comment": "group:security"
+        },
+        "knownHosts": {
+          "type": "string",
+          "title": "KnownHosts",
+          "description": "List of known hosts.",
+          "$comment": "group:security"
+        },
+        "name": {
+          "type": "string",
+          "title": "Name",
+          "description": "The name of the endpoint"
+        },
+        "password": {
+          "type": "string",
+          "title": "Password",
+          "description": "Sets the allowed user password.",
+          "$comment": "group:security"
+        },
+        "pollingInterval": {
+          "type": "integer",
+          "title": "PollingInterval",
+          "description": "Sets the polling interval when consuming messages."
+        },
+        "port": {
+          "type": "integer",
+          "title": "Port",
+          "description": "The Ftp server port."
+        },
+        "preferredAuthentications": {
+          "type": "string",
+          "title": "PreferredAuthentications",
+          "description": "Sets the preferred authentication mechanism.",
+          "$comment": "group:security"
+        },
+        "privateKeyPassword": {
+          "type": "string",
+          "title": "PrivateKeyPassword",
+          "description": "Sets the private key password.",
+          "$comment": "group:security"
+        },
+        "privateKeyPath": {
+          "type": "string",
+          "title": "PrivateKeyPath",
+          "description": "Sets the private key certificate path.",
+          "$comment": "group:security"
+        },
+        "sessionConfigs": {
+          "type": "object",
+          "title": "SessionConfigs",
+          "description": "The session configuration.",
+          "additionalProperties": {
+            "type": "string",
+            "title": "SessionConfigs",
+            "description": "The session configuration."
+          }
+        },
+        "strictHostChecking": {
+          "type": "boolean",
+          "title": "StrictHostChecking",
+          "description": "Enable strict host checking.",
+          "$comment": "group:security"
+        },
+        "timeout": {
+          "type": "integer",
+          "title": "Timeout",
+          "description": "The server timeout.",
+          "default": "5000"
+        },
+        "user": {
+          "type": "string",
+          "title": "User",
+          "description": "Sets the allowed user name."
+        },
+        "userHomePath": {
+          "type": "string",
+          "title": "UserHomePath",
+          "description": "Sets the user home path directory."
+        }
+      },
+      "additionalProperties": false    }
+  },
+  "direct-synchronous": {
+    "kind": "testEndpoint",
+    "version": "4.10.1",
+    "name": "direct-synchronous",
+    "group": "direct",
+    "module": "citrus-base",
+    "title": "DirectSynchronous",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "autoCreateQueue": {
+          "type": "boolean",
+          "title": "AutoCreateQueue",
+          "description": "When set the queue is automatically created when it does not exist in bean registry."
+        },
+        "correlator": {
+          "type": "string",
+          "title": "Correlator",
+          "description": "Sets the message correlator.",
+          "$comment": "group:advanced"
+        },
+        "name": {
+          "type": "string",
+          "title": "Name",
+          "description": "The name of the endpoint"
+        },
+        "pollingInterval": {
+          "type": "integer",
+          "title": "PollingInterval",
+          "description": "Sets the polling interval when consuming messages."
+        },
+        "queue": {
+          "type": "string",
+          "title": "Queue",
+          "description": "The queue name."
+        },
+        "timeout": {
+          "type": "integer",
+          "title": "Timeout",
+          "description": "The timeout when receiving messages from the queue."
+        }
+      },
+      "additionalProperties": false    }
+  },
+  "docker-client": {
+    "kind": "testEndpoint",
+    "version": "4.10.1",
+    "name": "docker-client",
+    "group": "docker",
+    "module": "citrus-docker",
+    "title": "DockerClient",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "certPath": {
+          "type": "string",
+          "title": "CertPath",
+          "description": "Sets the path to the client certificate.",
+          "$comment": "group:security"
+        },
+        "configPath": {
+          "type": "string",
+          "title": "ConfigPath",
+          "description": "Sets the path to the client configuration file.",
+          "$comment": "group:advanced"
+        },
+        "email": {
+          "type": "string",
+          "title": "Email",
+          "description": "The Docker client email.",
+          "$comment": "group:security"
+        },
+        "name": {
+          "type": "string",
+          "title": "Name",
+          "description": "The name of the endpoint"
+        },
+        "password": {
+          "type": "string",
+          "title": "Password",
+          "description": "The Docker client password.",
+          "$comment": "group:security"
+        },
+        "registry": {
+          "type": "string",
+          "title": "Registry",
+          "description": "The Docker registry URL."
+        },
+        "url": {
+          "type": "string",
+          "title": "Url",
+          "description": "The Docker host engine URL."
+        },
+        "username": {
+          "type": "string",
+          "title": "Username",
+          "description": "The Docker client username.",
+          "$comment": "group:security"
+        },
+        "verifyTls": {
+          "type": "boolean",
+          "title": "VerifyTls",
+          "description": "When enabled the client verifies the Docker host TLS.",
+          "$comment": "group:security"
+        },
+        "version": {
+          "type": "string",
+          "title": "Version",
+          "description": "The Docker client version."
+        }
+      },
+      "additionalProperties": false    }
+  },
+  "kafka-asynchronous": {
+    "kind": "testEndpoint",
+    "version": "4.10.1",
+    "name": "kafka-asynchronous",
+    "group": "kafka",
+    "module": "citrus-kafka",
+    "title": "KafkaAsynchronous",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "autoCommit": {
+          "type": "boolean",
+          "title": "AutoCommit",
+          "description": "Sets auto commit handling for this endpoint.",
+          "$comment": "group:consume"
+        },
+        "autoCommitInterval": {
+          "type": "integer",
+          "title": "AutoCommitInterval",
+          "description": "Sets the auto commit interval.",
+          "$comment": "group:consume"
+        },
+        "clientId": {
+          "type": "string",
+          "title": "ClientId",
+          "description": "Sets the client id used to connect to the Kafka server.",
+          "$comment": "group:advanced"
+        },
+        "consumerGroup": {
+          "type": "string",
+          "title": "ConsumerGroup",
+          "description": "Sets the consumer group used by the endpoint.",
+          "$comment": "group:consume"
+        },
+        "consumerProperties": {
+          "type": "object",
+          "title": "ConsumerProperties",
+          "description": "Sets the Kafka consumer properties.",
+          "$comment": "group:consume"
+        },
+        "headerMapper": {
+          "type": "string",
+          "title": "HeaderMapper",
+          "description": "Sets the Kafka header mapper.",
+          "$comment": "group:advanced"
+        },
+        "keyDeserializer": {
+          "type": "string",
+          "title": "KeyDeserializer",
+          "description": "Sets the fully qualified key deserializer type class name.",
+          "$comment": "group:deserialize"
+        },
+        "keySerializer": {
+          "type": "string",
+          "title": "KeySerializer",
+          "description": "Sets the fully qualified key serializer type class name.",
+          "$comment": "group:serialize"
+        },
+        "messageConverter": {
+          "type": "string",
+          "title": "MessageConverter",
+          "description": "Sets the message converter as a bean reference.",
+          "$comment": "group:advanced"
+        },
+        "name": {
+          "type": "string",
+          "title": "Name",
+          "description": "The name of the endpoint"
+        },
+        "offsetReset": {
+          "type": "string",
+          "title": "OffsetReset",
+          "description": "Sets the offset reset.",
+          "$comment": "group:consume"
+        },
+        "partition": {
+          "type": "integer",
+          "title": "Partition",
+          "description": "Sets the Kafka topic partition."
+        },
+        "producerProperties": {
+          "type": "object",
+          "title": "ProducerProperties",
+          "description": "Sets the Kafka producer properties.",
+          "$comment": "group:produce"
+        },
+        "server": {
+          "type": "string",
+          "title": "Server",
+          "description": "Sets the Kafka bootstrap server."
+        },
+        "timeout": {
+          "type": "integer",
+          "title": "Timeout",
+          "description": "Sets the Kafka consumer timeout.",
+          "$comment": "group:consume"
+        },
+        "topic": {
+          "type": "string",
+          "title": "Topic",
+          "description": "Sets the Kafka topic."
+        },
+        "valueDeserializer": {
+          "type": "string",
+          "title": "ValueDeserializer",
+          "description": "Sets the fully qualified value deserializer type class name.",
+          "$comment": "group:deserialize"
+        },
+        "valueSerializer": {
+          "type": "string",
+          "title": "ValueSerializer",
+          "description": "Sets the fully qualified value serializer type class name.",
+          "$comment": "group:serialize"
+        }
+      },
+      "additionalProperties": false    }
+  },
+  "k8s-client": {
+    "kind": "testEndpoint",
+    "version": "4.10.1",
+    "name": "k8s-client",
+    "group": "k8s",
+    "module": "citrus-kubernetes",
+    "title": "K8sClient",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "certFile": {
+          "type": "string",
+          "title": "CertFile",
+          "description": "Sets the client certificate.",
+          "$comment": "group:security"
+        },
+        "client": {
+          "type": "string",
+          "title": "Client",
+          "description": "Sets the reference to the Kubernetes client implementation.",
+          "$comment": "group:advanced"
+        },
+        "messageConverter": {
+          "type": "string",
+          "title": "MessageConverter",
+          "description": "Sets the message converter as a bean reference.",
+          "$comment": "group:advanced"
+        },
+        "name": {
+          "type": "string",
+          "title": "Name",
+          "description": "The name of the endpoint"
+        },
+        "namespace": {
+          "type": "string",
+          "title": "Namespace",
+          "description": "Sets the namespace on the cluster."
+        },
+        "oAuthToken": {
+          "type": "string",
+          "title": "OAuthToken",
+          "description": "Sets the OAuth token used to connect to the Kubernetes cluster.",
+          "$comment": "group:security"
+        },
+        "objectMapper": {
+          "type": "string",
+          "title": "ObjectMapper",
+          "description": "Sets the object mapper.",
+          "$comment": "group:advanced"
+        },
+        "password": {
+          "type": "string",
+          "title": "Password",
+          "description": "Sets the user password used to connect to the Kubernetes cluster.",
+          "$comment": "group:security"
+        },
+        "url": {
+          "type": "string",
+          "title": "Url",
+          "description": "Sets the master URL in the client configuration.",
+          "$comment": "group:advanced"
+        },
+        "username": {
+          "type": "string",
+          "title": "Username",
+          "description": "Sets the user name used to connect to the Kubernetes cluster.",
+          "$comment": "group:security"
+        },
+        "version": {
+          "type": "string",
+          "title": "Version",
+          "description": "Sets the Kubernetes client version.",
+          "$comment": "group:advanced"
+        }
+      },
+      "additionalProperties": false    }
+  },
+  "mail-client": {
+    "kind": "testEndpoint",
+    "version": "4.10.1",
+    "name": "mail-client",
+    "group": "mail",
+    "module": "citrus-mail",
+    "title": "MailClient",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "host": {
+          "type": "string",
+          "title": "Host",
+          "description": "The mail server host to connect to."
+        },
+        "javaMailProperties": {
+          "type": "object",
+          "title": "JavaMailProperties",
+          "description": "Custom properties passed to the java mail implementation.",
+          "$comment": "group:advanced"
+        },
+        "marshaller": {
+          "type": "string",
+          "title": "Marshaller",
+          "description": "Sets a custom mail message marshaller.",
+          "$comment": "group:advanced"
+        },
+        "messageConverter": {
+          "type": "string",
+          "title": "MessageConverter",
+          "description": "Sets custom message converter.",
+          "$comment": "group:advanced"
+        },
+        "name": {
+          "type": "string",
+          "title": "Name",
+          "description": "The name of the endpoint"
+        },
+        "password": {
+          "type": "string",
+          "title": "Password",
+          "description": "The client user password.",
+          "$comment": "group:security"
+        },
+        "port": {
+          "type": "integer",
+          "title": "Port",
+          "description": "The mail server port."
+        },
+        "protocol": {
+          "type": "string",
+          "title": "Protocol",
+          "description": "The mail protocol."
+        },
+        "timeout": {
+          "type": "integer",
+          "title": "Timeout",
+          "description": "Mail client timeout when waiting for a response."
+        },
+        "username": {
+          "type": "string",
+          "title": "Username",
+          "description": "The client user name.",
+          "$comment": "group:security"
+        }
+      },
+      "additionalProperties": false    }
+  },
+  "http-client": {
+    "kind": "testEndpoint",
+    "version": "4.10.1",
+    "name": "http-client",
+    "group": "http",
+    "module": "citrus-http",
+    "title": "HttpClient",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "authentication": {
+          "type": "string",
+          "title": "Authentication",
+          "description": "Use given authentication mechanism.",
+          "$comment": "group:security"
+        },
+        "binaryMediaTypes": {
+          "title": "BinaryMediaTypes",
+          "description": "Sets the list of binary media types.",
+          "$comment": "group:advanced",
+          "type": "array",
+          "items": {
+            "type": "string",
+            "title": "BinaryMediaTypes",
+            "description": "Sets the list of binary media types.",
+            "$comment": "group:advanced"
+          }
+        },
+        "charset": {
+          "type": "string",
+          "title": "Charset",
+          "description": "The default charset.",
+          "$comment": "group:advanced"
+        },
+        "contentType": {
+          "type": "string",
+          "title": "ContentType",
+          "description": "Sets the default content type header set for each request.",
+          "$comment": "group:advanced"
+        },
+        "correlator": {
+          "type": "string",
+          "title": "Correlator",
+          "description": "Sets the message correlator.",
+          "$comment": "group:advanced"
+        },
+        "defaultAcceptHeader": {
+          "type": "boolean",
+          "title": "DefaultAcceptHeader",
+          "description": "When enabled the client adds the default accept header to requests.",
+          "$comment": "group:advanced"
+        },
+        "disableRedirectHandling": {
+          "type": "boolean",
+          "title": "DisableRedirectHandling",
+          "description": "Disables the redirect handling for this client.",
+          "$comment": "group:advanced"
+        },
+        "endpointResolver": {
+          "type": "string",
+          "title": "EndpointResolver",
+          "description": "Sets the endpoint URI resolver.",
+          "$comment": "group:advanced"
+        },
+        "errorHandler": {
+          "type": "string",
+          "title": "ErrorHandler",
+          "description": "Sets a custom error handler.",
+          "$comment": "group:errorHandling"
+        },
+        "errorHandlingStrategy": {
+          "type": "string",
+          "enum": [
+            "THROWS_EXCEPTION",
+            "PROPAGATE"
+          ],
+          "title": "ErrorHandlingStrategy",
+          "description": "Sets the error handling strategy.",
+          "$comment": "group:errorHandling"
+        },
+        "handleCookies": {
+          "type": "boolean",
+          "title": "HandleCookies",
+          "description": "When enabled the client handles cookies.",
+          "$comment": "group:advanced"
+        },
+        "headerMapper": {
+          "type": "string",
+          "title": "HeaderMapper",
+          "description": "Sets a custom header mapper bean reference.",
+          "$comment": "group:advanced"
+        },
+        "interceptor": {
+          "type": "string",
+          "title": "Interceptor",
+          "description": "Sets a client interceptor.",
+          "$comment": "group:intercept"
+        },
+        "interceptors": {
+          "title": "Interceptors",
+          "description": "Sets the list of client interceptor bean references.",
+          "$comment": "group:intercept",
+          "type": "array",
+          "items": {
+            "type": "string",
+            "title": "Interceptors",
+            "description": "Sets the list of client interceptor bean references.",
+            "$comment": "group:intercept"
+          }
+        },
+        "messageConverter": {
+          "type": "string",
+          "title": "MessageConverter",
+          "description": "Bean reference to a message converter.",
+          "$comment": "group:advanced"
+        },
+        "name": {
+          "type": "string",
+          "title": "Name",
+          "description": "The name of the endpoint"
+        },
+        "pollingInterval": {
+          "type": "integer",
+          "title": "PollingInterval",
+          "description": "Sets the polling interval when consuming messages.",
+          "$comment": "group:advanced"
+        },
+        "requestFactory": {
+          "type": "string",
+          "title": "RequestFactory",
+          "description": "Reference to a request factory.",
+          "$comment": "group:advanced"
+        },
+        "requestMethod": {
+          "type": "string",
+          "enum": [
+            "GET",
+            "HEAD",
+            "POST",
+            "PUT",
+            "PATCH",
+            "DELETE",
+            "OPTIONS",
+            "TRACE"
+          ],
+          "title": "RequestMethod",
+          "description": "The default request method to use"
+        },
+        "requestUrl": {
+          "type": "string",
+          "title": "RequestUrl",
+          "description": "Sets the Http client request URL."
+        },
+        "restTemplate": {
+          "type": "string",
+          "title": "RestTemplate",
+          "description": "The reference to a REST template bean.",
+          "$comment": "group:advanced"
+        },
+        "securedConnection": {
+          "type": "string",
+          "title": "SecuredConnection",
+          "description": "Secure the connection with given security mechanism.",
+          "$comment": "group:security"
+        },
+        "timeout": {
+          "type": "integer",
+          "title": "Timeout",
+          "description": "The Http request timeout while waiting for a response",
+          "default": "5000"
+        }
+      },
+      "additionalProperties": false    }
+  },
+  "ssh-client": {
+    "kind": "testEndpoint",
+    "version": "4.10.1",
+    "name": "ssh-client",
+    "group": "ssh",
+    "module": "citrus-ssh",
+    "title": "SshClient",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "title": "Name",
+          "description": "The name of the endpoint"
+        }
+      },
+      "additionalProperties": false    }
+  },
+  "websocket-client": {
+    "kind": "testEndpoint",
+    "version": "4.10.1",
+    "name": "websocket-client",
+    "group": "websocket",
+    "module": "citrus-websocket",
+    "title": "WebsocketClient",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "endpointResolver": {
+          "type": "string",
+          "title": "EndpointResolver",
+          "description": "Sets the endpoint URI resolver.",
+          "$comment": "group:advanced"
+        },
+        "messageConverter": {
+          "type": "string",
+          "title": "MessageConverter",
+          "description": "Bean reference to a message converter.",
+          "$comment": "group:advanced"
+        },
+        "name": {
+          "type": "string",
+          "title": "Name",
+          "description": "The name of the endpoint"
+        },
+        "pollingInterval": {
+          "type": "integer",
+          "title": "PollingInterval",
+          "description": "Sets the polling interval when consuming messages.",
+          "$comment": "group:advanced"
+        },
+        "requestUrl": {
+          "type": "string",
+          "title": "RequestUrl",
+          "description": "Sets the client request URL."
+        },
+        "timeout": {
+          "type": "integer",
+          "title": "Timeout",
+          "description": "The Http request timeout while waiting for a response",
+          "default": "5000"
+        }
+      },
+      "additionalProperties": false    }
+  },
+  "channel-asynchronous": {
+    "kind": "testEndpoint",
+    "version": "4.10.1",
+    "name": "channel-asynchronous",
+    "group": "channel",
+    "module": "citrus-spring-integration",
+    "title": "ChannelAsynchronous",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "channel": {
+          "type": "string",
+          "title": "Channel",
+          "description": "The Spring message channel name."
+        },
+        "channelResolver": {
+          "type": "string",
+          "title": "ChannelResolver",
+          "description": "The channel destination resolver.",
+          "$comment": "group:advanced"
+        },
+        "filterInternalHeaders": {
+          "type": "boolean",
+          "title": "FilterInternalHeaders",
+          "description": "When enabled the endpoint removes all internal headers before sending a message.",
+          "$comment": "group:advanced"
+        },
+        "messageConverter": {
+          "type": "string",
+          "title": "MessageConverter",
+          "description": "Sets the message converter as a bean reference.",
+          "$comment": "group:advanced"
+        },
+        "messagingTemplate": {
+          "type": "string",
+          "title": "MessagingTemplate",
+          "description": "Sets a custom messaging template.",
+          "$comment": "group:advanced"
+        },
+        "name": {
+          "type": "string",
+          "title": "Name",
+          "description": "The name of the endpoint"
+        },
+        "timeout": {
+          "type": "integer",
+          "title": "Timeout",
+          "description": "Sets the receive timeout when waiting for messages.",
+          "default": "5000"
+        },
+        "useObjectMessages": {
+          "type": "boolean",
+          "title": "UseObjectMessages",
+          "description": "When enabled the endpoint uses object messages.",
+          "$comment": "group:advanced"
+        }
+      },
+      "additionalProperties": false    }
+  },
+  "soap-server": {
+    "kind": "testEndpoint",
+    "version": "4.10.1",
+    "name": "soap-server",
+    "group": "soap",
+    "module": "citrus-ws",
+    "title": "SoapServer",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "autoStart": {
+          "type": "boolean",
+          "title": "AutoStart",
+          "description": "When enabled the server is automatically started after creation."
+        },
+        "connector": {
+          "type": "string",
+          "title": "Connector",
+          "description": "Add a connector to this server.",
+          "$comment": "group:servlet"
+        },
+        "connectors": {
+          "title": "Connectors",
+          "description": "Sets a list of connectors for this server.",
+          "$comment": "group:servlet",
+          "type": "array",
+          "items": {
+            "type": "string",
+            "title": "Connectors",
+            "description": "Sets a list of connectors for this server.",
+            "$comment": "group:servlet"
+          }
+        },
+        "contextConfigLocation": {
+          "type": "string",
+          "title": "ContextConfigLocation",
+          "description": "Sets the path to the Spring context configuration for this server.",
+          "$comment": "group:advanced"
+        },
+        "contextPath": {
+          "type": "string",
+          "title": "ContextPath",
+          "description": "Sets the context path on this server.",
+          "$comment": "group:servlet"
+        },
+        "debugLogging": {
+          "type": "boolean",
+          "title": "DebugLogging",
+          "description": "When enabled the server prints debug logging output.",
+          "$comment": "group:advanced"
+        },
+        "endpointAdapter": {
+          "type": "string",
+          "title": "EndpointAdapter",
+          "description": "Sets a custom endpoint adapter to handle requests.",
+          "$comment": "group:advanced"
+        },
+        "handleAttributeHeaders": {
+          "type": "boolean",
+          "title": "HandleAttributeHeaders",
+          "description": "When enabled the server handles attribute headers.",
+          "$comment": "group:advanced"
+        },
+        "handleMimeHeaders": {
+          "type": "boolean",
+          "title": "HandleMimeHeaders",
+          "description": "When enabled the server handles mime headers.",
+          "$comment": "group:advanced"
+        },
+        "interceptor": {
+          "type": "string",
+          "title": "Interceptor",
+          "description": "Sets a endpoint interceptor.",
+          "$comment": "group:intercept"
+        },
+        "interceptors": {
+          "title": "Interceptors",
+          "description": "Sets the list of endpoint interceptor bean references.",
+          "$comment": "group:intercept",
+          "type": "array",
+          "items": {
+            "type": "string",
+            "title": "Interceptors",
+            "description": "Sets the list of endpoint interceptor bean references.",
+            "$comment": "group:intercept"
+          }
+        },
+        "keepSoapEnvelope": {
+          "type": "boolean",
+          "title": "KeepSoapEnvelope",
+          "description": "When enabled the server does not remove the SOAP envelope before processing messages.",
+          "$comment": "group:advanced"
+        },
+        "messageConverter": {
+          "type": "string",
+          "title": "MessageConverter",
+          "description": "Sets the Http message converter bean reference.",
+          "$comment": "group:advanced"
+        },
+        "messageFactory": {
+          "type": "string",
+          "title": "MessageFactory",
+          "description": "Sets a custom message factory.",
+          "$comment": "group:advanced"
+        },
+        "name": {
+          "type": "string",
+          "title": "Name",
+          "description": "The name of the endpoint"
+        },
+        "port": {
+          "type": "integer",
+          "title": "Port",
+          "description": "The SOAP WebService server port."
+        },
+        "resourceBase": {
+          "type": "string",
+          "title": "ResourceBase",
+          "description": "Sets the resource base path where the server reads resources from.",
+          "$comment": "group:advanced"
+        },
+        "rootParentContext": {
+          "type": "boolean",
+          "title": "RootParentContext",
+          "description": "When enabled the server uses the root Spring application context.",
+          "$comment": "group:advanced"
+        },
+        "securityHandler": {
+          "type": "string",
+          "title": "SecurityHandler",
+          "description": "Sets the security handler as a bean reference.",
+          "$comment": "group:security"
+        },
+        "serServletHandler": {
+          "type": "string",
+          "title": "SerServletHandler",
+          "description": "Sets a custom servlet handler as a bean reference.",
+          "$comment": "group:servlet"
+        },
+        "servletMappingPath": {
+          "type": "string",
+          "title": "ServletMappingPath",
+          "description": "Sets the servlet mapping path.",
+          "$comment": "group:servlet"
+        },
+        "servletName": {
+          "type": "string",
+          "title": "ServletName",
+          "description": "Sets the servlet name.",
+          "$comment": "group:servlet"
+        },
+        "soapHeaderNamespace": {
+          "type": "string",
+          "title": "SoapHeaderNamespace",
+          "description": "Sets the SOAP header namespace.",
+          "$comment": "group:advanced"
+        },
+        "soapHeaderPrefix": {
+          "type": "string",
+          "title": "SoapHeaderPrefix",
+          "description": "Sets the SOAP header namespace prefix.",
+          "$comment": "group:advanced"
+        },
+        "timeout": {
+          "type": "integer",
+          "title": "Timeout",
+          "description": "Sets the server timeout while waiting for incoming requests.",
+          "default": "5000"
+        }
+      },
+      "additionalProperties": false    }
+  },
+  "channel-synchronous": {
+    "kind": "testEndpoint",
+    "version": "4.10.1",
+    "name": "channel-synchronous",
+    "group": "channel",
+    "module": "citrus-spring-integration",
+    "title": "ChannelSynchronous",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "channel": {
+          "type": "string",
+          "title": "Channel",
+          "description": "The Spring message channel name."
+        },
+        "channelResolver": {
+          "type": "string",
+          "title": "ChannelResolver",
+          "description": "The channel destination resolver.",
+          "$comment": "group:advanced"
+        },
+        "correlator": {
+          "type": "string",
+          "title": "Correlator",
+          "description": "Sets the message correlator.",
+          "$comment": "group:advanced"
+        },
+        "filterInternalHeaders": {
+          "type": "boolean",
+          "title": "FilterInternalHeaders",
+          "description": "When enabled the endpoint removes all internal headers before sending a message.",
+          "$comment": "group:advanced"
+        },
+        "messageConverter": {
+          "type": "string",
+          "title": "MessageConverter",
+          "description": "Sets the message converter as a bean reference.",
+          "$comment": "group:advanced"
+        },
+        "messagingTemplate": {
+          "type": "string",
+          "title": "MessagingTemplate",
+          "description": "Sets a custom messaging template.",
+          "$comment": "group:advanced"
+        },
+        "name": {
+          "type": "string",
+          "title": "Name",
+          "description": "The name of the endpoint"
+        },
+        "pollingInterval": {
+          "type": "integer",
+          "title": "PollingInterval",
+          "description": "Sets the polling interval.",
+          "$comment": "group:advanced"
+        },
+        "timeout": {
+          "type": "integer",
+          "title": "Timeout",
+          "description": "Sets the receive timeout when waiting for messages.",
+          "default": "5000"
+        },
+        "useObjectMessages": {
+          "type": "boolean",
+          "title": "UseObjectMessages",
+          "description": "When enabled the endpoint uses object messages.",
+          "$comment": "group:advanced"
+        }
+      },
+      "additionalProperties": false    }
+  },
+  "sftp-server": {
+    "kind": "testEndpoint",
+    "version": "4.10.1",
+    "name": "sftp-server",
+    "group": "sftp",
+    "module": "citrus-ftp",
+    "title": "SftpServer",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "allowedKeyPath": {
+          "type": "string",
+          "title": "AllowedKeyPath",
+          "description": "Sets the allowed key certificate path.",
+          "$comment": "group:security"
+        },
+        "autoConnect": {
+          "type": "boolean",
+          "title": "AutoConnect",
+          "description": "When enabled the server uses automatic connect mode."
+        },
+        "autoLogin": {
+          "type": "boolean",
+          "title": "AutoLogin",
+          "description": "When enabled the server uses automatic login mode."
+        },
+        "autoStart": {
+          "type": "boolean",
+          "title": "AutoStart",
+          "description": "When enabled the server is automatically started after creation."
+        },
+        "debugLogging": {
+          "type": "boolean",
+          "title": "DebugLogging",
+          "description": "When enabled the server prints debug logging output.",
+          "$comment": "group:advanced"
+        },
+        "endpointAdapter": {
+          "type": "string",
+          "title": "EndpointAdapter",
+          "description": "Sets a custom endpoint adapter to handle requests.",
+          "$comment": "group:advanced"
+        },
+        "hostKeyPath": {
+          "type": "string",
+          "title": "HostKeyPath",
+          "description": "Sets the host key certificate path.",
+          "$comment": "group:security"
+        },
+        "knownHosts": {
+          "type": "string",
+          "title": "KnownHosts",
+          "description": "List of known hosts.",
+          "$comment": "group:security"
+        },
+        "name": {
+          "type": "string",
+          "title": "Name",
+          "description": "The name of the endpoint"
+        },
+        "password": {
+          "type": "string",
+          "title": "Password",
+          "description": "Sets the allowed user password.",
+          "$comment": "group:security"
+        },
+        "pollingInterval": {
+          "type": "integer",
+          "title": "PollingInterval",
+          "description": "Sets the polling interval when consuming messages."
+        },
+        "port": {
+          "type": "integer",
+          "title": "Port",
+          "description": "The Ftp server port."
+        },
+        "preferredAuthentications": {
+          "type": "string",
+          "title": "PreferredAuthentications",
+          "description": "Sets the preferred authentication mechanism.",
+          "$comment": "group:security"
+        },
+        "privateKeyPassword": {
+          "type": "string",
+          "title": "PrivateKeyPassword",
+          "description": "Sets the private key password.",
+          "$comment": "group:security"
+        },
+        "privateKeyPath": {
+          "type": "string",
+          "title": "PrivateKeyPath",
+          "description": "Sets the private key certificate path.",
+          "$comment": "group:security"
+        },
+        "sessionConfigs": {
+          "type": "object",
+          "title": "SessionConfigs",
+          "description": "The session configuration.",
+          "additionalProperties": {
+            "type": "string",
+            "title": "SessionConfigs",
+            "description": "The session configuration."
+          }
+        },
+        "strictHostChecking": {
+          "type": "boolean",
+          "title": "StrictHostChecking",
+          "description": "Enable strict host checking.",
+          "$comment": "group:security"
+        },
+        "timeout": {
+          "type": "integer",
+          "title": "Timeout",
+          "description": "The server timeout.",
+          "default": "5000"
+        },
+        "user": {
+          "type": "string",
+          "title": "User",
+          "description": "Sets the allowed user name."
+        },
+        "userHomePath": {
+          "type": "string",
+          "title": "UserHomePath",
+          "description": "Sets the user home path directory."
+        }
+      },
+      "additionalProperties": false    }
+  },
+  "ftp-server": {
+    "kind": "testEndpoint",
+    "version": "4.10.1",
+    "name": "ftp-server",
+    "group": "ftp",
+    "module": "citrus-ftp",
+    "title": "FtpServer",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "autoConnect": {
+          "type": "boolean",
+          "title": "AutoConnect",
+          "description": "When enabled the server uses automatic connect mode."
+        },
+        "autoHandleCommands": {
+          "type": "string",
+          "title": "AutoHandleCommands",
+          "description": "Enables the auto handle commands mode."
+        },
+        "autoLogin": {
+          "type": "boolean",
+          "title": "AutoLogin",
+          "description": "When enabled the server uses automatic login mode."
+        },
+        "autoReadFiles": {
+          "type": "boolean",
+          "title": "AutoReadFiles",
+          "description": "When enabled the client automatically reads new files."
+        },
+        "autoStart": {
+          "type": "boolean",
+          "title": "AutoStart",
+          "description": "When enabled the server is automatically started after creation."
+        },
+        "correlator": {
+          "type": "string",
+          "title": "Correlator",
+          "description": "Sets the message correlator.",
+          "$comment": "group:advanced"
+        },
+        "debugLogging": {
+          "type": "boolean",
+          "title": "DebugLogging",
+          "description": "When enabled the server prints debug logging output.",
+          "$comment": "group:advanced"
+        },
+        "endpointAdapter": {
+          "type": "string",
+          "title": "EndpointAdapter",
+          "description": "Sets a custom endpoint adapter to handle requests.",
+          "$comment": "group:advanced"
+        },
+        "errorHandlingStrategy": {
+          "type": "string",
+          "enum": [
+            "THROWS_EXCEPTION",
+            "PROPAGATE"
+          ],
+          "title": "ErrorHandlingStrategy",
+          "description": "Sets the error handling strategy.",
+          "$comment": "group:errorHandler"
+        },
+        "host": {
+          "type": "string",
+          "title": "Host",
+          "description": "The Ftp server host."
+        },
+        "listenerFactory": {
+          "type": "string",
+          "title": "ListenerFactory",
+          "description": "Sets a custom listener factory implementation.",
+          "$comment": "group:advanced"
+        },
+        "localPassiveMode": {
+          "type": "boolean",
+          "title": "LocalPassiveMode",
+          "description": "Enables the local passive mode."
+        },
+        "marshaller": {
+          "type": "string",
+          "title": "Marshaller",
+          "description": "Sets a custom Ftp message marshaller.",
+          "$comment": "group:advanced"
+        },
+        "name": {
+          "type": "string",
+          "title": "Name",
+          "description": "The name of the endpoint"
+        },
+        "password": {
+          "type": "string",
+          "title": "Password",
+          "description": "Sets the allowed user password.",
+          "$comment": "group:security"
+        },
+        "port": {
+          "type": "integer",
+          "title": "Port",
+          "description": "The Ftp server port."
+        },
+        "server": {
+          "type": "string",
+          "title": "Server",
+          "description": "Sets the Ftp server implementation.",
+          "$comment": "group:advanced"
+        },
+        "timeout": {
+          "type": "integer",
+          "title": "Timeout",
+          "description": "The server timeout.",
+          "default": "5000"
+        },
+        "user": {
+          "type": "string",
+          "title": "User",
+          "description": "Sets the allowed user name."
+        },
+        "userManager": {
+          "type": "string",
+          "title": "UserManager",
+          "description": "Sets a custom user manager implementation.",
+          "$comment": "group:advanced"
+        },
+        "userManagerProperties": {
+          "type": "string",
+          "title": "UserManagerProperties",
+          "description": "Loads user manage properties from a file resource.",
+          "$comment": "group:advanced"
+        }
+      },
+      "additionalProperties": false    }
+  },
+  "camel-inOut": {
+    "kind": "testEndpoint",
+    "version": "4.10.1",
+    "name": "camel-inOut",
+    "group": "camel",
+    "module": "citrus-camel",
+    "title": "CamelInOut",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "camelContext": {
+          "type": "string",
+          "title": "CamelContext",
+          "description": "The Camel context to use."
+        },
+        "correlator": {
+          "type": "string",
+          "title": "Correlator",
+          "description": "Sets the message correlator.",
+          "$comment": "group:advanced"
+        },
+        "endpointUri": {
+          "type": "string",
+          "title": "EndpointUri",
+          "description": "The Camel endpoint uri."
+        },
+        "messageConverter": {
+          "type": "string",
+          "title": "MessageConverter",
+          "description": "Sets the message converter as a bean reference.",
+          "$comment": "group:advanced"
+        },
+        "name": {
+          "type": "string",
+          "title": "Name",
+          "description": "The name of the endpoint"
+        },
+        "pollingInterval": {
+          "type": "integer",
+          "title": "PollingInterval",
+          "description": "Sets the polling interval when consuming messages."
+        },
+        "timeout": {
+          "type": "integer",
+          "title": "Timeout",
+          "description": "The endpoint timeout when waiting for messages."
+        }
+      },
+      "additionalProperties": false    }
+  },
+  "vertx-asynchronous": {
+    "kind": "testEndpoint",
+    "version": "4.10.1",
+    "name": "vertx-asynchronous",
+    "group": "vertx",
+    "module": "citrus-vertx",
+    "title": "VertxAsynchronous",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "address": {
+          "type": "string",
+          "title": "Address",
+          "description": "The event bus address."
+        },
+        "host": {
+          "type": "string",
+          "title": "Host",
+          "description": "The Vert.x event bus host."
+        },
+        "messageConverter": {
+          "type": "string",
+          "title": "MessageConverter",
+          "description": "Sets the message converter as a bean reference.",
+          "$comment": "group:advanced"
+        },
+        "name": {
+          "type": "string",
+          "title": "Name",
+          "description": "The name of the endpoint"
+        },
+        "pollingInterval": {
+          "type": "integer",
+          "title": "PollingInterval",
+          "description": "Sets the polling interval when consuming messages."
+        },
+        "port": {
+          "type": "integer",
+          "title": "Port",
+          "description": "The Vert.x event bus port."
+        },
+        "pubSubDomain": {
+          "type": "boolean",
+          "title": "PubSubDomain",
+          "description": "When enabled the endpoint uses publish/subscribe mode.",
+          "$comment": "group:advanced"
+        },
+        "timeout": {
+          "type": "integer",
+          "title": "Timeout",
+          "description": "The endpoint timeout when waiting for messages."
+        },
+        "vertxFactory": {
+          "type": "string",
+          "title": "VertxFactory",
+          "description": "Sets a custom Vert.x factory.",
+          "$comment": "group:advanced"
+        }
+      },
+      "additionalProperties": false    }
+  },
+  "ftp-client": {
+    "kind": "testEndpoint",
+    "version": "4.10.1",
+    "name": "ftp-client",
+    "group": "ftp",
+    "module": "citrus-ftp",
+    "title": "FtpClient",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "autoReadFiles": {
+          "type": "boolean",
+          "title": "AutoReadFiles",
+          "description": "When enabled the client automatically reads new files."
+        },
+        "correlator": {
+          "type": "string",
+          "title": "Correlator",
+          "description": "Sets the message correlator.",
+          "$comment": "group:advanced"
+        },
+        "errorHandlingStrategy": {
+          "type": "string",
+          "enum": [
+            "THROWS_EXCEPTION",
+            "PROPAGATE"
+          ],
+          "title": "ErrorHandlingStrategy",
+          "description": "Sets the error handling strategy.",
+          "$comment": "group:errorHandler"
+        },
+        "host": {
+          "type": "string",
+          "title": "Host",
+          "description": "The Ftp server host."
+        },
+        "localPassiveMode": {
+          "type": "boolean",
+          "title": "LocalPassiveMode",
+          "description": "SEnables the local passive mode."
+        },
+        "name": {
+          "type": "string",
+          "title": "Name",
+          "description": "The name of the endpoint"
+        },
+        "password": {
+          "type": "string",
+          "title": "Password",
+          "description": "Sets the user password.",
+          "$comment": "group:security"
+        },
+        "pollingInterval": {
+          "type": "integer",
+          "title": "PollingInterval",
+          "description": "Sets the polling interval when consuming messages."
+        },
+        "port": {
+          "type": "integer",
+          "title": "Port",
+          "description": "The Ftp server port."
+        },
+        "timeout": {
+          "type": "integer",
+          "title": "Timeout",
+          "description": "The endpoint timeout when waiting for messages."
+        },
+        "username": {
+          "type": "string",
+          "title": "Username",
+          "description": "Sets the user name.",
+          "$comment": "group:security"
+        }
+      },
+      "additionalProperties": false    }
+  },
+  "camel-asynchronous": {
+    "kind": "testEndpoint",
+    "version": "4.10.1",
+    "name": "camel-asynchronous",
+    "group": "camel",
+    "module": "citrus-camel",
+    "title": "CamelAsynchronous",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "camelContext": {
+          "type": "string",
+          "title": "CamelContext",
+          "description": "The Camel context to use."
+        },
+        "endpointUri": {
+          "type": "string",
+          "title": "EndpointUri",
+          "description": "The Camel endpoint uri."
+        },
+        "messageConverter": {
+          "type": "string",
+          "title": "MessageConverter",
+          "description": "Sets the message converter as a bean reference.",
+          "$comment": "group:advanced"
+        },
+        "name": {
+          "type": "string",
+          "title": "Name",
+          "description": "The name of the endpoint"
+        },
+        "timeout": {
+          "type": "integer",
+          "title": "Timeout",
+          "description": "The endpoint timeout when waiting for messages."
+        }
+      },
+      "additionalProperties": false    }
+  },
+  "scp-client": {
+    "kind": "testEndpoint",
+    "version": "4.10.1",
+    "name": "scp-client",
+    "group": "scp",
+    "module": "citrus-ftp",
+    "title": "ScpClient",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "autoReadFiles": {
+          "type": "boolean",
+          "title": "AutoReadFiles",
+          "description": "When enabled the client automatically reads new files."
+        },
+        "correlator": {
+          "type": "string",
+          "title": "Correlator",
+          "description": "Sets the message correlator.",
+          "$comment": "group:advanced"
+        },
+        "errorHandlingStrategy": {
+          "type": "string",
+          "enum": [
+            "THROWS_EXCEPTION",
+            "PROPAGATE"
+          ],
+          "title": "ErrorHandlingStrategy",
+          "description": "Sets the error handling strategy.",
+          "$comment": "group:errorHandler"
+        },
+        "host": {
+          "type": "string",
+          "title": "Host",
+          "description": "The Ftp server host."
+        },
+        "knownHosts": {
+          "type": "string",
+          "title": "KnownHosts",
+          "description": "List of known hosts.",
+          "$comment": "group:security"
+        },
+        "name": {
+          "type": "string",
+          "title": "Name",
+          "description": "The name of the endpoint"
+        },
+        "password": {
+          "type": "string",
+          "title": "Password",
+          "description": "Sets the user password.",
+          "$comment": "group:security"
+        },
+        "pollingInterval": {
+          "type": "integer",
+          "title": "PollingInterval",
+          "description": "Sets the polling interval when consuming messages."
+        },
+        "port": {
+          "type": "integer",
+          "title": "Port",
+          "description": "The Ftp server port."
+        },
+        "portOption": {
+          "type": "string",
+          "title": "PortOption",
+          "description": "Sets the port option.",
+          "$comment": "group:advanced"
+        },
+        "privateKeyPassword": {
+          "type": "string",
+          "title": "PrivateKeyPassword",
+          "description": "Sets the private key password.",
+          "$comment": "group:security"
+        },
+        "privateKeyPath": {
+          "type": "string",
+          "title": "PrivateKeyPath",
+          "description": "Sets the private key path.",
+          "$comment": "group:security"
+        },
+        "strictHostChecking": {
+          "type": "boolean",
+          "title": "StrictHostChecking",
+          "description": "Enable strict host checking.",
+          "$comment": "group:security"
+        },
+        "timeout": {
+          "type": "integer",
+          "title": "Timeout",
+          "description": "The endpoint timeout when waiting for messages."
+        },
+        "username": {
+          "type": "string",
+          "title": "Username",
+          "description": "Sets the user name.",
+          "$comment": "group:security"
+        }
+      },
+      "additionalProperties": false    }
+  },
+  "vertx-synchronous": {
+    "kind": "testEndpoint",
+    "version": "4.10.1",
+    "name": "vertx-synchronous",
+    "group": "vertx",
+    "module": "citrus-vertx",
+    "title": "VertxSynchronous",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "address": {
+          "type": "string",
+          "title": "Address",
+          "description": "The event bus address."
+        },
+        "correlator": {
+          "type": "string",
+          "title": "Correlator",
+          "description": "Sets the message correlator.",
+          "$comment": "group:advanced"
+        },
+        "host": {
+          "type": "string",
+          "title": "Host",
+          "description": "The Vert.x event bus host."
+        },
+        "messageConverter": {
+          "type": "string",
+          "title": "MessageConverter",
+          "description": "Sets the message converter as a bean reference.",
+          "$comment": "group:advanced"
+        },
+        "name": {
+          "type": "string",
+          "title": "Name",
+          "description": "The name of the endpoint"
+        },
+        "pollingInterval": {
+          "type": "integer",
+          "title": "PollingInterval",
+          "description": "Sets the polling interval when consuming messages."
+        },
+        "port": {
+          "type": "integer",
+          "title": "Port",
+          "description": "The Vert.x event bus port."
+        },
+        "pubSubDomain": {
+          "type": "boolean",
+          "title": "PubSubDomain",
+          "description": "When enabled the endpoint uses publish/subscribe mode.",
+          "$comment": "group:advanced"
+        },
+        "timeout": {
+          "type": "integer",
+          "title": "Timeout",
+          "description": "The endpoint timeout when waiting for messages."
+        },
+        "vertxFactory": {
+          "type": "string",
+          "title": "VertxFactory",
+          "description": "Sets a custom Vert.x factory.",
+          "$comment": "group:advanced"
+        }
+      },
+      "additionalProperties": false    }
+  },
+  "jms-synchronous": {
+    "kind": "testEndpoint",
+    "version": "4.10.1",
+    "name": "jms-synchronous",
+    "group": "jms",
+    "module": "citrus-jms",
+    "title": "JmsSynchronous",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "connectionFactory": {
+          "type": "string",
+          "title": "ConnectionFactory",
+          "description": "The JMS connection factory."
+        },
+        "correlator": {
+          "type": "string",
+          "title": "Correlator",
+          "description": "Sets the message correlator.",
+          "$comment": "group:advanced"
+        },
+        "destination": {
+          "type": "string",
+          "title": "Destination",
+          "description": "The JMS destination name."
+        },
+        "destinationNameResolver": {
+          "type": "string",
+          "title": "DestinationNameResolver",
+          "description": "Sets the destination name resolver.",
+          "$comment": "group:advanced"
+        },
+        "destinationResolver": {
+          "type": "string",
+          "title": "DestinationResolver",
+          "description": "Sets the destination resolver.",
+          "$comment": "group:advanced"
+        },
+        "filterInternalHeaders": {
+          "type": "boolean",
+          "title": "FilterInternalHeaders",
+          "description": "When enabled the endpoint removes all internal headers before sending a message.",
+          "$comment": "group:advanced"
+        },
+        "jmsTemplate": {
+          "type": "string",
+          "title": "JmsTemplate",
+          "description": "Sets the JMS template.",
+          "$comment": "group:advanced"
+        },
+        "messageConverter": {
+          "type": "string",
+          "title": "MessageConverter",
+          "description": "Sets the message converter bean reference.",
+          "$comment": "group:advanced"
+        },
+        "name": {
+          "type": "string",
+          "title": "Name",
+          "description": "The name of the endpoint"
+        },
+        "pollingInterval": {
+          "type": "integer",
+          "title": "PollingInterval",
+          "description": "Sets the polling interval.",
+          "$comment": "group:advanced"
+        },
+        "pubSubDomain": {
+          "type": "boolean",
+          "title": "PubSubDomain",
+          "description": "When enabled the endpoint uses publish/subscribe mode.",
+          "$comment": "group:advanced"
+        },
+        "replyDestination": {
+          "type": "string",
+          "title": "ReplyDestination",
+          "description": "Sets the reply destination name."
+        },
+        "timeout": {
+          "type": "integer",
+          "title": "Timeout",
+          "description": "Sets the receive timeout when the consumer waits for messages to arrive."
+        },
+        "useObjectMessages": {
+          "type": "boolean",
+          "title": "UseObjectMessages",
+          "description": "When enabled the endpoint uses object messages.",
+          "$comment": "group:advanced"
+        }
+      },
+      "additionalProperties": false    }
+  },
+  "camel-inOnly": {
+    "kind": "testEndpoint",
+    "version": "4.10.1",
+    "name": "camel-inOnly",
+    "group": "camel",
+    "module": "citrus-camel",
+    "title": "CamelInOnly",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "camelContext": {
+          "type": "string",
+          "title": "CamelContext",
+          "description": "The Camel context to use."
+        },
+        "endpointUri": {
+          "type": "string",
+          "title": "EndpointUri",
+          "description": "The Camel endpoint uri."
+        },
+        "messageConverter": {
+          "type": "string",
+          "title": "MessageConverter",
+          "description": "Sets the message converter as a bean reference.",
+          "$comment": "group:advanced"
+        },
+        "name": {
+          "type": "string",
+          "title": "Name",
+          "description": "The name of the endpoint"
+        },
+        "timeout": {
+          "type": "integer",
+          "title": "Timeout",
+          "description": "The endpoint timeout when waiting for messages."
+        }
+      },
+      "additionalProperties": false    }
+  },
+  "direct-asynchronous": {
+    "kind": "testEndpoint",
+    "version": "4.10.1",
+    "name": "direct-asynchronous",
+    "group": "direct",
+    "module": "citrus-base",
+    "title": "DirectAsynchronous",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "autoCreateQueue": {
+          "type": "boolean",
+          "title": "AutoCreateQueue",
+          "description": "When set the queue is automatically created when it does not exist in bean registry."
+        },
+        "name": {
+          "type": "string",
+          "title": "Name",
+          "description": "The name of the endpoint"
+        },
+        "queue": {
+          "type": "string",
+          "title": "Queue",
+          "description": "The queue name."
+        },
+        "timeout": {
+          "type": "integer",
+          "title": "Timeout",
+          "description": "The timeout when receiving messages from the queue."
+        }
+      },
+      "additionalProperties": false    }
+  },
+  "camel-synchronous": {
+    "kind": "testEndpoint",
+    "version": "4.10.1",
+    "name": "camel-synchronous",
+    "group": "camel",
+    "module": "citrus-camel",
+    "title": "CamelSynchronous",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "camelContext": {
+          "type": "string",
+          "title": "CamelContext",
+          "description": "The Camel context to use."
+        },
+        "correlator": {
+          "type": "string",
+          "title": "Correlator",
+          "description": "Sets the message correlator.",
+          "$comment": "group:advanced"
+        },
+        "endpointUri": {
+          "type": "string",
+          "title": "EndpointUri",
+          "description": "The Camel endpoint uri."
+        },
+        "messageConverter": {
+          "type": "string",
+          "title": "MessageConverter",
+          "description": "Sets the message converter as a bean reference.",
+          "$comment": "group:advanced"
+        },
+        "name": {
+          "type": "string",
+          "title": "Name",
+          "description": "The name of the endpoint"
+        },
+        "pollingInterval": {
+          "type": "integer",
+          "title": "PollingInterval",
+          "description": "Sets the polling interval when consuming messages."
+        },
+        "timeout": {
+          "type": "integer",
+          "title": "Timeout",
+          "description": "The endpoint timeout when waiting for messages."
+        }
+      },
+      "additionalProperties": false    }
+  },
+  "soap-client": {
+    "kind": "testEndpoint",
+    "version": "4.10.1",
+    "name": "soap-client",
+    "group": "soap",
+    "module": "citrus-ws",
+    "title": "SoapClient",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "correlator": {
+          "type": "string",
+          "title": "Correlator",
+          "description": "Sets the message correlator.",
+          "$comment": "group:advanced"
+        },
+        "defaultUri": {
+          "type": "string",
+          "title": "DefaultUri",
+          "description": "Sets the SOAP Web Service server url."
+        },
+        "endpointResolver": {
+          "type": "string",
+          "title": "EndpointResolver",
+          "description": "Sets the endpoint resolver.",
+          "$comment": "group:advanced"
+        },
+        "faultStrategy": {
+          "type": "string",
+          "enum": [
+            "THROWS_EXCEPTION",
+            "PROPAGATE"
+          ],
+          "title": "FaultStrategy",
+          "description": "Sets the error handling strategy.",
+          "$comment": "group:errorHandler"
+        },
+        "interceptor": {
+          "type": "string",
+          "title": "Interceptor",
+          "description": "Sets a custom client interceptor.",
+          "$comment": "group:intercept"
+        },
+        "interceptors": {
+          "title": "Interceptors",
+          "description": "Sets client interceptors.",
+          "$comment": "group:intercept",
+          "type": "array",
+          "items": {
+            "type": "string",
+            "title": "Interceptors",
+            "description": "Sets client interceptors.",
+            "$comment": "group:intercept"
+          }
+        },
+        "keepSoapEnvelope": {
+          "type": "boolean",
+          "title": "KeepSoapEnvelope",
+          "description": "When enabled the client does not remove the SOAP envelope before processing the message.",
+          "$comment": "group:advanced"
+        },
+        "messageConverter": {
+          "type": "string",
+          "title": "MessageConverter",
+          "description": "Sets a custom message converter implementation.",
+          "$comment": "group:advanced"
+        },
+        "messageFactory": {
+          "type": "string",
+          "title": "MessageFactory",
+          "description": "Sets a custom message factory.",
+          "$comment": "group:advanced"
+        },
+        "messageSender": {
+          "type": "string",
+          "title": "MessageSender",
+          "description": "Sets a custom message sender implementation.",
+          "$comment": "group:advanced"
+        },
+        "name": {
+          "type": "string",
+          "title": "Name",
+          "description": "The name of the endpoint"
+        },
+        "pollingInterval": {
+          "type": "integer",
+          "title": "PollingInterval",
+          "description": "Sets the polling interval when consuming messages."
+        },
+        "timeout": {
+          "type": "integer",
+          "title": "Timeout",
+          "description": "Sets the receive timeout when the client waits for response messages.",
+          "default": "5000"
+        },
+        "webServiceTemplate": {
+          "type": "string",
+          "title": "WebServiceTemplate",
+          "description": "Sets custom web service template reference.",
+          "$comment": "group:advanced"
+        }
+      },
+      "additionalProperties": false    }
+  },
+  "jms-asynchronous": {
+    "kind": "testEndpoint",
+    "version": "4.10.1",
+    "name": "jms-asynchronous",
+    "group": "jms",
+    "module": "citrus-jms",
+    "title": "JmsAsynchronous",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "autoStart": {
+          "type": "boolean",
+          "title": "AutoStart",
+          "description": "When enabled the JMS consumer is started right after the endpoint is created.",
+          "$comment": "group:publishSubscribe"
+        },
+        "connectionFactory": {
+          "type": "string",
+          "title": "ConnectionFactory",
+          "description": "The JMS connection factory."
+        },
+        "destination": {
+          "type": "string",
+          "title": "Destination",
+          "description": "The JMS destination name."
+        },
+        "destinationNameResolver": {
+          "type": "string",
+          "title": "DestinationNameResolver",
+          "description": "Sets the destination name resolver.",
+          "$comment": "group:advanced"
+        },
+        "destinationResolver": {
+          "type": "string",
+          "title": "DestinationResolver",
+          "description": "Sets the destination resolver.",
+          "$comment": "group:advanced"
+        },
+        "durableSubscriberName": {
+          "type": "string",
+          "title": "DurableSubscriberName",
+          "description": "Sets the durable subscriber name.",
+          "$comment": "group:publishSubscribe"
+        },
+        "durableSubscription": {
+          "type": "boolean",
+          "title": "DurableSubscription",
+          "description": "Enables/disables durable subscription mode.",
+          "$comment": "group:publishSubscribe"
+        },
+        "filterInternalHeaders": {
+          "type": "boolean",
+          "title": "FilterInternalHeaders",
+          "description": "Filter internal headers.",
+          "$comment": "group:advanced"
+        },
+        "jmsTemplate": {
+          "type": "string",
+          "title": "JmsTemplate",
+          "description": "Sets the JMS template.",
+          "$comment": "group:advanced"
+        },
+        "messageConverter": {
+          "type": "string",
+          "title": "MessageConverter",
+          "description": "Sets the message converter bean reference.",
+          "$comment": "group:advanced"
+        },
+        "name": {
+          "type": "string",
+          "title": "Name",
+          "description": "The name of the endpoint"
+        },
+        "pubSubDomain": {
+          "type": "boolean",
+          "title": "PubSubDomain",
+          "description": "When enabled the endpoint uses publish/subscribe mode.",
+          "$comment": "group:publishSubscribe"
+        },
+        "timeout": {
+          "type": "integer",
+          "title": "Timeout",
+          "description": "Sets the receive timeout when the consumer waits for messages to arrive.",
+          "default": "5000"
+        },
+        "useObjectMessages": {
+          "type": "boolean",
+          "title": "UseObjectMessages",
+          "description": "When enabled the endpoint uses object messages.",
+          "$comment": "group:advanced"
+        }
+      },
+      "additionalProperties": false    }
+  },
+  "sftp-client": {
+    "kind": "testEndpoint",
+    "version": "4.10.1",
+    "name": "sftp-client",
+    "group": "sftp",
+    "module": "citrus-ftp",
+    "title": "SftpClient",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "autoReadFiles": {
+          "type": "boolean",
+          "title": "AutoReadFiles",
+          "description": "When enabled the client automatically reads new files."
+        },
+        "correlator": {
+          "type": "string",
+          "title": "Correlator",
+          "description": "Sets the message correlator.",
+          "$comment": "group:advanced"
+        },
+        "errorHandlingStrategy": {
+          "type": "string",
+          "enum": [
+            "THROWS_EXCEPTION",
+            "PROPAGATE"
+          ],
+          "title": "ErrorHandlingStrategy",
+          "description": "Sets the error handling strategy.",
+          "$comment": "group:errorHandler"
+        },
+        "host": {
+          "type": "string",
+          "title": "Host",
+          "description": "The Ftp server host."
+        },
+        "knownHosts": {
+          "type": "string",
+          "title": "KnownHosts",
+          "description": "List of known hosts.",
+          "$comment": "group:security"
+        },
+        "localPassiveMode": {
+          "type": "boolean",
+          "title": "LocalPassiveMode",
+          "description": "SEnables the local passive mode."
+        },
+        "name": {
+          "type": "string",
+          "title": "Name",
+          "description": "The name of the endpoint"
+        },
+        "password": {
+          "type": "string",
+          "title": "Password",
+          "description": "Sets the user password.",
+          "$comment": "group:security"
+        },
+        "pollingInterval": {
+          "type": "integer",
+          "title": "PollingInterval",
+          "description": "Sets the polling interval when consuming messages."
+        },
+        "port": {
+          "type": "integer",
+          "title": "Port",
+          "description": "The Ftp server port."
+        },
+        "preferredAuthentications": {
+          "type": "string",
+          "title": "PreferredAuthentications",
+          "description": "Sets the preferred authentication mechanism.",
+          "$comment": "group:security"
+        },
+        "privateKeyPassword": {
+          "type": "string",
+          "title": "PrivateKeyPassword",
+          "description": "Sets the private key password.",
+          "$comment": "group:security"
+        },
+        "privateKeyPath": {
+          "type": "string",
+          "title": "PrivateKeyPath",
+          "description": "Sets the private key path.",
+          "$comment": "group:security"
+        },
+        "sessionConfigs": {
+          "type": "object",
+          "title": "SessionConfigs",
+          "description": "The session configuration.",
+          "additionalProperties": {
+            "type": "string",
+            "title": "SessionConfigs",
+            "description": "The session configuration."
+          }
+        },
+        "strictHostChecking": {
+          "type": "boolean",
+          "title": "StrictHostChecking",
+          "description": "Enable strict host checking.",
+          "$comment": "group:security"
+        },
+        "timeout": {
+          "type": "integer",
+          "title": "Timeout",
+          "description": "The endpoint timeout when waiting for messages."
+        },
+        "username": {
+          "type": "string",
+          "title": "Username",
+          "description": "Sets the user name.",
+          "$comment": "group:security"
+        }
+      },
+      "additionalProperties": false    }
+  },
+  "selenium-browser": {
+    "kind": "testEndpoint",
+    "version": "4.10.1",
+    "name": "selenium-browser",
+    "group": "selenium",
+    "module": "citrus-selenium",
+    "title": "SeleniumBrowser",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "eventListeners": {
+          "title": "EventListeners",
+          "description": "Sets the list of event listeners.",
+          "$comment": "group:advanced",
+          "type": "array",
+          "items": {
+            "type": "string",
+            "title": "EventListeners",
+            "description": "Sets the list of event listeners.",
+            "$comment": "group:advanced"
+          }
+        },
+        "javaScript": {
+          "type": "boolean",
+          "title": "JavaScript",
+          "description": "When enabled the browser supports JavaScript."
+        },
+        "name": {
+          "type": "string",
+          "title": "Name",
+          "description": "The name of the endpoint"
+        },
+        "profile": {
+          "type": "string",
+          "title": "Profile",
+          "description": "The Firefox profile.",
+          "$comment": "group:firefox"
+        },
+        "remoteServerUrl": {
+          "type": "string",
+          "title": "RemoteServerUrl",
+          "description": "The remote server URL."
+        },
+        "startPage": {
+          "type": "string",
+          "title": "StartPage",
+          "description": "The URL to the start page."
+        },
+        "timeout": {
+          "type": "integer",
+          "title": "Timeout",
+          "description": "The browser timeout."
+        },
+        "type": {
+          "type": "string",
+          "title": "Type",
+          "description": "The Selenium browser type.",
+          "default": "htmlunit"
+        },
+        "version": {
+          "type": "string",
+          "title": "Version",
+          "description": "The browser version.",
+          "$comment": "group:advanced"
+        },
+        "webDriver": {
+          "type": "string",
+          "title": "WebDriver",
+          "description": "Sets a custom web driver as a bean reference.",
+          "$comment": "group:advanced"
+        }
+      },
+      "additionalProperties": false    }
+  },
+  "http-server": {
+    "kind": "testEndpoint",
+    "version": "4.10.1",
+    "name": "http-server",
+    "group": "http",
+    "module": "citrus-http",
+    "title": "HttpServer",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "authentication": {
+          "type": "string",
+          "title": "Authentication",
+          "description": "Use given authentication mechanism for all request paths.",
+          "$comment": "group:security"
+        },
+        "autoStart": {
+          "type": "boolean",
+          "title": "AutoStart",
+          "description": "When enabled the server is automatically started after creation."
+        },
+        "binaryMediaTypes": {
+          "title": "BinaryMediaTypes",
+          "description": "List of supported media types on this server.",
+          "$comment": "group:advanced",
+          "type": "array",
+          "items": {
+            "type": "string",
+            "title": "BinaryMediaTypes",
+            "description": "List of supported media types on this server.",
+            "$comment": "group:advanced"
+          }
+        },
+        "connector": {
+          "type": "string",
+          "title": "Connector",
+          "description": "Add a connector to this server.",
+          "$comment": "group:servlet"
+        },
+        "connectors": {
+          "title": "Connectors",
+          "description": "Sets a list of connectors for this server.",
+          "$comment": "group:servlet",
+          "type": "array",
+          "items": {
+            "type": "string",
+            "title": "Connectors",
+            "description": "Sets a list of connectors for this server.",
+            "$comment": "group:servlet"
+          }
+        },
+        "contextConfigLocation": {
+          "type": "string",
+          "title": "ContextConfigLocation",
+          "description": "Sets the Spring context configuration loaded for this Http server.",
+          "$comment": "group:advanced"
+        },
+        "contextPath": {
+          "type": "string",
+          "title": "ContextPath",
+          "description": "Sets the context path on this server.",
+          "$comment": "group:servlet"
+        },
+        "debugLogging": {
+          "type": "boolean",
+          "title": "DebugLogging",
+          "description": "When enabled the server prints debug logging output.",
+          "$comment": "group:advanced"
+        },
+        "defaultStatus": {
+          "type": "string",
+          "enum": [
+            "CONTINUE",
+            "SWITCHING_PROTOCOLS",
+            "PROCESSING",
+            "EARLY_HINTS",
+            "CHECKPOINT",
+            "OK",
+            "CREATED",
+            "ACCEPTED",
+            "NON_AUTHORITATIVE_INFORMATION",
+            "NO_CONTENT",
+            "RESET_CONTENT",
+            "PARTIAL_CONTENT",
+            "MULTI_STATUS",
+            "ALREADY_REPORTED",
+            "IM_USED",
+            "MULTIPLE_CHOICES",
+            "MOVED_PERMANENTLY",
+            "FOUND",
+            "MOVED_TEMPORARILY",
+            "SEE_OTHER",
+            "NOT_MODIFIED",
+            "USE_PROXY",
+            "TEMPORARY_REDIRECT",
+            "PERMANENT_REDIRECT",
+            "BAD_REQUEST",
+            "UNAUTHORIZED",
+            "PAYMENT_REQUIRED",
+            "FORBIDDEN",
+            "NOT_FOUND",
+            "METHOD_NOT_ALLOWED",
+            "NOT_ACCEPTABLE",
+            "PROXY_AUTHENTICATION_REQUIRED",
+            "REQUEST_TIMEOUT",
+            "CONFLICT",
+            "GONE",
+            "LENGTH_REQUIRED",
+            "PRECONDITION_FAILED",
+            "PAYLOAD_TOO_LARGE",
+            "REQUEST_ENTITY_TOO_LARGE",
+            "URI_TOO_LONG",
+            "REQUEST_URI_TOO_LONG",
+            "UNSUPPORTED_MEDIA_TYPE",
+            "REQUESTED_RANGE_NOT_SATISFIABLE",
+            "EXPECTATION_FAILED",
+            "I_AM_A_TEAPOT",
+            "INSUFFICIENT_SPACE_ON_RESOURCE",
+            "METHOD_FAILURE",
+            "DESTINATION_LOCKED",
+            "UNPROCESSABLE_ENTITY",
+            "LOCKED",
+            "FAILED_DEPENDENCY",
+            "TOO_EARLY",
+            "UPGRADE_REQUIRED",
+            "PRECONDITION_REQUIRED",
+            "TOO_MANY_REQUESTS",
+            "REQUEST_HEADER_FIELDS_TOO_LARGE",
+            "UNAVAILABLE_FOR_LEGAL_REASONS",
+            "INTERNAL_SERVER_ERROR",
+            "NOT_IMPLEMENTED",
+            "BAD_GATEWAY",
+            "SERVICE_UNAVAILABLE",
+            "GATEWAY_TIMEOUT",
+            "HTTP_VERSION_NOT_SUPPORTED",
+            "VARIANT_ALSO_NEGOTIATES",
+            "INSUFFICIENT_STORAGE",
+            "LOOP_DETECTED",
+            "BANDWIDTH_LIMIT_EXCEEDED",
+            "NOT_EXTENDED",
+            "NETWORK_AUTHENTICATION_REQUIRED"
+          ],
+          "title": "DefaultStatus",
+          "description": "Sets the default status returned by the server.",
+          "$comment": "group:advanced"
+        },
+        "endpointAdapter": {
+          "type": "string",
+          "title": "EndpointAdapter",
+          "description": "Sets a custom endpoint adapter to handle requests.",
+          "$comment": "group:advanced"
+        },
+        "filterMappings": {
+          "type": "object",
+          "title": "FilterMappings",
+          "description": "Filter mapping used on this server.",
+          "additionalProperties": {
+            "type": "string",
+            "title": "FilterMappings",
+            "description": "Filter mapping used on this server.",
+            "$comment": "group:filter"
+          },
+          "$comment": "group:filter"
+        },
+        "filters": {
+          "type": "object",
+          "title": "Filters",
+          "description": "Map of Http filters used on this server.",
+          "additionalProperties": {
+            "type": "string",
+            "title": "Filters",
+            "description": "Map of Http filters used on this server.",
+            "$comment": "group:filter"
+          },
+          "$comment": "group:filter"
+        },
+        "handleAttributeHeaders": {
+          "type": "boolean",
+          "title": "HandleAttributeHeaders",
+          "description": "When enabled the server handles attribute headers.",
+          "$comment": "group:advanced"
+        },
+        "handleCookies": {
+          "type": "boolean",
+          "title": "HandleCookies",
+          "description": "When enabled the server handles cookies.",
+          "$comment": "group:advanced"
+        },
+        "interceptor": {
+          "type": "string",
+          "title": "Interceptor",
+          "description": "Sets a handler interceptor.",
+          "$comment": "group:intercept"
+        },
+        "interceptors": {
+          "title": "Interceptors",
+          "description": "Sets the list of handler interceptor bean references.",
+          "$comment": "group:intercept",
+          "type": "array",
+          "items": {
+            "type": "string",
+            "title": "Interceptors",
+            "description": "Sets the list of handler interceptor bean references.",
+            "$comment": "group:intercept"
+          }
+        },
+        "messageConverter": {
+          "type": "string",
+          "title": "MessageConverter",
+          "description": "Sets the Http message converter bean reference.",
+          "$comment": "group:advanced"
+        },
+        "name": {
+          "type": "string",
+          "title": "Name",
+          "description": "The name of the endpoint"
+        },
+        "port": {
+          "type": "integer",
+          "title": "Port",
+          "description": "The Http server port."
+        },
+        "removeSemicolonPathContent": {
+          "type": "boolean",
+          "title": "RemoveSemicolonPathContent",
+          "description": "When enabled the server removes semicolon path content from headers.",
+          "$comment": "group:advanced"
+        },
+        "resourceBase": {
+          "type": "string",
+          "title": "ResourceBase",
+          "description": "The server resource base path where resources get loaded from.",
+          "$comment": "group:advanced"
+        },
+        "responseCacheSize": {
+          "type": "integer",
+          "title": "ResponseCacheSize",
+          "description": "Sets the response cache size.",
+          "$comment": "group:advanced"
+        },
+        "rootParentContext": {
+          "type": "boolean",
+          "title": "RootParentContext",
+          "description": "When enabled the server uses the root Spring application context.",
+          "$comment": "group:advanced"
+        },
+        "securePort": {
+          "type": "integer",
+          "title": "SecurePort",
+          "description": "The secured port.",
+          "$comment": "group:security"
+        },
+        "securedConnection": {
+          "type": "string",
+          "title": "SecuredConnection",
+          "description": "Secure the connections on given secured port with given security mechanism.",
+          "$comment": "group:security"
+        },
+        "securityHandler": {
+          "type": "string",
+          "title": "SecurityHandler",
+          "description": "Sets the security handler as a bean reference.",
+          "$comment": "group:security"
+        },
+        "serServletHandler": {
+          "type": "string",
+          "title": "SerServletHandler",
+          "description": "Sets a custom servlet handler as a bean reference.",
+          "$comment": "group:servlet"
+        },
+        "servletMappingPath": {
+          "type": "string",
+          "title": "ServletMappingPath",
+          "description": "Sets the servlet mapping path.",
+          "$comment": "group:servlet"
+        },
+        "servletName": {
+          "type": "string",
+          "title": "ServletName",
+          "description": "Sets the servlet name.",
+          "$comment": "group:servlet"
+        },
+        "timeout": {
+          "type": "integer",
+          "title": "Timeout",
+          "description": "Sets the server timeout while waiting for incoming requests.",
+          "default": "5000"
+        },
+        "useDefaultFilters": {
+          "type": "boolean",
+          "title": "UseDefaultFilters",
+          "description": "When enabled the server uses the default set of Http servlet filters.",
+          "$comment": "group:filter"
+        }
+      },
+      "additionalProperties": false    }
+  },
+  "websocket-server": {
+    "kind": "testEndpoint",
+    "version": "4.10.1",
+    "name": "websocket-server",
+    "group": "websocket",
+    "module": "citrus-websocket",
+    "title": "WebsocketServer",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "authentication": {
+          "type": "string",
+          "title": "Authentication",
+          "description": "Use given authentication mechanism for all request paths.",
+          "$comment": "group:security"
+        },
+        "autoStart": {
+          "type": "boolean",
+          "title": "AutoStart",
+          "description": "When enabled the server is automatically started after creation."
+        },
+        "binaryMediaTypes": {
+          "title": "BinaryMediaTypes",
+          "description": "List of supported media types on this server.",
+          "$comment": "group:advanced",
+          "type": "array",
+          "items": {
+            "type": "string",
+            "title": "BinaryMediaTypes",
+            "description": "List of supported media types on this server.",
+            "$comment": "group:advanced"
+          }
+        },
+        "connector": {
+          "type": "string",
+          "title": "Connector",
+          "description": "Add a connector to this server.",
+          "$comment": "group:servlet"
+        },
+        "connectors": {
+          "title": "Connectors",
+          "description": "Sets a list of connectors for this server.",
+          "$comment": "group:servlet",
+          "type": "array",
+          "items": {
+            "type": "string",
+            "title": "Connectors",
+            "description": "Sets a list of connectors for this server.",
+            "$comment": "group:servlet"
+          }
+        },
+        "contextConfigLocation": {
+          "type": "string",
+          "title": "ContextConfigLocation",
+          "description": "Sets the Spring context configuration loaded for this Http server.",
+          "$comment": "group:advanced"
+        },
+        "contextPath": {
+          "type": "string",
+          "title": "ContextPath",
+          "description": "Sets the context path on this server.",
+          "$comment": "group:servlet"
+        },
+        "debugLogging": {
+          "type": "boolean",
+          "title": "DebugLogging",
+          "description": "When enabled the server prints debug logging output.",
+          "$comment": "group:advanced"
+        },
+        "defaultStatus": {
+          "type": "string",
+          "enum": [
+            "CONTINUE",
+            "SWITCHING_PROTOCOLS",
+            "PROCESSING",
+            "EARLY_HINTS",
+            "CHECKPOINT",
+            "OK",
+            "CREATED",
+            "ACCEPTED",
+            "NON_AUTHORITATIVE_INFORMATION",
+            "NO_CONTENT",
+            "RESET_CONTENT",
+            "PARTIAL_CONTENT",
+            "MULTI_STATUS",
+            "ALREADY_REPORTED",
+            "IM_USED",
+            "MULTIPLE_CHOICES",
+            "MOVED_PERMANENTLY",
+            "FOUND",
+            "MOVED_TEMPORARILY",
+            "SEE_OTHER",
+            "NOT_MODIFIED",
+            "USE_PROXY",
+            "TEMPORARY_REDIRECT",
+            "PERMANENT_REDIRECT",
+            "BAD_REQUEST",
+            "UNAUTHORIZED",
+            "PAYMENT_REQUIRED",
+            "FORBIDDEN",
+            "NOT_FOUND",
+            "METHOD_NOT_ALLOWED",
+            "NOT_ACCEPTABLE",
+            "PROXY_AUTHENTICATION_REQUIRED",
+            "REQUEST_TIMEOUT",
+            "CONFLICT",
+            "GONE",
+            "LENGTH_REQUIRED",
+            "PRECONDITION_FAILED",
+            "PAYLOAD_TOO_LARGE",
+            "REQUEST_ENTITY_TOO_LARGE",
+            "URI_TOO_LONG",
+            "REQUEST_URI_TOO_LONG",
+            "UNSUPPORTED_MEDIA_TYPE",
+            "REQUESTED_RANGE_NOT_SATISFIABLE",
+            "EXPECTATION_FAILED",
+            "I_AM_A_TEAPOT",
+            "INSUFFICIENT_SPACE_ON_RESOURCE",
+            "METHOD_FAILURE",
+            "DESTINATION_LOCKED",
+            "UNPROCESSABLE_ENTITY",
+            "LOCKED",
+            "FAILED_DEPENDENCY",
+            "TOO_EARLY",
+            "UPGRADE_REQUIRED",
+            "PRECONDITION_REQUIRED",
+            "TOO_MANY_REQUESTS",
+            "REQUEST_HEADER_FIELDS_TOO_LARGE",
+            "UNAVAILABLE_FOR_LEGAL_REASONS",
+            "INTERNAL_SERVER_ERROR",
+            "NOT_IMPLEMENTED",
+            "BAD_GATEWAY",
+            "SERVICE_UNAVAILABLE",
+            "GATEWAY_TIMEOUT",
+            "HTTP_VERSION_NOT_SUPPORTED",
+            "VARIANT_ALSO_NEGOTIATES",
+            "INSUFFICIENT_STORAGE",
+            "LOOP_DETECTED",
+            "BANDWIDTH_LIMIT_EXCEEDED",
+            "NOT_EXTENDED",
+            "NETWORK_AUTHENTICATION_REQUIRED"
+          ],
+          "title": "DefaultStatus",
+          "description": "Sets the default status returned by the server.",
+          "$comment": "group:advanced"
+        },
+        "endpointAdapter": {
+          "type": "string",
+          "title": "EndpointAdapter",
+          "description": "Sets a custom endpoint adapter to handle requests.",
+          "$comment": "group:advanced"
+        },
+        "filterMappings": {
+          "type": "object",
+          "title": "FilterMappings",
+          "description": "Filter mapping used on this server.",
+          "additionalProperties": {
+            "type": "string",
+            "title": "FilterMappings",
+            "description": "Filter mapping used on this server.",
+            "$comment": "group:filter"
+          },
+          "$comment": "group:filter"
+        },
+        "filters": {
+          "type": "object",
+          "title": "Filters",
+          "description": "Map of Http filters used on this server.",
+          "additionalProperties": {
+            "type": "string",
+            "title": "Filters",
+            "description": "Map of Http filters used on this server.",
+            "$comment": "group:filter"
+          },
+          "$comment": "group:filter"
+        },
+        "handleAttributeHeaders": {
+          "type": "boolean",
+          "title": "HandleAttributeHeaders",
+          "description": "When enabled the server handles attribute headers.",
+          "$comment": "group:advanced"
+        },
+        "handleCookies": {
+          "type": "boolean",
+          "title": "HandleCookies",
+          "description": "When enabled the server handles cookies.",
+          "$comment": "group:advanced"
+        },
+        "interceptor": {
+          "type": "string",
+          "title": "Interceptor",
+          "description": "Sets a handler interceptor.",
+          "$comment": "group:intercept"
+        },
+        "interceptors": {
+          "title": "Interceptors",
+          "description": "Sets the list of handler interceptor bean references.",
+          "$comment": "group:intercept",
+          "type": "array",
+          "items": {
+            "type": "string",
+            "title": "Interceptors",
+            "description": "Sets the list of handler interceptor bean references.",
+            "$comment": "group:intercept"
+          }
+        },
+        "messageConverter": {
+          "type": "string",
+          "title": "MessageConverter",
+          "description": "Sets the Http message converter bean reference.",
+          "$comment": "group:advanced"
+        },
+        "name": {
+          "type": "string",
+          "title": "Name",
+          "description": "The name of the endpoint"
+        },
+        "port": {
+          "type": "integer",
+          "title": "Port",
+          "description": "The Http server port."
+        },
+        "removeSemicolonPathContent": {
+          "type": "boolean",
+          "title": "RemoveSemicolonPathContent",
+          "description": "When enabled the server removes semicolon path content from headers.",
+          "$comment": "group:advanced"
+        },
+        "resourceBase": {
+          "type": "string",
+          "title": "ResourceBase",
+          "description": "The server resource base path where resources get loaded from.",
+          "$comment": "group:advanced"
+        },
+        "responseCacheSize": {
+          "type": "integer",
+          "title": "ResponseCacheSize",
+          "description": "Sets the response cache size.",
+          "$comment": "group:advanced"
+        },
+        "rootParentContext": {
+          "type": "boolean",
+          "title": "RootParentContext",
+          "description": "When enabled the server uses the root Spring application context.",
+          "$comment": "group:advanced"
+        },
+        "securePort": {
+          "type": "integer",
+          "title": "SecurePort",
+          "description": "The secured port.",
+          "$comment": "group:security"
+        },
+        "securedConnection": {
+          "type": "string",
+          "title": "SecuredConnection",
+          "description": "Secure the connections on given secured port with given security mechanism.",
+          "$comment": "group:security"
+        },
+        "securityHandler": {
+          "type": "string",
+          "title": "SecurityHandler",
+          "description": "Sets the security handler as a bean reference.",
+          "$comment": "group:security"
+        },
+        "serServletHandler": {
+          "type": "string",
+          "title": "SerServletHandler",
+          "description": "Sets a custom servlet handler as a bean reference.",
+          "$comment": "group:servlet"
+        },
+        "servletMappingPath": {
+          "type": "string",
+          "title": "ServletMappingPath",
+          "description": "Sets the servlet mapping path.",
+          "$comment": "group:servlet"
+        },
+        "servletName": {
+          "type": "string",
+          "title": "ServletName",
+          "description": "Sets the servlet name.",
+          "$comment": "group:servlet"
+        },
+        "timeout": {
+          "type": "integer",
+          "title": "Timeout",
+          "description": "Sets the server timeout while waiting for incoming requests.",
+          "default": "5000"
+        },
+        "useDefaultFilters": {
+          "type": "boolean",
+          "title": "UseDefaultFilters",
+          "description": "When enabled the server uses the default set of Http servlet filters.",
+          "$comment": "group:filter"
+        },
+        "webSockets": {
+          "title": "WebSockets",
+          "description": "Sets the list of web sockets for this server.",
+          "type": "array",
+          "items": {
+            "type": "string",
+            "title": "WebSockets",
+            "description": "Sets the list of web sockets for this server."
+          }
+        }
+      },
+      "additionalProperties": false    }
+  },
+  "ssh-server": {
+    "kind": "testEndpoint",
+    "version": "4.10.1",
+    "name": "ssh-server",
+    "group": "ssh",
+    "module": "citrus-ssh",
+    "title": "SshServer",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "autoStart": {
+          "type": "boolean",
+          "title": "AutoStart",
+          "description": "When enabled the server is automatically started after creation."
+        },
+        "debugLogging": {
+          "type": "boolean",
+          "title": "DebugLogging",
+          "description": "When enabled the server prints debug logging output.",
+          "$comment": "group:advanced"
+        },
+        "endpointAdapter": {
+          "type": "string",
+          "title": "EndpointAdapter",
+          "description": "Sets a custom endpoint adapter to handle requests.",
+          "$comment": "group:advanced"
+        },
+        "name": {
+          "type": "string",
+          "title": "Name",
+          "description": "The name of the endpoint"
+        },
+        "timeout": {
+          "type": "integer",
+          "title": "Timeout",
+          "description": "The server timeout.",
+          "default": "5000"
+        }
+      },
+      "additionalProperties": false    }
+  },
+  "mail-server": {
+    "kind": "testEndpoint",
+    "version": "4.10.1",
+    "name": "mail-server",
+    "group": "mail",
+    "module": "citrus-mail",
+    "title": "MailServer",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "authRequired": {
+          "type": "boolean",
+          "title": "AuthRequired",
+          "description": "When enabled users must authenticate with the server.",
+          "$comment": "group:security"
+        },
+        "autoAccept": {
+          "type": "boolean",
+          "title": "AutoAccept",
+          "description": "When enabled server will auto accept client connections.",
+          "$comment": "group:security"
+        },
+        "autoStart": {
+          "type": "boolean",
+          "title": "AutoStart",
+          "description": "When enabled the server is automatically started after creation."
+        },
+        "debugLogging": {
+          "type": "boolean",
+          "title": "DebugLogging",
+          "description": "When enabled the server prints debug logging output.",
+          "$comment": "group:advanced"
+        },
+        "endpointAdapter": {
+          "type": "string",
+          "title": "EndpointAdapter",
+          "description": "Sets a custom endpoint adapter to handle requests.",
+          "$comment": "group:advanced"
+        },
+        "javaMailProperties": {
+          "type": "object",
+          "title": "JavaMailProperties",
+          "description": "Custom properties passed to the java mail implementation.",
+          "$comment": "group:advanced"
+        },
+        "knownUsers": {
+          "title": "KnownUsers",
+          "description": "Sets a list of known users that will be accepted when establishing a connection.",
+          "$comment": "group:security",
+          "type": "array",
+          "items": {
+            "type": "string",
+            "title": "KnownUsers",
+            "description": "Sets a list of known users that will be accepted when establishing a connection.",
+            "$comment": "group:security"
+          }
+        },
+        "marshaller": {
+          "type": "string",
+          "title": "Marshaller",
+          "description": "Sets a custom mail message marshaller.",
+          "$comment": "group:advanced"
+        },
+        "messageConverter": {
+          "type": "string",
+          "title": "MessageConverter",
+          "description": "Sets custom message converter.",
+          "$comment": "group:advanced"
+        },
+        "name": {
+          "type": "string",
+          "title": "Name",
+          "description": "The name of the endpoint"
+        },
+        "port": {
+          "type": "integer",
+          "title": "Port",
+          "description": "The mail server port."
+        },
+        "smtp": {
+          "type": "string",
+          "title": "Smtp",
+          "description": "Sets the SMTP implementation.",
+          "$comment": "group:advanced"
+        },
+        "splitMultipart": {
+          "type": "boolean",
+          "title": "SplitMultipart",
+          "description": "When enabled the server splits multipart messages into individual parts.",
+          "$comment": "group:advanced"
+        },
+        "timeout": {
+          "type": "integer",
+          "title": "Timeout",
+          "description": "The server timeout.",
+          "default": "5000"
+        }
+      },
+      "additionalProperties": false    }
+  }
+}

--- a/catalog/citrus/4.10.1/citrus-catalog-aggregate-functions.json
+++ b/catalog/citrus/4.10.1/citrus-catalog-aggregate-functions.json
@@ -1,0 +1,1156 @@
+{
+  "average": {
+    "kind": "testFunction",
+    "version": "4.10.1",
+    "name": "average",
+    "group": "citrus",
+    "module": "citrus-base",
+    "title": "Average",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "values": {
+          "title": "Values",
+          "description": "The list of values to evaluate. Must be numeric values or test variables that evaluate to numeric values.",
+          "type": "array",
+          "items": {
+            "type": "string",
+            "title": "Values",
+            "description": "The list of values to evaluate. Must be numeric values or test variables that evaluate to numeric values."
+          }
+        }
+      },
+      "required": [
+        "values"
+      ],
+      "additionalProperties": false    }
+  },
+  "cdataSection": {
+    "kind": "testFunction",
+    "version": "4.10.1",
+    "name": "cdataSection",
+    "group": "citrus",
+    "module": "citrus-validation-xml",
+    "title": "CdataSection",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "value": {
+          "type": "string",
+          "title": "Value",
+          "description": "The value to evaluate."
+        }
+      },
+      "required": [
+        "value"
+      ],
+      "additionalProperties": false    }
+  },
+  "unixTimestamp": {
+    "kind": "testFunction",
+    "version": "4.10.1",
+    "name": "unixTimestamp",
+    "group": "citrus",
+    "module": "citrus-base",
+    "title": "UnixTimestamp",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "additionalProperties": false    }
+  },
+  "randomString": {
+    "kind": "testFunction",
+    "version": "4.10.1",
+    "name": "randomString",
+    "group": "citrus",
+    "module": "citrus-base",
+    "title": "RandomString",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "length": {
+          "type": "integer",
+          "title": "Length",
+          "description": "Defines the length of the generated string."
+        },
+        "minNumberOfLetters": {
+          "type": "integer",
+          "title": "MinNumberOfLetters",
+          "description": "Number of letters that must be part of the generated string."
+        },
+        "notationMethod": {
+          "type": "string",
+          "enum": [
+            "MIXED",
+            "UPPERCASE",
+            "LOWERCASE"
+          ],
+          "title": "NotationMethod",
+          "description": "The notation method to use."
+        }
+      },
+      "required": [
+        "length"
+      ],
+      "additionalProperties": false    }
+  },
+  "resolveExternalServiceUrl": {
+    "kind": "testFunction",
+    "version": "4.10.1",
+    "name": "resolveExternalServiceUrl",
+    "group": "citrus",
+    "module": "citrus-base",
+    "title": "ResolveExternalServiceUrl",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "namespace": {
+          "type": "string",
+          "title": "Namespace",
+          "description": "The Kubernetes namespace."
+        },
+        "serviceName": {
+          "type": "string",
+          "title": "ServiceName",
+          "description": "The Kubernetes service name."
+        }
+      },
+      "required": [
+        "serviceName"
+      ],
+      "additionalProperties": false    }
+  },
+  "urlDecode": {
+    "kind": "testFunction",
+    "version": "4.10.1",
+    "name": "urlDecode",
+    "group": "citrus",
+    "module": "citrus-base",
+    "title": "UrlDecode",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "charset": {
+          "type": "string",
+          "title": "Charset",
+          "description": "Optional charset used to decode.",
+          "default": "UTF-8"
+        },
+        "value": {
+          "type": "string",
+          "title": "Value",
+          "description": "The value to perform substring."
+        }
+      },
+      "required": [
+        "value"
+      ],
+      "additionalProperties": false    }
+  },
+  "localHostAddress": {
+    "kind": "testFunction",
+    "version": "4.10.1",
+    "name": "localHostAddress",
+    "group": "citrus",
+    "module": "citrus-base",
+    "title": "LocalHostAddress",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "additionalProperties": false    }
+  },
+  "currentDate": {
+    "kind": "testFunction",
+    "version": "4.10.1",
+    "name": "currentDate",
+    "group": "citrus",
+    "module": "citrus-base",
+    "title": "CurrentDate",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "dateFormat": {
+          "type": "string",
+          "title": "DateFormat",
+          "description": "The date format string."
+        },
+        "offset": {
+          "type": "string",
+          "title": "Offset",
+          "description": "The date offset."
+        },
+        "timeZone": {
+          "type": "string",
+          "title": "TimeZone",
+          "description": "The time zone."
+        }
+      },
+      "additionalProperties": false    }
+  },
+  "sum": {
+    "kind": "testFunction",
+    "version": "4.10.1",
+    "name": "sum",
+    "group": "citrus",
+    "module": "citrus-base",
+    "title": "Sum",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "values": {
+          "title": "Values",
+          "description": "The list of values to evaluate. Must be numeric values or test variables that evaluate to numeric values.",
+          "type": "array",
+          "items": {
+            "type": "string",
+            "title": "Values",
+            "description": "The list of values to evaluate. Must be numeric values or test variables that evaluate to numeric values."
+          }
+        }
+      },
+      "required": [
+        "values"
+      ],
+      "additionalProperties": false    }
+  },
+  "urlEncode": {
+    "kind": "testFunction",
+    "version": "4.10.1",
+    "name": "urlEncode",
+    "group": "citrus",
+    "module": "citrus-base",
+    "title": "UrlEncode",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "charset": {
+          "type": "string",
+          "title": "Charset",
+          "description": "Optional charset used to decode.",
+          "default": "UTF-8"
+        },
+        "value": {
+          "type": "string",
+          "title": "Value",
+          "description": "The value to perform substring."
+        }
+      },
+      "required": [
+        "value"
+      ],
+      "additionalProperties": false    }
+  },
+  "substring": {
+    "kind": "testFunction",
+    "version": "4.10.1",
+    "name": "substring",
+    "group": "citrus",
+    "module": "citrus-base",
+    "title": "Substring",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "beginIndex": {
+          "type": "integer",
+          "title": "BeginIndex",
+          "description": "The substring begin index."
+        },
+        "endIndex": {
+          "type": "integer",
+          "title": "EndIndex",
+          "description": "Optional substring end index."
+        },
+        "value": {
+          "type": "string",
+          "title": "Value",
+          "description": "The value to perform substring."
+        }
+      },
+      "required": [
+        "beginIndex",
+        "value"
+      ],
+      "additionalProperties": false    }
+  },
+  "translate": {
+    "kind": "testFunction",
+    "version": "4.10.1",
+    "name": "translate",
+    "group": "citrus",
+    "module": "citrus-base",
+    "title": "Translate",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "regex": {
+          "type": "string",
+          "title": "Regex",
+          "description": "The regular expression to evaluate."
+        },
+        "replacement": {
+          "type": "string",
+          "title": "Replacement",
+          "description": "The transform replacement."
+        },
+        "value": {
+          "type": "string",
+          "title": "Value",
+          "description": "The value to evaluate."
+        }
+      },
+      "required": [
+        "regex",
+        "replacement",
+        "value"
+      ],
+      "additionalProperties": false    }
+  },
+  "escapeJson": {
+    "kind": "testFunction",
+    "version": "4.10.1",
+    "name": "escapeJson",
+    "group": "citrus",
+    "module": "citrus-base",
+    "title": "EscapeJson",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "value": {
+          "type": "string",
+          "title": "Value",
+          "description": "The value to evaluate."
+        }
+      },
+      "required": [
+        "value"
+      ],
+      "additionalProperties": false    }
+  },
+  "digestAuthHeader": {
+    "kind": "testFunction",
+    "version": "4.10.1",
+    "name": "digestAuthHeader",
+    "group": "citrus",
+    "module": "citrus-base",
+    "title": "DigestAuthHeader",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "algorithm": {
+          "type": "string",
+          "title": "Algorithm",
+          "description": "The algorithm."
+        },
+        "method": {
+          "type": "string",
+          "title": "Method",
+          "description": "The method."
+        },
+        "noncekey": {
+          "type": "string",
+          "title": "Noncekey",
+          "description": "The noncekey."
+        },
+        "opaque": {
+          "type": "string",
+          "title": "Opaque",
+          "description": "The opaque."
+        },
+        "password": {
+          "type": "string",
+          "title": "Password",
+          "description": "The password."
+        },
+        "realm": {
+          "type": "string",
+          "title": "Realm",
+          "description": "The realm."
+        },
+        "uri": {
+          "type": "string",
+          "title": "Uri",
+          "description": "The uri."
+        },
+        "username": {
+          "type": "string",
+          "title": "Username",
+          "description": "The username."
+        }
+      },
+      "required": [
+        "algorithm",
+        "method",
+        "noncekey",
+        "opaque",
+        "password",
+        "realm",
+        "uri",
+        "username"
+      ],
+      "additionalProperties": false    }
+  },
+  "xpath": {
+    "kind": "testFunction",
+    "version": "4.10.1",
+    "name": "xpath",
+    "group": "citrus",
+    "module": "citrus-validation-xml",
+    "title": "Xpath",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "expression": {
+          "type": "string",
+          "title": "Expression",
+          "description": "The XPath expression to evaluate."
+        },
+        "source": {
+          "type": "string",
+          "title": "Source",
+          "description": "The XML source as inline data."
+        }
+      },
+      "required": [
+        "source"
+      ],
+      "additionalProperties": false    }
+  },
+  "resolveServiceUrl": {
+    "kind": "testFunction",
+    "version": "4.10.1",
+    "name": "resolveServiceUrl",
+    "group": "citrus",
+    "module": "citrus-base",
+    "title": "ResolveServiceUrl",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "secure": {
+          "type": "boolean",
+          "title": "Secure",
+          "description": "When enabled use secure Http connection."
+        },
+        "serviceName": {
+          "type": "string",
+          "title": "ServiceName",
+          "description": "The service name."
+        },
+        "servicePort": {
+          "type": "integer",
+          "title": "ServicePort",
+          "description": "The service port."
+        }
+      },
+      "required": [
+        "serviceName",
+        "servicePort"
+      ],
+      "additionalProperties": false    }
+  },
+  "lowerCase": {
+    "kind": "testFunction",
+    "version": "4.10.1",
+    "name": "lowerCase",
+    "group": "citrus",
+    "module": "citrus-base",
+    "title": "LowerCase",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "value": {
+          "type": "string",
+          "title": "Value",
+          "description": "The value to evaluate."
+        }
+      },
+      "required": [
+        "value"
+      ],
+      "additionalProperties": false    }
+  },
+  "randomNumber": {
+    "kind": "testFunction",
+    "version": "4.10.1",
+    "name": "randomNumber",
+    "group": "citrus",
+    "module": "citrus-base",
+    "title": "RandomNumber",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "length": {
+          "type": "integer",
+          "title": "Length",
+          "description": "Defines the length of the generated number."
+        },
+        "paddingOn": {
+          "type": "boolean",
+          "title": "PaddingOn",
+          "description": "When enabled the generated number is filled with zero numbers to always get the given length."
+        }
+      },
+      "required": [
+        "length"
+      ],
+      "additionalProperties": false    }
+  },
+  "changeDate": {
+    "kind": "testFunction",
+    "version": "4.10.1",
+    "name": "changeDate",
+    "group": "citrus",
+    "module": "citrus-base",
+    "title": "ChangeDate",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "dateFormat": {
+          "type": "string",
+          "title": "DateFormat",
+          "description": "The date format string."
+        },
+        "offset": {
+          "type": "string",
+          "title": "Offset",
+          "description": "The date offset."
+        },
+        "value": {
+          "type": "string",
+          "title": "Value",
+          "description": "The value to evaluate."
+        }
+      },
+      "required": [
+        "value"
+      ],
+      "additionalProperties": false    }
+  },
+  "randomEnumValue": {
+    "kind": "testFunction",
+    "version": "4.10.1",
+    "name": "randomEnumValue",
+    "group": "citrus",
+    "module": "citrus-base",
+    "title": "RandomEnumValue",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "values": {
+          "title": "Values",
+          "description": "The list of values to evaluate.",
+          "type": "array",
+          "items": {
+            "type": "string",
+            "title": "Values",
+            "description": "The list of values to evaluate."
+          }
+        }
+      },
+      "required": [
+        "values"
+      ],
+      "additionalProperties": false    }
+  },
+  "escapeXml": {
+    "kind": "testFunction",
+    "version": "4.10.1",
+    "name": "escapeXml",
+    "group": "citrus",
+    "module": "citrus-validation-xml",
+    "title": "EscapeXml",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "value": {
+          "type": "string",
+          "title": "Value",
+          "description": "The value to evaluate."
+        }
+      },
+      "required": [
+        "value"
+      ],
+      "additionalProperties": false    }
+  },
+  "substringAfter": {
+    "kind": "testFunction",
+    "version": "4.10.1",
+    "name": "substringAfter",
+    "group": "citrus",
+    "module": "citrus-base",
+    "title": "SubstringAfter",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "searchString": {
+          "type": "string",
+          "title": "SearchString",
+          "description": "Search string used to substring after the occurrence."
+        },
+        "value": {
+          "type": "string",
+          "title": "Value",
+          "description": "The value to perform substring."
+        }
+      },
+      "required": [
+        "searchString",
+        "value"
+      ],
+      "additionalProperties": false    }
+  },
+  "randomUUID": {
+    "kind": "testFunction",
+    "version": "4.10.1",
+    "name": "randomUUID",
+    "group": "citrus",
+    "module": "citrus-base",
+    "title": "RandomUUID",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "additionalProperties": false    }
+  },
+  "jsonPatch": {
+    "kind": "testFunction",
+    "version": "4.10.1",
+    "name": "jsonPatch",
+    "group": "citrus",
+    "module": "citrus-base",
+    "title": "JsonPatch",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "operations": {
+          "title": "Operations",
+          "description": "List of JSON Patch operations (add, remove, replace, move, copy) applied to the source JSON.",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "operation": {
+                "type": "string",
+                "title": "Operation",
+                "description": "JSON Patch operation type. One of: add, remove, replace, move, copy."
+              },
+              "path": {
+                "type": "string",
+                "title": "Path",
+                "description": "JSONPath expression to the target element (e.g. '$.items[0].name')."
+              },
+              "value": {
+                "type": "string",
+                "title": "Value",
+                "description": "Value for add/replace operations, or source path for move/copy operations."
+              }
+            },
+            "required": [
+              "operation",
+              "path"
+            ],
+            "additionalProperties": false,
+            "title": "Operations",
+            "description": "List of JSON Patch operations (add, remove, replace, move, copy) applied to the source JSON."
+          }
+        },
+        "source": {
+          "type": "string",
+          "title": "Source",
+          "description": "The JSON source content to be patched as inline data."
+        }
+      },
+      "required": [
+        "operations",
+        "source"
+      ],
+      "additionalProperties": false    }
+  },
+  "floor": {
+    "kind": "testFunction",
+    "version": "4.10.1",
+    "name": "floor",
+    "group": "citrus",
+    "module": "citrus-base",
+    "title": "Floor",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "value": {
+          "type": "number",
+          "title": "Value",
+          "description": "The numeric value to evaluate."
+        }
+      },
+      "required": [
+        "value"
+      ],
+      "additionalProperties": false    }
+  },
+  "stringLength": {
+    "kind": "testFunction",
+    "version": "4.10.1",
+    "name": "stringLength",
+    "group": "citrus",
+    "module": "citrus-base",
+    "title": "StringLength",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "value": {
+          "type": "string",
+          "title": "Value",
+          "description": "The value to evaluate."
+        }
+      },
+      "required": [
+        "value"
+      ],
+      "additionalProperties": false    }
+  },
+  "encodeBase64": {
+    "kind": "testFunction",
+    "version": "4.10.1",
+    "name": "encodeBase64",
+    "group": "citrus",
+    "module": "citrus-base",
+    "title": "EncodeBase64",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "charset": {
+          "type": "string",
+          "title": "Charset",
+          "description": "Optional charset used to decode.",
+          "default": "UTF-8"
+        },
+        "value": {
+          "type": "string",
+          "title": "Value",
+          "description": "The value to perform substring."
+        }
+      },
+      "required": [
+        "value"
+      ],
+      "additionalProperties": false    }
+  },
+  "ceiling": {
+    "kind": "testFunction",
+    "version": "4.10.1",
+    "name": "ceiling",
+    "group": "citrus",
+    "module": "citrus-base",
+    "title": "Ceiling",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "value": {
+          "type": "number",
+          "title": "Value",
+          "description": "The numeric value to evaluate."
+        }
+      },
+      "required": [
+        "value"
+      ],
+      "additionalProperties": false    }
+  },
+  "randomNumberGenerator": {
+    "kind": "testFunction",
+    "version": "4.10.1",
+    "name": "randomNumberGenerator",
+    "group": "citrus",
+    "module": "citrus-base",
+    "title": "RandomNumberGenerator",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "additionalProperties": false    }
+  },
+  "systemProperty": {
+    "kind": "testFunction",
+    "version": "4.10.1",
+    "name": "systemProperty",
+    "group": "citrus",
+    "module": "citrus-base",
+    "title": "SystemProperty",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "defaultValue": {
+          "type": "string",
+          "title": "DefaultValue",
+          "description": "The default value when system property is not set."
+        },
+        "propertyName": {
+          "type": "string",
+          "title": "PropertyName",
+          "description": "The system property name."
+        }
+      },
+      "required": [
+        "propertyName"
+      ],
+      "additionalProperties": false    }
+  },
+  "jsonPath": {
+    "kind": "testFunction",
+    "version": "4.10.1",
+    "name": "jsonPath",
+    "group": "citrus",
+    "module": "citrus-base",
+    "title": "JsonPath",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "expression": {
+          "type": "string",
+          "title": "Expression",
+          "description": "The JsonPath expression to evaluate."
+        },
+        "source": {
+          "type": "string",
+          "title": "Source",
+          "description": "The Json source as inline data."
+        }
+      },
+      "required": [
+        "source"
+      ],
+      "additionalProperties": false    }
+  },
+  "concat": {
+    "kind": "testFunction",
+    "version": "4.10.1",
+    "name": "concat",
+    "group": "citrus",
+    "module": "citrus-base",
+    "title": "Concat",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "values": {
+          "title": "Values",
+          "description": "The list of values to evaluate.",
+          "type": "array",
+          "items": {
+            "type": "string",
+            "title": "Values",
+            "description": "The list of values to evaluate."
+          }
+        }
+      },
+      "required": [
+        "values"
+      ],
+      "additionalProperties": false    }
+  },
+  "message": {
+    "kind": "testFunction",
+    "version": "4.10.1",
+    "name": "message",
+    "group": "citrus",
+    "module": "citrus-base",
+    "title": "Message",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "value": {
+          "type": "string",
+          "title": "Value",
+          "description": "The value to evaluate."
+        }
+      },
+      "required": [
+        "value"
+      ],
+      "additionalProperties": false    }
+  },
+  "round": {
+    "kind": "testFunction",
+    "version": "4.10.1",
+    "name": "round",
+    "group": "citrus",
+    "module": "citrus-base",
+    "title": "Round",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "value": {
+          "type": "number",
+          "title": "Value",
+          "description": "The numeric value to evaluate."
+        }
+      },
+      "required": [
+        "value"
+      ],
+      "additionalProperties": false    }
+  },
+  "decodeBase64": {
+    "kind": "testFunction",
+    "version": "4.10.1",
+    "name": "decodeBase64",
+    "group": "citrus",
+    "module": "citrus-base",
+    "title": "DecodeBase64",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "charset": {
+          "type": "string",
+          "title": "Charset",
+          "description": "Optional charset used to decode.",
+          "default": "UTF-8"
+        },
+        "value": {
+          "type": "string",
+          "title": "Value",
+          "description": "The value to perform substring."
+        }
+      },
+      "required": [
+        "value"
+      ],
+      "additionalProperties": false    }
+  },
+  "serviceClusterIp": {
+    "kind": "testFunction",
+    "version": "4.10.1",
+    "name": "serviceClusterIp",
+    "group": "citrus",
+    "module": "citrus-base",
+    "title": "ServiceClusterIp",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "namespace": {
+          "type": "string",
+          "title": "Namespace",
+          "description": "The Kubernetes namespace."
+        },
+        "serviceName": {
+          "type": "string",
+          "title": "ServiceName",
+          "description": "The Kubernetes service name."
+        }
+      },
+      "required": [
+        "serviceName"
+      ],
+      "additionalProperties": false    }
+  },
+  "randomPattern": {
+    "kind": "testFunction",
+    "version": "4.10.1",
+    "name": "randomPattern",
+    "group": "citrus",
+    "module": "citrus-base",
+    "title": "RandomPattern",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "value": {
+          "type": "string",
+          "title": "Value",
+          "description": "The value to evaluate."
+        }
+      },
+      "required": [
+        "value"
+      ],
+      "additionalProperties": false    }
+  },
+  "upperCase": {
+    "kind": "testFunction",
+    "version": "4.10.1",
+    "name": "upperCase",
+    "group": "citrus",
+    "module": "citrus-base",
+    "title": "UpperCase",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "value": {
+          "type": "string",
+          "title": "Value",
+          "description": "The value to evaluate."
+        }
+      },
+      "required": [
+        "value"
+      ],
+      "additionalProperties": false    }
+  },
+  "absolute": {
+    "kind": "testFunction",
+    "version": "4.10.1",
+    "name": "absolute",
+    "group": "citrus",
+    "module": "citrus-base",
+    "title": "Absolute",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "value": {
+          "type": "number",
+          "title": "Value",
+          "description": "The numeric value to evaluate."
+        }
+      },
+      "required": [
+        "value"
+      ],
+      "additionalProperties": false    }
+  },
+  "readFile": {
+    "kind": "testFunction",
+    "version": "4.10.1",
+    "name": "readFile",
+    "group": "citrus",
+    "module": "citrus-base",
+    "title": "ReadFile",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "base64": {
+          "type": "boolean",
+          "title": "Base64",
+          "description": "When enabled the read file content is converted into bas64."
+        },
+        "filePath": {
+          "type": "string",
+          "title": "FilePath",
+          "description": "The file path to read."
+        },
+        "useCharset": {
+          "type": "boolean",
+          "title": "UseCharset",
+          "description": "When enabled the charset to use is derived from the file path before converting into bas64.",
+          "$comment": "group:advanced"
+        }
+      },
+      "required": [
+        "filePath"
+      ],
+      "additionalProperties": false    }
+  },
+  "maximum": {
+    "kind": "testFunction",
+    "version": "4.10.1",
+    "name": "maximum",
+    "group": "citrus",
+    "module": "citrus-base",
+    "title": "Maximum",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "values": {
+          "title": "Values",
+          "description": "The list of values to evaluate. Must be numeric values or test variables that evaluate to numeric values.",
+          "type": "array",
+          "items": {
+            "type": "string",
+            "title": "Values",
+            "description": "The list of values to evaluate. Must be numeric values or test variables that evaluate to numeric values."
+          }
+        }
+      },
+      "required": [
+        "values"
+      ],
+      "additionalProperties": false    }
+  },
+  "substringBefore": {
+    "kind": "testFunction",
+    "version": "4.10.1",
+    "name": "substringBefore",
+    "group": "citrus",
+    "module": "citrus-base",
+    "title": "SubstringBefore",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "searchString": {
+          "type": "string",
+          "title": "SearchString",
+          "description": "Search string used to substring before the occurrence."
+        },
+        "value": {
+          "type": "string",
+          "title": "Value",
+          "description": "The value to perform substring."
+        }
+      },
+      "required": [
+        "searchString",
+        "value"
+      ],
+      "additionalProperties": false    }
+  },
+  "minimum": {
+    "kind": "testFunction",
+    "version": "4.10.1",
+    "name": "minimum",
+    "group": "citrus",
+    "module": "citrus-base",
+    "title": "Minimum",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "values": {
+          "title": "Values",
+          "description": "The list of values to evaluate. Must be numeric values or test variables that evaluate to numeric values.",
+          "type": "array",
+          "items": {
+            "type": "string",
+            "title": "Values",
+            "description": "The list of values to evaluate. Must be numeric values or test variables that evaluate to numeric values."
+          }
+        }
+      },
+      "required": [
+        "values"
+      ],
+      "additionalProperties": false    }
+  }
+}

--- a/catalog/citrus/4.10.1/citrus-catalog-aggregate-test-actions.json
+++ b/catalog/citrus/4.10.1/citrus-catalog-aggregate-test-actions.json
@@ -1,0 +1,19990 @@
+{
+  "action": {
+    "kind": "testAction",
+    "version": "4.10.1",
+    "name": "action",
+    "title": "Action",
+    "description": "Generic test action.",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "ref": {
+          "type": "string",
+          "title": "Ref",
+          "description": "The reference to the test action in the bean registry."
+        },
+        "reference": {
+          "type": "string",
+          "title": "Reference",
+          "description": "The reference to the test action in the bean registry."
+        }
+      },
+      "additionalProperties": false    }
+  },
+  "agent": {
+    "kind": "testActionGroup",
+    "version": "4.10.1",
+    "name": "agent",
+    "module": "citrus-agent-connector",
+    "title": "Agent",
+    "description": "Agent service test actions.",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "title": "Name"
+        }
+      },
+      "additionalProperties": false    }
+  },
+  "agent-connect": {
+    "kind": "testAction",
+    "version": "4.10.1",
+    "name": "agent-connect",
+    "group": "agent",
+    "module": "citrus-agent-connector",
+    "title": "Connect",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "port": {
+          "type": "integer",
+          "title": "Port"
+        },
+        "url": {
+          "type": "string",
+          "title": "Url"
+        }
+      },
+      "additionalProperties": false    }
+  },
+  "agent-run": {
+    "kind": "testAction",
+    "version": "4.10.1",
+    "name": "agent-run",
+    "group": "agent",
+    "module": "citrus-agent-connector",
+    "title": "Run",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "actions": {
+          "title": "Actions",
+          "description": "Sequence of test actions to execute.",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "title": "Actions",
+            "description": "Sequence of test actions to execute."
+          }
+        },
+        "source": {
+          "type": "object",
+          "properties": {
+            "code": {
+              "type": "string",
+              "title": "Code"
+            },
+            "file": {
+              "type": "string",
+              "title": "File"
+            }
+          },
+          "additionalProperties": false,
+          "title": "Source"
+        }
+      },
+      "additionalProperties": false    }
+  },
+  "ant": {
+    "kind": "testAction",
+    "version": "4.10.1",
+    "name": "ant",
+    "title": "Ant",
+    "description": "Ant run test action.",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "buildFile": {
+          "type": "string",
+          "title": "BuildFile",
+          "description": "Path to the Ant build file."
+        },
+        "buildListener": {
+          "type": "string",
+          "title": "BuildListener",
+          "description": "Optional reference to a build listener.",
+          "$comment": "group:advanced"
+        },
+        "description": {
+          "type": "string",
+          "title": "Description",
+          "description": "Test action description printed when the action is executed.",
+          "$comment": "group:advanced"
+        },
+        "execute": {
+          "type": "object",
+          "properties": {
+            "target": {
+              "type": "string",
+              "title": "Target"
+            },
+            "targets": {
+              "type": "string",
+              "title": "Targets"
+            }
+          },
+          "additionalProperties": false,
+          "title": "Execute",
+          "description": "The build target to call."
+        },
+        "properties": {
+          "title": "Properties",
+          "description": "Ant build properties.",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string",
+                "title": "Name"
+              },
+              "value": {
+                "type": "string",
+                "title": "Value"
+              }
+            },
+            "additionalProperties": false,
+            "title": "Properties",
+            "description": "Ant build properties."
+          }
+        },
+        "propertyFile": {
+          "type": "string",
+          "title": "PropertyFile",
+          "description": "Adds a build property file."
+        }
+      },
+      "additionalProperties": false    }
+  },
+  "applyTemplate": {
+    "kind": "testAction",
+    "version": "4.10.1",
+    "name": "applyTemplate",
+    "title": "ApplyTemplate",
+    "description": "Apply template test action.",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "file": {
+          "type": "string",
+          "title": "File",
+          "description": "Load the template from given file resource."
+        },
+        "name": {
+          "type": "string",
+          "title": "Name",
+          "description": "The name of the template."
+        },
+        "parameters": {
+          "title": "Parameters",
+          "description": "Template parameters, passed to the template as test variables.",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string",
+                "title": "Name",
+                "description": "The name of the parameter."
+              },
+              "value": {
+                "type": "string",
+                "title": "Value",
+                "description": "The parameter value."
+              }
+            },
+            "required": [
+              "name",
+              "value"
+            ],
+            "additionalProperties": false,
+            "title": "Parameters",
+            "description": "Template parameters, passed to the template as test variables."
+          }
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "additionalProperties": false    }
+  },
+  "camel": {
+    "kind": "testActionGroup",
+    "version": "4.10.1",
+    "name": "camel",
+    "module": "citrus-camel",
+    "title": "Camel",
+    "description": "Test actions related to Apache Camel.",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "actor": {
+          "type": "string",
+          "title": "Actor",
+          "$comment": "group:advanced"
+        },
+        "camelContext": {
+          "type": "string",
+          "title": "CamelContext",
+          "description": "Name of the Camel context."
+        },
+        "description": {
+          "type": "string",
+          "title": "Description",
+          "description": "Test action description printed when the action is executed.",
+          "$comment": "group:advanced"
+        }
+      },
+      "additionalProperties": false    }
+  },
+  "camel-controlBus": {
+    "kind": "testAction",
+    "version": "4.10.1",
+    "name": "camel-controlBus",
+    "group": "camel",
+    "module": "citrus-camel",
+    "title": "ControlBus",
+    "description": "Connects with the Camel control bus to run operations.",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "action": {
+          "type": "string",
+          "title": "Action",
+          "description": "The control bus action to execute."
+        },
+        "description": {
+          "type": "string",
+          "title": "Description",
+          "description": "Test action description printed when the action is executed.",
+          "$comment": "group:advanced"
+        },
+        "language": {
+          "type": "object",
+          "properties": {
+            "expression": {
+              "type": "string",
+              "title": "Expression",
+              "description": "The language expression."
+            },
+            "name": {
+              "type": "string",
+              "title": "Name",
+              "description": "The language name."
+            }
+          },
+          "additionalProperties": false,
+          "title": "Language",
+          "description": "Runs another Camel language expression."
+        },
+        "result": {
+          "type": "string",
+          "title": "Result",
+          "description": "The expected action result."
+        },
+        "route": {
+          "type": "string",
+          "title": "Route",
+          "description": "The route id"
+        },
+        "simple": {
+          "type": "string",
+          "title": "Simple",
+          "description": "Runs a simple expression"
+        }
+      },
+      "additionalProperties": false    }
+  },
+  "camel-createComponent": {
+    "kind": "testAction",
+    "version": "4.10.1",
+    "name": "camel-createComponent",
+    "group": "camel",
+    "module": "citrus-camel",
+    "title": "CreateComponent",
+    "description": "Create components in the Camel registry.",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "file": {
+          "type": "string",
+          "title": "File",
+          "description": "The Camel component script loaded from a file resource."
+        },
+        "name": {
+          "type": "string",
+          "title": "Name",
+          "description": "The Camel component name."
+        },
+        "script": {
+          "type": "string",
+          "title": "Script",
+          "description": "The script that defines the Camel component."
+        }
+      },
+      "additionalProperties": false    }
+  },
+  "camel-createContext": {
+    "kind": "testAction",
+    "version": "4.10.1",
+    "name": "camel-createContext",
+    "group": "camel",
+    "module": "citrus-camel",
+    "title": "CreateContext",
+    "description": "Create a new Camel context.",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "autoStart": {
+          "type": "boolean",
+          "title": "AutoStart",
+          "description": "When enabled the context is automatically started after creation.",
+          "$comment": "group:advanced"
+        },
+        "name": {
+          "type": "string",
+          "title": "Name",
+          "description": "The name of the Camel context."
+        }
+      },
+      "additionalProperties": false    }
+  },
+  "camel-createRoutes": {
+    "kind": "testAction",
+    "version": "4.10.1",
+    "name": "camel-createRoutes",
+    "group": "camel",
+    "module": "citrus-camel",
+    "title": "CreateRoutes",
+    "description": "Create a new Camel route in the context.",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "file": {
+          "type": "string",
+          "title": "File",
+          "description": "Route definitions loaded from a file resource",
+          "$comment": "group:advanced"
+        },
+        "id": {
+          "type": "string",
+          "title": "Id",
+          "description": "The route id."
+        },
+        "route": {
+          "type": "string",
+          "title": "Route",
+          "description": "Inline route definition."
+        },
+        "routeContext": {
+          "type": "string",
+          "title": "RouteContext",
+          "description": "Camel route context to load multiple routes.",
+          "$comment": "group:advanced"
+        }
+      },
+      "additionalProperties": false    }
+  },
+  "camel-infra": {
+    "kind": "testActionGroup",
+    "version": "4.10.1",
+    "name": "camel-infra",
+    "group": "camel",
+    "module": "citrus-camel",
+    "title": "Infra",
+    "description": "Manage Camel infra services.",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "additionalProperties": false    }
+  },
+  "camel-infra-run": {
+    "kind": "testAction",
+    "version": "4.10.1",
+    "name": "camel-infra-run",
+    "group": "camel-infra",
+    "title": "Run",
+    "description": "Runs a Camel infra service.",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "autoRemove": {
+          "type": "boolean",
+          "title": "AutoRemove",
+          "description": "When enabled the infra service is automatically stopped after the test."
+        },
+        "catalog": {
+          "type": "string",
+          "title": "Catalog",
+          "description": "The Camel catalog that holds the infra service definitions.",
+          "$comment": "group:advanced"
+        },
+        "dumpServiceOutput": {
+          "type": "boolean",
+          "title": "DumpServiceOutput",
+          "description": "When enabled the service output is saved into a log file.",
+          "$comment": "group:advanced"
+        },
+        "implementation": {
+          "type": "string",
+          "title": "Implementation",
+          "description": "Optional service implementation detail."
+        },
+        "service": {
+          "type": "string",
+          "title": "Service",
+          "description": "The Camel infra service name."
+        }
+      },
+      "additionalProperties": false    }
+  },
+  "camel-infra-stop": {
+    "kind": "testAction",
+    "version": "4.10.1",
+    "name": "camel-infra-stop",
+    "group": "camel-infra",
+    "title": "Stop",
+    "description": "Stops a Camel infra service.",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "implementation": {
+          "type": "string",
+          "title": "Implementation",
+          "description": "Optional service implementation detail."
+        },
+        "service": {
+          "type": "string",
+          "title": "Service",
+          "description": "The Camel infra service name."
+        }
+      },
+      "additionalProperties": false    }
+  },
+  "camel-jbang": {
+    "kind": "testActionGroup",
+    "version": "4.10.1",
+    "name": "camel-jbang",
+    "group": "camel",
+    "module": "citrus-camel",
+    "title": "Jbang",
+    "description": "Connect with Camel JBang to run commands.",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "camelVersion": {
+          "type": "string",
+          "title": "CamelVersion",
+          "description": "The Apache Camel version."
+        },
+        "kameletsVersion": {
+          "type": "string",
+          "title": "KameletsVersion",
+          "description": "The Kamelets version."
+        }
+      },
+      "additionalProperties": false    }
+  },
+  "camel-jbang-cmd": {
+    "kind": "testActionGroup",
+    "version": "4.10.1",
+    "name": "camel-jbang-cmd",
+    "group": "camel-jbang",
+    "title": "Cmd",
+    "description": "Camel JBang cmd operations.",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "additionalProperties": false    }
+  },
+  "camel-jbang-cmd-receive": {
+    "kind": "testAction",
+    "version": "4.10.1",
+    "name": "camel-jbang-cmd-receive",
+    "group": "camel-jbang-cmd",
+    "title": "Receive",
+    "description": "Receives a message from a Camel JBang integration.",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "args": {
+          "title": "Args",
+          "description": "Command arguments.",
+          "$comment": "group:advanced",
+          "type": "array",
+          "items": {
+            "type": "string",
+            "title": "Args",
+            "description": "Command arguments.",
+            "$comment": "group:advanced"
+          }
+        },
+        "delayBetweenAttempts": {
+          "type": "integer",
+          "title": "DelayBetweenAttempts",
+          "description": "The delay in milliseconds to wait between validation attempts.",
+          "default": "1000",
+          "$comment": "group:advanced"
+        },
+        "endpoint": {
+          "type": "string",
+          "title": "Endpoint",
+          "description": "Optional endpoint in the Camel integration.",
+          "$comment": "group:advanced"
+        },
+        "grep": {
+          "type": "string",
+          "title": "Grep",
+          "description": "Filter messages based on this expression."
+        },
+        "integration": {
+          "type": "string",
+          "title": "Integration",
+          "description": "The Camel integration to send the message to."
+        },
+        "jsonOutput": {
+          "type": "boolean",
+          "title": "JsonOutput",
+          "description": "When enabled action stores messages from json output.",
+          "default": "false",
+          "$comment": "group:advanced"
+        },
+        "loggingColor": {
+          "type": "boolean",
+          "title": "LoggingColor",
+          "description": "When enabled the output uses logging color.",
+          "default": "false",
+          "$comment": "group:advanced"
+        },
+        "maxAttempts": {
+          "type": "integer",
+          "title": "MaxAttempts",
+          "description": "Maximum number of validation attempts.",
+          "default": "60",
+          "$comment": "group:advanced"
+        },
+        "printLogs": {
+          "type": "boolean",
+          "title": "PrintLogs",
+          "description": "When enabled the Camel integration log output is added to the test log output.",
+          "$comment": "group:advanced"
+        },
+        "since": {
+          "type": "string",
+          "title": "Since",
+          "description": "Return messages newer than a relative duration.",
+          "$comment": "group:advanced"
+        },
+        "stopOnErrorStatus": {
+          "type": "boolean",
+          "title": "StopOnErrorStatus",
+          "description": "When enabled the validation attempts stop when error state is reported.",
+          "default": "true",
+          "$comment": "group:advanced"
+        },
+        "tail": {
+          "type": "string",
+          "title": "Tail",
+          "description": "The number of messages from the end to show.",
+          "default": "0",
+          "$comment": "group:advanced"
+        },
+        "uri": {
+          "type": "string",
+          "title": "Uri",
+          "description": "Camel endpoint URI to send message to.",
+          "$comment": "group:advanced"
+        }
+      },
+      "additionalProperties": false    }
+  },
+  "camel-jbang-cmd-send": {
+    "kind": "testAction",
+    "version": "4.10.1",
+    "name": "camel-jbang-cmd-send",
+    "group": "camel-jbang-cmd",
+    "title": "Send",
+    "description": "Sends a message to Camel JBang integration.",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "args": {
+          "title": "Args",
+          "description": "Command arguments.",
+          "$comment": "group:advanced",
+          "type": "array",
+          "items": {
+            "type": "string",
+            "title": "Args",
+            "description": "Command arguments.",
+            "$comment": "group:advanced"
+          }
+        },
+        "body": {
+          "type": "object",
+          "properties": {
+            "data": {
+              "type": "string",
+              "title": "Data",
+              "description": "The message body as inline data."
+            },
+            "file": {
+              "type": "string",
+              "title": "File",
+              "description": "The message body content loaded from a file resource."
+            }
+          },
+          "additionalProperties": false,
+          "title": "Body",
+          "description": "The message body."
+        },
+        "endpoint": {
+          "type": "string",
+          "title": "Endpoint",
+          "description": "Optional endpoint in the Camel integration.",
+          "$comment": "group:advanced"
+        },
+        "headers": {
+          "type": "object",
+          "title": "Headers",
+          "description": "The message headers.",
+          "additionalProperties": {
+            "type": "string",
+            "title": "Headers",
+            "description": "The message headers."
+          }
+        },
+        "infra": {
+          "type": "string",
+          "title": "Infra",
+          "description": "Optional Camel infrastructure service to connect to.",
+          "$comment": "group:advanced"
+        },
+        "integration": {
+          "type": "string",
+          "title": "Integration",
+          "description": "The Camel integration to send the message to."
+        },
+        "reply": {
+          "type": "boolean",
+          "title": "Reply",
+          "description": "When enabled the operation waits for a reply message from the integration.",
+          "$comment": "group:advanced"
+        },
+        "timeout": {
+          "type": "string",
+          "title": "Timeout",
+          "description": "The send timeout."
+        },
+        "uri": {
+          "type": "string",
+          "title": "Uri",
+          "description": "Camel endpoint URI to send message to.",
+          "$comment": "group:advanced"
+        }
+      },
+      "additionalProperties": false    }
+  },
+  "camel-jbang-custom": {
+    "kind": "testAction",
+    "version": "4.10.1",
+    "name": "camel-jbang-custom",
+    "group": "camel-jbang",
+    "title": "Custom",
+    "description": "Runs a Camel integration with customized parameters.",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "args": {
+          "title": "Args",
+          "description": "Optional command arguments.",
+          "$comment": "group:advanced",
+          "type": "array",
+          "items": {
+            "type": "string",
+            "title": "Args",
+            "description": "Optional command arguments.",
+            "$comment": "group:advanced"
+          }
+        },
+        "autoRemove": {
+          "type": "boolean",
+          "title": "AutoRemove",
+          "description": "When enabled the Camel integration is automatically stopped after the test.",
+          "default": "true",
+          "$comment": "group:advanced"
+        },
+        "commands": {
+          "title": "Commands",
+          "description": "Customized Camel JBang commands.",
+          "type": "array",
+          "items": {
+            "type": "string",
+            "title": "Commands",
+            "description": "Customized Camel JBang commands."
+          }
+        },
+        "dumpIntegrationOutput": {
+          "type": "boolean",
+          "title": "DumpIntegrationOutput",
+          "description": "When enabled the integration output is saved to a log file.",
+          "default": "false",
+          "$comment": "group:advanced"
+        },
+        "integration": {
+          "type": "object",
+          "properties": {
+            "environment": {
+              "type": "object",
+              "properties": {
+                "file": {
+                  "type": "string",
+                  "title": "File",
+                  "description": "Environment variables loaded from a file resource."
+                },
+                "variables": {
+                  "title": "Variables",
+                  "description": "List of environment variables.",
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "name": {
+                        "type": "string",
+                        "title": "Name",
+                        "description": "The environment variable name."
+                      },
+                      "value": {
+                        "type": "string",
+                        "title": "Value",
+                        "description": "The environment variable value."
+                      }
+                    },
+                    "required": [
+                      "name",
+                      "value"
+                    ],
+                    "additionalProperties": false,
+                    "title": "Variables",
+                    "description": "List of environment variables."
+                  }
+                }
+              },
+              "additionalProperties": false,
+              "title": "Environment",
+              "description": "Environment variables set for the Camel JBang process.",
+              "$comment": "group:advanced"
+            },
+            "file": {
+              "type": "string",
+              "title": "File",
+              "description": "Camel integration source code loaded from a file resource."
+            },
+            "name": {
+              "type": "string",
+              "title": "Name",
+              "description": "The Camel integration name."
+            },
+            "systemProperties": {
+              "type": "object",
+              "properties": {
+                "file": {
+                  "type": "string",
+                  "title": "File",
+                  "description": "System properties loaded from a file resource."
+                },
+                "properties": {
+                  "title": "Properties",
+                  "description": "List of system properties.",
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "name": {
+                        "type": "string",
+                        "title": "Name",
+                        "description": "The system property name."
+                      },
+                      "value": {
+                        "type": "string",
+                        "title": "Value",
+                        "description": "The system property value."
+                      }
+                    },
+                    "required": [
+                      "name",
+                      "value"
+                    ],
+                    "additionalProperties": false,
+                    "title": "Properties",
+                    "description": "List of system properties."
+                  }
+                }
+              },
+              "additionalProperties": false,
+              "title": "SystemProperties",
+              "description": "System properties set for the Camel JBang process.",
+              "$comment": "group:advanced"
+            }
+          },
+          "additionalProperties": false,
+          "title": "Integration",
+          "description": "The Camel integration."
+        },
+        "processName": {
+          "type": "string",
+          "title": "ProcessName",
+          "description": "Custom Camel JBang process name.",
+          "$comment": "group:advanced"
+        },
+        "resources": {
+          "title": "Resources",
+          "description": "Optional list of resources added to the Camel JBang process.",
+          "$comment": "group:advanced",
+          "type": "array",
+          "items": {
+            "type": "string",
+            "title": "Resources",
+            "description": "Optional list of resources added to the Camel JBang process.",
+            "$comment": "group:advanced"
+          }
+        },
+        "waitForRunningState": {
+          "type": "boolean",
+          "title": "WaitForRunningState",
+          "description": "Wait for the integration to report running state.",
+          "default": "true",
+          "$comment": "group:advanced"
+        },
+        "workDir": {
+          "type": "string",
+          "title": "WorkDir",
+          "description": "Custom working directory for the Camel JBang process.",
+          "$comment": "group:advanced"
+        }
+      },
+      "additionalProperties": false    }
+  },
+  "camel-jbang-kubernetes": {
+    "kind": "testActionGroup",
+    "version": "4.10.1",
+    "name": "camel-jbang-kubernetes",
+    "group": "camel-jbang",
+    "title": "Kubernetes",
+    "description": "Camel Kubernetes plugin related operations.",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "additionalProperties": false    }
+  },
+  "camel-jbang-kubernetes-delete": {
+    "kind": "testAction",
+    "version": "4.10.1",
+    "name": "camel-jbang-kubernetes-delete",
+    "group": "camel-jbang-kubernetes",
+    "title": "Delete",
+    "description": "Deletes a Camel integration from Kubernetes.",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "clusterType": {
+          "type": "string",
+          "title": "ClusterType",
+          "description": "The Kubernetes cluster type.",
+          "$comment": "group:advanced"
+        },
+        "integration": {
+          "type": "object",
+          "properties": {
+            "file": {
+              "type": "string",
+              "title": "File",
+              "description": "The Camel integration source code loaded from a file resource."
+            },
+            "name": {
+              "type": "string",
+              "title": "Name",
+              "description": "The Camel integration name."
+            }
+          },
+          "additionalProperties": false,
+          "title": "Integration",
+          "description": "The Camel integration to delete."
+        },
+        "namespace": {
+          "type": "string",
+          "title": "Namespace",
+          "description": "The Kubernetes namespace.",
+          "$comment": "group:advanced"
+        },
+        "workingDir": {
+          "type": "string",
+          "title": "WorkingDir",
+          "description": "The working directory that contains the Kubernetes manifest.",
+          "$comment": "group:advanced"
+        }
+      },
+      "additionalProperties": false    }
+  },
+  "camel-jbang-kubernetes-run": {
+    "kind": "testAction",
+    "version": "4.10.1",
+    "name": "camel-jbang-kubernetes-run",
+    "group": "camel-jbang-kubernetes",
+    "title": "Run",
+    "description": "Runs a Camel integration on Kubernetes.",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "argLine": {
+          "type": "string",
+          "title": "ArgLine",
+          "description": "Camel JBang command arguments.",
+          "$comment": "group:advanced"
+        },
+        "args": {
+          "title": "Args",
+          "description": "Camel JBang command arguments.",
+          "$comment": "group:advanced",
+          "type": "array",
+          "items": {
+            "type": "string",
+            "title": "Args",
+            "description": "Camel JBang command arguments.",
+            "$comment": "group:advanced"
+          }
+        },
+        "autoRemove": {
+          "type": "boolean",
+          "title": "AutoRemove",
+          "description": "When enabled the Camel integration is automatically removed from Kubernetes after the test.",
+          "default": "true"
+        },
+        "buildProperties": {
+          "title": "BuildProperties",
+          "description": "List of build properties passed to the Camel JBang project build.",
+          "$comment": "group:advanced",
+          "type": "array",
+          "items": {
+            "type": "string",
+            "title": "BuildProperties",
+            "description": "List of build properties passed to the Camel JBang project build.",
+            "$comment": "group:advanced"
+          }
+        },
+        "clusterType": {
+          "type": "string",
+          "title": "ClusterType",
+          "description": "The Kubernetes cluster type.",
+          "$comment": "group:advanced"
+        },
+        "imageBuilder": {
+          "type": "string",
+          "title": "ImageBuilder",
+          "description": "The Docker image builder.",
+          "$comment": "group:advanced"
+        },
+        "imageRegistry": {
+          "type": "string",
+          "title": "ImageRegistry",
+          "description": "The Docker image registry.",
+          "$comment": "group:advanced"
+        },
+        "integration": {
+          "type": "object",
+          "properties": {
+            "file": {
+              "type": "string",
+              "title": "File",
+              "description": "The integration source code loaded as a file resource."
+            },
+            "name": {
+              "type": "string",
+              "title": "Name",
+              "description": "The Camel integration name."
+            },
+            "source": {
+              "type": "string",
+              "title": "Source",
+              "description": "The integration source code as inline data."
+            }
+          },
+          "additionalProperties": false,
+          "title": "Integration",
+          "description": "The Camel integration name."
+        },
+        "properties": {
+          "title": "Properties",
+          "description": "Properties set on the Camel JBang project export.",
+          "type": "array",
+          "items": {
+            "type": "string",
+            "title": "Properties",
+            "description": "Properties set on the Camel JBang project export."
+          }
+        },
+        "runtime": {
+          "type": "string",
+          "title": "Runtime",
+          "description": "The runtime to use.",
+          "default": "quarkus",
+          "$comment": "group:advanced"
+        },
+        "traits": {
+          "title": "Traits",
+          "description": "List of traits to set for the project export.",
+          "type": "array",
+          "items": {
+            "type": "string",
+            "title": "Traits",
+            "description": "List of traits to set for the project export."
+          }
+        },
+        "verbose": {
+          "type": "boolean",
+          "title": "Verbose",
+          "description": "When enabled the Camel JBang command print verbose log messages.",
+          "default": "false",
+          "$comment": "group:advanced"
+        },
+        "waitForRunningState": {
+          "type": "boolean",
+          "title": "WaitForRunningState",
+          "description": "When enabled the test waits for the Camel integration Kubernetes deployment to report proper running state.",
+          "default": "true",
+          "$comment": "group:advanced"
+        }
+      },
+      "additionalProperties": false    }
+  },
+  "camel-jbang-kubernetes-verify": {
+    "kind": "testAction",
+    "version": "4.10.1",
+    "name": "camel-jbang-kubernetes-verify",
+    "group": "camel-jbang-kubernetes",
+    "title": "Verify",
+    "description": "Verify the status and log messages for a Camel integration run on Kubernetes.",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "args": {
+          "title": "Args",
+          "description": "Camel JBang command arguments.",
+          "$comment": "group:advanced",
+          "type": "array",
+          "items": {
+            "type": "string",
+            "title": "Args",
+            "description": "Camel JBang command arguments.",
+            "$comment": "group:advanced"
+          }
+        },
+        "delayBetweenAttempts": {
+          "type": "integer",
+          "title": "DelayBetweenAttempts",
+          "description": "The delay in milliseconds to wait between validation attempts.",
+          "default": "1000",
+          "$comment": "group:advanced"
+        },
+        "integration": {
+          "type": "string",
+          "title": "Integration",
+          "description": "The Camel integration name."
+        },
+        "label": {
+          "type": "string",
+          "title": "Label",
+          "description": "Identify the Camel integration via a Kubernetes label."
+        },
+        "logMessage": {
+          "type": "string",
+          "title": "LogMessage",
+          "description": "The expected log message to verify."
+        },
+        "maxAttempts": {
+          "type": "integer",
+          "title": "MaxAttempts",
+          "description": "Maximum number of validation attempts.",
+          "default": "60",
+          "$comment": "group:advanced"
+        },
+        "namespace": {
+          "type": "string",
+          "title": "Namespace",
+          "description": "The Kubernetes namespace.",
+          "$comment": "group:advanced"
+        },
+        "printLogs": {
+          "type": "boolean",
+          "title": "PrintLogs",
+          "description": "When enabled the Camel integration log output is added to the test log output.",
+          "$comment": "group:advanced"
+        }
+      },
+      "additionalProperties": false    }
+  },
+  "camel-jbang-plugin": {
+    "kind": "testActionGroup",
+    "version": "4.10.1",
+    "name": "camel-jbang-plugin",
+    "group": "camel-jbang",
+    "title": "Plugin",
+    "description": "Manage Camel JBang plugins.",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "additionalProperties": false    }
+  },
+  "camel-jbang-plugin-add": {
+    "kind": "testAction",
+    "version": "4.10.1",
+    "name": "camel-jbang-plugin-add",
+    "group": "camel-jbang-plugin",
+    "title": "Add",
+    "description": "Adds a plugin to the Camel Jbang installation.",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "args": {
+          "title": "Args",
+          "description": "Plugin arguments.",
+          "$comment": "group:advanced",
+          "type": "array",
+          "items": {
+            "type": "string",
+            "title": "Args",
+            "description": "Plugin arguments.",
+            "$comment": "group:advanced"
+          }
+        },
+        "name": {
+          "type": "string",
+          "title": "Name",
+          "description": "The plugin name."
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "additionalProperties": false    }
+  },
+  "camel-jbang-run": {
+    "kind": "testAction",
+    "version": "4.10.1",
+    "name": "camel-jbang-run",
+    "group": "camel-jbang",
+    "title": "Run",
+    "description": "Runs a Camel integration.",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "args": {
+          "title": "Args",
+          "description": "Optional command arguments.",
+          "$comment": "group:advanced",
+          "type": "array",
+          "items": {
+            "type": "string",
+            "title": "Args",
+            "description": "Optional command arguments.",
+            "$comment": "group:advanced"
+          }
+        },
+        "autoRemove": {
+          "type": "boolean",
+          "title": "AutoRemove",
+          "description": "When enabled the Camel integration is automatically stopped after the test.",
+          "default": "true",
+          "$comment": "group:advanced"
+        },
+        "dumpIntegrationOutput": {
+          "type": "boolean",
+          "title": "DumpIntegrationOutput",
+          "description": "When enabled the integration output is saved to a log file.",
+          "default": "false",
+          "$comment": "group:advanced"
+        },
+        "integration": {
+          "type": "object",
+          "properties": {
+            "environment": {
+              "type": "object",
+              "properties": {
+                "file": {
+                  "type": "string",
+                  "title": "File",
+                  "description": "Environment variables loaded from a file resource."
+                },
+                "variables": {
+                  "title": "Variables",
+                  "description": "List of environment variables.",
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "name": {
+                        "type": "string",
+                        "title": "Name",
+                        "description": "The environment variable name."
+                      },
+                      "value": {
+                        "type": "string",
+                        "title": "Value",
+                        "description": "The environment variable value."
+                      }
+                    },
+                    "required": [
+                      "name",
+                      "value"
+                    ],
+                    "additionalProperties": false,
+                    "title": "Variables",
+                    "description": "List of environment variables."
+                  }
+                }
+              },
+              "additionalProperties": false,
+              "title": "Environment",
+              "description": "Environment variables set for the Camel JBang process.",
+              "$comment": "group:advanced"
+            },
+            "file": {
+              "type": "string",
+              "title": "File",
+              "description": "Camel integration source code loaded from a file resource."
+            },
+            "name": {
+              "type": "string",
+              "title": "Name",
+              "description": "The Camel integration name."
+            },
+            "source": {
+              "type": "string",
+              "title": "Source",
+              "description": "Camel integration source code as inline data."
+            },
+            "systemProperties": {
+              "type": "object",
+              "properties": {
+                "file": {
+                  "type": "string",
+                  "title": "File",
+                  "description": "System properties loaded from a file resource."
+                },
+                "properties": {
+                  "title": "Properties",
+                  "description": "List of system properties.",
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "name": {
+                        "type": "string",
+                        "title": "Name",
+                        "description": "The system property name."
+                      },
+                      "value": {
+                        "type": "string",
+                        "title": "Value",
+                        "description": "The system property value."
+                      }
+                    },
+                    "required": [
+                      "name",
+                      "value"
+                    ],
+                    "additionalProperties": false,
+                    "title": "Properties",
+                    "description": "List of system properties."
+                  }
+                }
+              },
+              "additionalProperties": false,
+              "title": "SystemProperties",
+              "description": "System properties set for the Camel JBang process.",
+              "$comment": "group:advanced"
+            }
+          },
+          "additionalProperties": false,
+          "title": "Integration",
+          "description": "The Camel integration."
+        },
+        "resources": {
+          "title": "Resources",
+          "description": "Optional list of resources added to the Camel JBang process.",
+          "$comment": "group:advanced",
+          "type": "array",
+          "items": {
+            "type": "string",
+            "title": "Resources",
+            "description": "Optional list of resources added to the Camel JBang process.",
+            "$comment": "group:advanced"
+          }
+        },
+        "stub": {
+          "title": "Stub",
+          "description": "Optional stubbed components.",
+          "$comment": "group:advanced",
+          "type": "array",
+          "items": {
+            "type": "string",
+            "title": "Stub",
+            "description": "Optional stubbed components.",
+            "$comment": "group:advanced"
+          }
+        },
+        "waitForRunningState": {
+          "type": "boolean",
+          "title": "WaitForRunningState",
+          "description": "Wait for the integration to report running state.",
+          "default": "true",
+          "$comment": "group:advanced"
+        }
+      },
+      "additionalProperties": false    }
+  },
+  "camel-jbang-stop": {
+    "kind": "testAction",
+    "version": "4.10.1",
+    "name": "camel-jbang-stop",
+    "group": "camel-jbang",
+    "title": "Stop",
+    "description": "Stops a Camel integration.",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "integration": {
+          "type": "string",
+          "title": "Integration",
+          "description": "Camel integration name"
+        }
+      },
+      "additionalProperties": false    }
+  },
+  "camel-jbang-verify": {
+    "kind": "testAction",
+    "version": "4.10.1",
+    "name": "camel-jbang-verify",
+    "group": "camel-jbang",
+    "title": "Verify",
+    "description": "Verify the Camel integration status and log messages.",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "delayBetweenAttempts": {
+          "type": "integer",
+          "title": "DelayBetweenAttempts",
+          "description": "The delay in milliseconds to wait between validation attempts.",
+          "default": "1000",
+          "$comment": "group:advanced"
+        },
+        "integration": {
+          "type": "string",
+          "title": "Integration",
+          "description": "The Camel integration name."
+        },
+        "logMessage": {
+          "type": "string",
+          "title": "LogMessage",
+          "description": "The expected log message to verify."
+        },
+        "maxAttempts": {
+          "type": "integer",
+          "title": "MaxAttempts",
+          "description": "Maximum attempts to validate the integration.",
+          "default": "60",
+          "$comment": "group:advanced"
+        },
+        "phase": {
+          "type": "string",
+          "title": "Phase",
+          "description": "The expected integration status",
+          "default": "Running",
+          "$comment": "group:advanced"
+        },
+        "printLogs": {
+          "type": "boolean",
+          "title": "PrintLogs",
+          "description": "When enabled the Camel integration log output is added to the test log output.",
+          "$comment": "group:advanced"
+        },
+        "stopOnErrorStatus": {
+          "type": "boolean",
+          "title": "StopOnErrorStatus",
+          "description": "When enabled the validation attempts stop when error state is reported.",
+          "default": "true",
+          "$comment": "group:advanced"
+        }
+      },
+      "additionalProperties": false    }
+  },
+  "camel-removeRoutes": {
+    "kind": "testAction",
+    "version": "4.10.1",
+    "name": "camel-removeRoutes",
+    "group": "camel",
+    "module": "citrus-camel",
+    "title": "RemoveRoutes",
+    "description": "Remove given Camel routes.",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "routes": {
+          "title": "Routes",
+          "description": "The Camel route ids to remove.",
+          "type": "array",
+          "items": {
+            "type": "string",
+            "title": "Routes",
+            "description": "The Camel route ids to remove."
+          }
+        }
+      },
+      "additionalProperties": false    }
+  },
+  "camel-startContext": {
+    "kind": "testAction",
+    "version": "4.10.1",
+    "name": "camel-startContext",
+    "group": "camel",
+    "module": "citrus-camel",
+    "title": "StartContext",
+    "description": "Starts the given Camel context.",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "title": "Name",
+          "description": "The Camel context name."
+        }
+      },
+      "additionalProperties": false    }
+  },
+  "camel-startRoutes": {
+    "kind": "testAction",
+    "version": "4.10.1",
+    "name": "camel-startRoutes",
+    "group": "camel",
+    "module": "citrus-camel",
+    "title": "StartRoutes",
+    "description": "Start existing Camel routes in the context.",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "routes": {
+          "title": "Routes",
+          "description": "The Camel route ids to start.",
+          "type": "array",
+          "items": {
+            "type": "string",
+            "title": "Routes",
+            "description": "The Camel route ids to start."
+          }
+        }
+      },
+      "additionalProperties": false    }
+  },
+  "camel-stopContext": {
+    "kind": "testAction",
+    "version": "4.10.1",
+    "name": "camel-stopContext",
+    "group": "camel",
+    "module": "citrus-camel",
+    "title": "StopContext",
+    "description": "Stops the given Camel context.",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "title": "Name",
+          "description": "The Camel context name."
+        }
+      },
+      "additionalProperties": false    }
+  },
+  "camel-stopRoutes": {
+    "kind": "testAction",
+    "version": "4.10.1",
+    "name": "camel-stopRoutes",
+    "group": "camel",
+    "module": "citrus-camel",
+    "title": "StopRoutes",
+    "description": "Stop given Camel routes.",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "routes": {
+          "title": "Routes",
+          "description": "The Camel route ids to stop.",
+          "type": "array",
+          "items": {
+            "type": "string",
+            "title": "Routes",
+            "description": "The Camel route ids to stop."
+          }
+        }
+      },
+      "additionalProperties": false    }
+  },
+  "createEndpoint": {
+    "kind": "testAction",
+    "version": "4.10.1",
+    "name": "createEndpoint",
+    "title": "CreateEndpoint",
+    "description": "Create endpoints test action.",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "camel": {
+        },
+        "channel": {
+        },
+        "context": {
+        },
+        "description": {
+          "type": "string",
+          "title": "Description",
+          "description": "Test action description printed when the action is executed.",
+          "$comment": "group:advanced"
+        },
+        "direct": {
+        },
+        "docker": {
+        },
+        "ftp": {
+        },
+        "http": {
+        },
+        "jms": {
+        },
+        "kafka": {
+        },
+        "kubernetes": {
+        },
+        "mail": {
+        },
+        "name": {
+          "type": "string",
+          "title": "Name",
+          "description": "The endpoint name. When set this endpoint is retrievable via this name in the bean registry.",
+          "$comment": "group:generic"
+        },
+        "properties": {
+          "type": "object",
+          "title": "Properties",
+          "description": "List of properties for this endpoint.",
+          "additionalProperties": {
+            "type": "string",
+            "title": "Properties",
+            "description": "List of properties for this endpoint.",
+            "$comment": "group:generic"
+          },
+          "$comment": "group:generic"
+        },
+        "scp": {
+        },
+        "selenium": {
+        },
+        "sftp": {
+        },
+        "soap": {
+        },
+        "type": {
+          "type": "string",
+          "title": "Type",
+          "description": "The endpoint type.",
+          "$comment": "group:generic"
+        },
+        "uri": {
+          "type": "string",
+          "title": "Uri",
+          "description": "The URI with properties defining the endpoint.",
+          "$comment": "group:generic"
+        },
+        "vertx": {
+        },
+        "webSocket": {
+        }
+      },
+      "additionalProperties": false,
+      "anyOf": [
+        {
+          "oneOf": [
+            {
+              "type": "object",
+              "properties": {
+                "http": {
+                  "type": "object",
+                  "properties": {
+                    "client": {
+                    },
+                    "server": {
+                    }
+                  },
+                  "additionalProperties": false,
+                  "anyOf": [
+                    {
+                      "oneOf": [
+                        {
+                          "type": "object",
+                          "properties": {
+                            "client": {
+                              "type": "object",
+                              "properties": {
+                                "authentication": {
+                                  "type": "string",
+                                  "title": "Authentication",
+                                  "description": "Use given authentication mechanism.",
+                                  "$comment": "group:security"
+                                },
+                                "binaryMediaTypes": {
+                                  "title": "BinaryMediaTypes",
+                                  "description": "Sets the list of binary media types.",
+                                  "$comment": "group:advanced",
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string",
+                                    "title": "BinaryMediaTypes",
+                                    "description": "Sets the list of binary media types.",
+                                    "$comment": "group:advanced"
+                                  }
+                                },
+                                "charset": {
+                                  "type": "string",
+                                  "title": "Charset",
+                                  "description": "The default charset.",
+                                  "$comment": "group:advanced"
+                                },
+                                "contentType": {
+                                  "type": "string",
+                                  "title": "ContentType",
+                                  "description": "Sets the default content type header set for each request.",
+                                  "$comment": "group:advanced"
+                                },
+                                "correlator": {
+                                  "type": "string",
+                                  "title": "Correlator",
+                                  "description": "Sets the message correlator.",
+                                  "$comment": "group:advanced"
+                                },
+                                "defaultAcceptHeader": {
+                                  "type": "boolean",
+                                  "title": "DefaultAcceptHeader",
+                                  "description": "When enabled the client adds the default accept header to requests.",
+                                  "$comment": "group:advanced"
+                                },
+                                "disableRedirectHandling": {
+                                  "type": "boolean",
+                                  "title": "DisableRedirectHandling",
+                                  "description": "Disables the redirect handling for this client.",
+                                  "$comment": "group:advanced"
+                                },
+                                "endpointResolver": {
+                                  "type": "string",
+                                  "title": "EndpointResolver",
+                                  "description": "Sets the endpoint URI resolver.",
+                                  "$comment": "group:advanced"
+                                },
+                                "errorHandler": {
+                                  "type": "string",
+                                  "title": "ErrorHandler",
+                                  "description": "Sets a custom error handler.",
+                                  "$comment": "group:errorHandling"
+                                },
+                                "errorHandlingStrategy": {
+                                  "type": "string",
+                                  "enum": [
+                                    "THROWS_EXCEPTION",
+                                    "PROPAGATE"
+                                  ],
+                                  "title": "ErrorHandlingStrategy",
+                                  "description": "Sets the error handling strategy.",
+                                  "$comment": "group:errorHandling"
+                                },
+                                "handleCookies": {
+                                  "type": "boolean",
+                                  "title": "HandleCookies",
+                                  "description": "When enabled the client handles cookies.",
+                                  "$comment": "group:advanced"
+                                },
+                                "headerMapper": {
+                                  "type": "string",
+                                  "title": "HeaderMapper",
+                                  "description": "Sets a custom header mapper bean reference.",
+                                  "$comment": "group:advanced"
+                                },
+                                "interceptor": {
+                                  "type": "string",
+                                  "title": "Interceptor",
+                                  "description": "Sets a client interceptor.",
+                                  "$comment": "group:intercept"
+                                },
+                                "interceptors": {
+                                  "title": "Interceptors",
+                                  "description": "Sets the list of client interceptor bean references.",
+                                  "$comment": "group:intercept",
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string",
+                                    "title": "Interceptors",
+                                    "description": "Sets the list of client interceptor bean references.",
+                                    "$comment": "group:intercept"
+                                  }
+                                },
+                                "messageConverter": {
+                                  "type": "string",
+                                  "title": "MessageConverter",
+                                  "description": "Bean reference to a message converter.",
+                                  "$comment": "group:advanced"
+                                },
+                                "name": {
+                                  "type": "string",
+                                  "title": "Name",
+                                  "description": "The name of the endpoint"
+                                },
+                                "pollingInterval": {
+                                  "type": "integer",
+                                  "title": "PollingInterval",
+                                  "description": "Sets the polling interval when consuming messages.",
+                                  "$comment": "group:advanced"
+                                },
+                                "requestFactory": {
+                                  "type": "string",
+                                  "title": "RequestFactory",
+                                  "description": "Reference to a request factory.",
+                                  "$comment": "group:advanced"
+                                },
+                                "requestMethod": {
+                                  "type": "string",
+                                  "enum": [
+                                    "GET",
+                                    "HEAD",
+                                    "POST",
+                                    "PUT",
+                                    "PATCH",
+                                    "DELETE",
+                                    "OPTIONS",
+                                    "TRACE"
+                                  ],
+                                  "title": "RequestMethod",
+                                  "description": "The default request method to use"
+                                },
+                                "requestUrl": {
+                                  "type": "string",
+                                  "title": "RequestUrl",
+                                  "description": "Sets the Http client request URL."
+                                },
+                                "restTemplate": {
+                                  "type": "string",
+                                  "title": "RestTemplate",
+                                  "description": "The reference to a REST template bean.",
+                                  "$comment": "group:advanced"
+                                },
+                                "securedConnection": {
+                                  "type": "string",
+                                  "title": "SecuredConnection",
+                                  "description": "Secure the connection with given security mechanism.",
+                                  "$comment": "group:security"
+                                },
+                                "timeout": {
+                                  "type": "integer",
+                                  "title": "Timeout",
+                                  "description": "The Http request timeout while waiting for a response",
+                                  "default": "5000"
+                                }
+                              },
+                              "additionalProperties": false,
+                              "title": "Client",
+                              "description": "Sets the Http client endpoint."
+                            }
+                          }
+                        },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "server": {
+                              "type": "object",
+                              "properties": {
+                                "authentication": {
+                                  "type": "string",
+                                  "title": "Authentication",
+                                  "description": "Use given authentication mechanism for all request paths.",
+                                  "$comment": "group:security"
+                                },
+                                "autoStart": {
+                                  "type": "boolean",
+                                  "title": "AutoStart",
+                                  "description": "When enabled the server is automatically started after creation."
+                                },
+                                "binaryMediaTypes": {
+                                  "title": "BinaryMediaTypes",
+                                  "description": "List of supported media types on this server.",
+                                  "$comment": "group:advanced",
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string",
+                                    "title": "BinaryMediaTypes",
+                                    "description": "List of supported media types on this server.",
+                                    "$comment": "group:advanced"
+                                  }
+                                },
+                                "connector": {
+                                  "type": "string",
+                                  "title": "Connector",
+                                  "description": "Add a connector to this server.",
+                                  "$comment": "group:servlet"
+                                },
+                                "connectors": {
+                                  "title": "Connectors",
+                                  "description": "Sets a list of connectors for this server.",
+                                  "$comment": "group:servlet",
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string",
+                                    "title": "Connectors",
+                                    "description": "Sets a list of connectors for this server.",
+                                    "$comment": "group:servlet"
+                                  }
+                                },
+                                "contextConfigLocation": {
+                                  "type": "string",
+                                  "title": "ContextConfigLocation",
+                                  "description": "Sets the Spring context configuration loaded for this Http server.",
+                                  "$comment": "group:advanced"
+                                },
+                                "contextPath": {
+                                  "type": "string",
+                                  "title": "ContextPath",
+                                  "description": "Sets the context path on this server.",
+                                  "$comment": "group:servlet"
+                                },
+                                "debugLogging": {
+                                  "type": "boolean",
+                                  "title": "DebugLogging",
+                                  "description": "When enabled the server prints debug logging output.",
+                                  "$comment": "group:advanced"
+                                },
+                                "defaultStatus": {
+                                  "type": "string",
+                                  "enum": [
+                                    "CONTINUE",
+                                    "SWITCHING_PROTOCOLS",
+                                    "PROCESSING",
+                                    "EARLY_HINTS",
+                                    "CHECKPOINT",
+                                    "OK",
+                                    "CREATED",
+                                    "ACCEPTED",
+                                    "NON_AUTHORITATIVE_INFORMATION",
+                                    "NO_CONTENT",
+                                    "RESET_CONTENT",
+                                    "PARTIAL_CONTENT",
+                                    "MULTI_STATUS",
+                                    "ALREADY_REPORTED",
+                                    "IM_USED",
+                                    "MULTIPLE_CHOICES",
+                                    "MOVED_PERMANENTLY",
+                                    "FOUND",
+                                    "MOVED_TEMPORARILY",
+                                    "SEE_OTHER",
+                                    "NOT_MODIFIED",
+                                    "USE_PROXY",
+                                    "TEMPORARY_REDIRECT",
+                                    "PERMANENT_REDIRECT",
+                                    "BAD_REQUEST",
+                                    "UNAUTHORIZED",
+                                    "PAYMENT_REQUIRED",
+                                    "FORBIDDEN",
+                                    "NOT_FOUND",
+                                    "METHOD_NOT_ALLOWED",
+                                    "NOT_ACCEPTABLE",
+                                    "PROXY_AUTHENTICATION_REQUIRED",
+                                    "REQUEST_TIMEOUT",
+                                    "CONFLICT",
+                                    "GONE",
+                                    "LENGTH_REQUIRED",
+                                    "PRECONDITION_FAILED",
+                                    "PAYLOAD_TOO_LARGE",
+                                    "REQUEST_ENTITY_TOO_LARGE",
+                                    "URI_TOO_LONG",
+                                    "REQUEST_URI_TOO_LONG",
+                                    "UNSUPPORTED_MEDIA_TYPE",
+                                    "REQUESTED_RANGE_NOT_SATISFIABLE",
+                                    "EXPECTATION_FAILED",
+                                    "I_AM_A_TEAPOT",
+                                    "INSUFFICIENT_SPACE_ON_RESOURCE",
+                                    "METHOD_FAILURE",
+                                    "DESTINATION_LOCKED",
+                                    "UNPROCESSABLE_ENTITY",
+                                    "LOCKED",
+                                    "FAILED_DEPENDENCY",
+                                    "TOO_EARLY",
+                                    "UPGRADE_REQUIRED",
+                                    "PRECONDITION_REQUIRED",
+                                    "TOO_MANY_REQUESTS",
+                                    "REQUEST_HEADER_FIELDS_TOO_LARGE",
+                                    "UNAVAILABLE_FOR_LEGAL_REASONS",
+                                    "INTERNAL_SERVER_ERROR",
+                                    "NOT_IMPLEMENTED",
+                                    "BAD_GATEWAY",
+                                    "SERVICE_UNAVAILABLE",
+                                    "GATEWAY_TIMEOUT",
+                                    "HTTP_VERSION_NOT_SUPPORTED",
+                                    "VARIANT_ALSO_NEGOTIATES",
+                                    "INSUFFICIENT_STORAGE",
+                                    "LOOP_DETECTED",
+                                    "BANDWIDTH_LIMIT_EXCEEDED",
+                                    "NOT_EXTENDED",
+                                    "NETWORK_AUTHENTICATION_REQUIRED"
+                                  ],
+                                  "title": "DefaultStatus",
+                                  "description": "Sets the default status returned by the server.",
+                                  "$comment": "group:advanced"
+                                },
+                                "endpointAdapter": {
+                                  "type": "string",
+                                  "title": "EndpointAdapter",
+                                  "description": "Sets a custom endpoint adapter to handle requests.",
+                                  "$comment": "group:advanced"
+                                },
+                                "filterMappings": {
+                                  "type": "object",
+                                  "title": "FilterMappings",
+                                  "description": "Filter mapping used on this server.",
+                                  "additionalProperties": {
+                                    "type": "string",
+                                    "title": "FilterMappings",
+                                    "description": "Filter mapping used on this server.",
+                                    "$comment": "group:filter"
+                                  },
+                                  "$comment": "group:filter"
+                                },
+                                "filters": {
+                                  "type": "object",
+                                  "title": "Filters",
+                                  "description": "Map of Http filters used on this server.",
+                                  "additionalProperties": {
+                                    "type": "string",
+                                    "title": "Filters",
+                                    "description": "Map of Http filters used on this server.",
+                                    "$comment": "group:filter"
+                                  },
+                                  "$comment": "group:filter"
+                                },
+                                "handleAttributeHeaders": {
+                                  "type": "boolean",
+                                  "title": "HandleAttributeHeaders",
+                                  "description": "When enabled the server handles attribute headers.",
+                                  "$comment": "group:advanced"
+                                },
+                                "handleCookies": {
+                                  "type": "boolean",
+                                  "title": "HandleCookies",
+                                  "description": "When enabled the server handles cookies.",
+                                  "$comment": "group:advanced"
+                                },
+                                "interceptor": {
+                                  "type": "string",
+                                  "title": "Interceptor",
+                                  "description": "Sets a handler interceptor.",
+                                  "$comment": "group:intercept"
+                                },
+                                "interceptors": {
+                                  "title": "Interceptors",
+                                  "description": "Sets the list of handler interceptor bean references.",
+                                  "$comment": "group:intercept",
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string",
+                                    "title": "Interceptors",
+                                    "description": "Sets the list of handler interceptor bean references.",
+                                    "$comment": "group:intercept"
+                                  }
+                                },
+                                "messageConverter": {
+                                  "type": "string",
+                                  "title": "MessageConverter",
+                                  "description": "Sets the Http message converter bean reference.",
+                                  "$comment": "group:advanced"
+                                },
+                                "name": {
+                                  "type": "string",
+                                  "title": "Name",
+                                  "description": "The name of the endpoint"
+                                },
+                                "port": {
+                                  "type": "integer",
+                                  "title": "Port",
+                                  "description": "The Http server port."
+                                },
+                                "removeSemicolonPathContent": {
+                                  "type": "boolean",
+                                  "title": "RemoveSemicolonPathContent",
+                                  "description": "When enabled the server removes semicolon path content from headers.",
+                                  "$comment": "group:advanced"
+                                },
+                                "resourceBase": {
+                                  "type": "string",
+                                  "title": "ResourceBase",
+                                  "description": "The server resource base path where resources get loaded from.",
+                                  "$comment": "group:advanced"
+                                },
+                                "responseCacheSize": {
+                                  "type": "integer",
+                                  "title": "ResponseCacheSize",
+                                  "description": "Sets the response cache size.",
+                                  "$comment": "group:advanced"
+                                },
+                                "rootParentContext": {
+                                  "type": "boolean",
+                                  "title": "RootParentContext",
+                                  "description": "When enabled the server uses the root Spring application context.",
+                                  "$comment": "group:advanced"
+                                },
+                                "securePort": {
+                                  "type": "integer",
+                                  "title": "SecurePort",
+                                  "description": "The secured port.",
+                                  "$comment": "group:security"
+                                },
+                                "securedConnection": {
+                                  "type": "string",
+                                  "title": "SecuredConnection",
+                                  "description": "Secure the connections on given secured port with given security mechanism.",
+                                  "$comment": "group:security"
+                                },
+                                "securityHandler": {
+                                  "type": "string",
+                                  "title": "SecurityHandler",
+                                  "description": "Sets the security handler as a bean reference.",
+                                  "$comment": "group:security"
+                                },
+                                "serServletHandler": {
+                                  "type": "string",
+                                  "title": "SerServletHandler",
+                                  "description": "Sets a custom servlet handler as a bean reference.",
+                                  "$comment": "group:servlet"
+                                },
+                                "servletMappingPath": {
+                                  "type": "string",
+                                  "title": "ServletMappingPath",
+                                  "description": "Sets the servlet mapping path.",
+                                  "$comment": "group:servlet"
+                                },
+                                "servletName": {
+                                  "type": "string",
+                                  "title": "ServletName",
+                                  "description": "Sets the servlet name.",
+                                  "$comment": "group:servlet"
+                                },
+                                "timeout": {
+                                  "type": "integer",
+                                  "title": "Timeout",
+                                  "description": "Sets the server timeout while waiting for incoming requests.",
+                                  "default": "5000"
+                                },
+                                "useDefaultFilters": {
+                                  "type": "boolean",
+                                  "title": "UseDefaultFilters",
+                                  "description": "When enabled the server uses the default set of Http servlet filters.",
+                                  "$comment": "group:filter"
+                                }
+                              },
+                              "additionalProperties": false,
+                              "title": "Server",
+                              "description": "Sets the Http server endpoint."
+                            }
+                          }
+                        }
+                      ]
+                    }
+                  ],
+                  "title": "Http",
+                  "description": "Http client and server endpoints"
+                }
+              }
+            },
+            {
+              "type": "object",
+              "properties": {
+                "soap": {
+                  "type": "object",
+                  "properties": {
+                    "client": {
+                    },
+                    "server": {
+                    }
+                  },
+                  "additionalProperties": false,
+                  "anyOf": [
+                    {
+                      "oneOf": [
+                        {
+                          "type": "object",
+                          "properties": {
+                            "client": {
+                              "type": "object",
+                              "properties": {
+                                "correlator": {
+                                  "type": "string",
+                                  "title": "Correlator",
+                                  "description": "Sets the message correlator.",
+                                  "$comment": "group:advanced"
+                                },
+                                "defaultUri": {
+                                  "type": "string",
+                                  "title": "DefaultUri",
+                                  "description": "Sets the SOAP Web Service server url."
+                                },
+                                "endpointResolver": {
+                                  "type": "string",
+                                  "title": "EndpointResolver",
+                                  "description": "Sets the endpoint resolver.",
+                                  "$comment": "group:advanced"
+                                },
+                                "faultStrategy": {
+                                  "type": "string",
+                                  "enum": [
+                                    "THROWS_EXCEPTION",
+                                    "PROPAGATE"
+                                  ],
+                                  "title": "FaultStrategy",
+                                  "description": "Sets the error handling strategy.",
+                                  "$comment": "group:errorHandler"
+                                },
+                                "interceptor": {
+                                  "type": "string",
+                                  "title": "Interceptor",
+                                  "description": "Sets a custom client interceptor.",
+                                  "$comment": "group:intercept"
+                                },
+                                "interceptors": {
+                                  "title": "Interceptors",
+                                  "description": "Sets client interceptors.",
+                                  "$comment": "group:intercept",
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string",
+                                    "title": "Interceptors",
+                                    "description": "Sets client interceptors.",
+                                    "$comment": "group:intercept"
+                                  }
+                                },
+                                "keepSoapEnvelope": {
+                                  "type": "boolean",
+                                  "title": "KeepSoapEnvelope",
+                                  "description": "When enabled the client does not remove the SOAP envelope before processing the message.",
+                                  "$comment": "group:advanced"
+                                },
+                                "messageConverter": {
+                                  "type": "string",
+                                  "title": "MessageConverter",
+                                  "description": "Sets a custom message converter implementation.",
+                                  "$comment": "group:advanced"
+                                },
+                                "messageFactory": {
+                                  "type": "string",
+                                  "title": "MessageFactory",
+                                  "description": "Sets a custom message factory.",
+                                  "$comment": "group:advanced"
+                                },
+                                "messageSender": {
+                                  "type": "string",
+                                  "title": "MessageSender",
+                                  "description": "Sets a custom message sender implementation.",
+                                  "$comment": "group:advanced"
+                                },
+                                "name": {
+                                  "type": "string",
+                                  "title": "Name",
+                                  "description": "The name of the endpoint"
+                                },
+                                "pollingInterval": {
+                                  "type": "integer",
+                                  "title": "PollingInterval",
+                                  "description": "Sets the polling interval when consuming messages."
+                                },
+                                "timeout": {
+                                  "type": "integer",
+                                  "title": "Timeout",
+                                  "description": "Sets the receive timeout when the client waits for response messages.",
+                                  "default": "5000"
+                                },
+                                "webServiceTemplate": {
+                                  "type": "string",
+                                  "title": "WebServiceTemplate",
+                                  "description": "Sets custom web service template reference.",
+                                  "$comment": "group:advanced"
+                                }
+                              },
+                              "additionalProperties": false,
+                              "title": "Client",
+                              "description": "Sets the SOAP WebService client endpoint."
+                            }
+                          }
+                        },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "server": {
+                              "type": "object",
+                              "properties": {
+                                "autoStart": {
+                                  "type": "boolean",
+                                  "title": "AutoStart",
+                                  "description": "When enabled the server is automatically started after creation."
+                                },
+                                "connector": {
+                                  "type": "string",
+                                  "title": "Connector",
+                                  "description": "Add a connector to this server.",
+                                  "$comment": "group:servlet"
+                                },
+                                "connectors": {
+                                  "title": "Connectors",
+                                  "description": "Sets a list of connectors for this server.",
+                                  "$comment": "group:servlet",
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string",
+                                    "title": "Connectors",
+                                    "description": "Sets a list of connectors for this server.",
+                                    "$comment": "group:servlet"
+                                  }
+                                },
+                                "contextConfigLocation": {
+                                  "type": "string",
+                                  "title": "ContextConfigLocation",
+                                  "description": "Sets the path to the Spring context configuration for this server.",
+                                  "$comment": "group:advanced"
+                                },
+                                "contextPath": {
+                                  "type": "string",
+                                  "title": "ContextPath",
+                                  "description": "Sets the context path on this server.",
+                                  "$comment": "group:servlet"
+                                },
+                                "debugLogging": {
+                                  "type": "boolean",
+                                  "title": "DebugLogging",
+                                  "description": "When enabled the server prints debug logging output.",
+                                  "$comment": "group:advanced"
+                                },
+                                "endpointAdapter": {
+                                  "type": "string",
+                                  "title": "EndpointAdapter",
+                                  "description": "Sets a custom endpoint adapter to handle requests.",
+                                  "$comment": "group:advanced"
+                                },
+                                "handleAttributeHeaders": {
+                                  "type": "boolean",
+                                  "title": "HandleAttributeHeaders",
+                                  "description": "When enabled the server handles attribute headers.",
+                                  "$comment": "group:advanced"
+                                },
+                                "handleMimeHeaders": {
+                                  "type": "boolean",
+                                  "title": "HandleMimeHeaders",
+                                  "description": "When enabled the server handles mime headers.",
+                                  "$comment": "group:advanced"
+                                },
+                                "interceptor": {
+                                  "type": "string",
+                                  "title": "Interceptor",
+                                  "description": "Sets a endpoint interceptor.",
+                                  "$comment": "group:intercept"
+                                },
+                                "interceptors": {
+                                  "title": "Interceptors",
+                                  "description": "Sets the list of endpoint interceptor bean references.",
+                                  "$comment": "group:intercept",
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string",
+                                    "title": "Interceptors",
+                                    "description": "Sets the list of endpoint interceptor bean references.",
+                                    "$comment": "group:intercept"
+                                  }
+                                },
+                                "keepSoapEnvelope": {
+                                  "type": "boolean",
+                                  "title": "KeepSoapEnvelope",
+                                  "description": "When enabled the server does not remove the SOAP envelope before processing messages.",
+                                  "$comment": "group:advanced"
+                                },
+                                "messageConverter": {
+                                  "type": "string",
+                                  "title": "MessageConverter",
+                                  "description": "Sets the Http message converter bean reference.",
+                                  "$comment": "group:advanced"
+                                },
+                                "messageFactory": {
+                                  "type": "string",
+                                  "title": "MessageFactory",
+                                  "description": "Sets a custom message factory.",
+                                  "$comment": "group:advanced"
+                                },
+                                "name": {
+                                  "type": "string",
+                                  "title": "Name",
+                                  "description": "The name of the endpoint"
+                                },
+                                "port": {
+                                  "type": "integer",
+                                  "title": "Port",
+                                  "description": "The SOAP WebService server port."
+                                },
+                                "resourceBase": {
+                                  "type": "string",
+                                  "title": "ResourceBase",
+                                  "description": "Sets the resource base path where the server reads resources from.",
+                                  "$comment": "group:advanced"
+                                },
+                                "rootParentContext": {
+                                  "type": "boolean",
+                                  "title": "RootParentContext",
+                                  "description": "When enabled the server uses the root Spring application context.",
+                                  "$comment": "group:advanced"
+                                },
+                                "securityHandler": {
+                                  "type": "string",
+                                  "title": "SecurityHandler",
+                                  "description": "Sets the security handler as a bean reference.",
+                                  "$comment": "group:security"
+                                },
+                                "serServletHandler": {
+                                  "type": "string",
+                                  "title": "SerServletHandler",
+                                  "description": "Sets a custom servlet handler as a bean reference.",
+                                  "$comment": "group:servlet"
+                                },
+                                "servletMappingPath": {
+                                  "type": "string",
+                                  "title": "ServletMappingPath",
+                                  "description": "Sets the servlet mapping path.",
+                                  "$comment": "group:servlet"
+                                },
+                                "servletName": {
+                                  "type": "string",
+                                  "title": "ServletName",
+                                  "description": "Sets the servlet name.",
+                                  "$comment": "group:servlet"
+                                },
+                                "soapHeaderNamespace": {
+                                  "type": "string",
+                                  "title": "SoapHeaderNamespace",
+                                  "description": "Sets the SOAP header namespace.",
+                                  "$comment": "group:advanced"
+                                },
+                                "soapHeaderPrefix": {
+                                  "type": "string",
+                                  "title": "SoapHeaderPrefix",
+                                  "description": "Sets the SOAP header namespace prefix.",
+                                  "$comment": "group:advanced"
+                                },
+                                "timeout": {
+                                  "type": "integer",
+                                  "title": "Timeout",
+                                  "description": "Sets the server timeout while waiting for incoming requests.",
+                                  "default": "5000"
+                                }
+                              },
+                              "additionalProperties": false,
+                              "title": "Server",
+                              "description": "Sets the SOAP WebService server endpoint."
+                            }
+                          }
+                        }
+                      ]
+                    }
+                  ],
+                  "title": "Soap",
+                  "description": "SOAP WebService client and server endpoints"
+                }
+              }
+            },
+            {
+              "type": "object",
+              "properties": {
+                "webSocket": {
+                  "type": "object",
+                  "properties": {
+                    "client": {
+                    },
+                    "server": {
+                    }
+                  },
+                  "additionalProperties": false,
+                  "anyOf": [
+                    {
+                      "oneOf": [
+                        {
+                          "type": "object",
+                          "properties": {
+                            "client": {
+                              "type": "object",
+                              "properties": {
+                                "endpointResolver": {
+                                  "type": "string",
+                                  "title": "EndpointResolver",
+                                  "description": "Sets the endpoint URI resolver.",
+                                  "$comment": "group:advanced"
+                                },
+                                "messageConverter": {
+                                  "type": "string",
+                                  "title": "MessageConverter",
+                                  "description": "Bean reference to a message converter.",
+                                  "$comment": "group:advanced"
+                                },
+                                "name": {
+                                  "type": "string",
+                                  "title": "Name",
+                                  "description": "The name of the endpoint"
+                                },
+                                "pollingInterval": {
+                                  "type": "integer",
+                                  "title": "PollingInterval",
+                                  "description": "Sets the polling interval when consuming messages.",
+                                  "$comment": "group:advanced"
+                                },
+                                "requestUrl": {
+                                  "type": "string",
+                                  "title": "RequestUrl",
+                                  "description": "Sets the client request URL."
+                                },
+                                "timeout": {
+                                  "type": "integer",
+                                  "title": "Timeout",
+                                  "description": "The Http request timeout while waiting for a response",
+                                  "default": "5000"
+                                }
+                              },
+                              "additionalProperties": false,
+                              "title": "Client",
+                              "description": "Sets the WebSocket client endpoint."
+                            }
+                          }
+                        },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "server": {
+                              "type": "object",
+                              "properties": {
+                                "authentication": {
+                                  "type": "string",
+                                  "title": "Authentication",
+                                  "description": "Use given authentication mechanism for all request paths.",
+                                  "$comment": "group:security"
+                                },
+                                "autoStart": {
+                                  "type": "boolean",
+                                  "title": "AutoStart",
+                                  "description": "When enabled the server is automatically started after creation."
+                                },
+                                "binaryMediaTypes": {
+                                  "title": "BinaryMediaTypes",
+                                  "description": "List of supported media types on this server.",
+                                  "$comment": "group:advanced",
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string",
+                                    "title": "BinaryMediaTypes",
+                                    "description": "List of supported media types on this server.",
+                                    "$comment": "group:advanced"
+                                  }
+                                },
+                                "connector": {
+                                  "type": "string",
+                                  "title": "Connector",
+                                  "description": "Add a connector to this server.",
+                                  "$comment": "group:servlet"
+                                },
+                                "connectors": {
+                                  "title": "Connectors",
+                                  "description": "Sets a list of connectors for this server.",
+                                  "$comment": "group:servlet",
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string",
+                                    "title": "Connectors",
+                                    "description": "Sets a list of connectors for this server.",
+                                    "$comment": "group:servlet"
+                                  }
+                                },
+                                "contextConfigLocation": {
+                                  "type": "string",
+                                  "title": "ContextConfigLocation",
+                                  "description": "Sets the Spring context configuration loaded for this Http server.",
+                                  "$comment": "group:advanced"
+                                },
+                                "contextPath": {
+                                  "type": "string",
+                                  "title": "ContextPath",
+                                  "description": "Sets the context path on this server.",
+                                  "$comment": "group:servlet"
+                                },
+                                "debugLogging": {
+                                  "type": "boolean",
+                                  "title": "DebugLogging",
+                                  "description": "When enabled the server prints debug logging output.",
+                                  "$comment": "group:advanced"
+                                },
+                                "defaultStatus": {
+                                  "type": "string",
+                                  "enum": [
+                                    "CONTINUE",
+                                    "SWITCHING_PROTOCOLS",
+                                    "PROCESSING",
+                                    "EARLY_HINTS",
+                                    "CHECKPOINT",
+                                    "OK",
+                                    "CREATED",
+                                    "ACCEPTED",
+                                    "NON_AUTHORITATIVE_INFORMATION",
+                                    "NO_CONTENT",
+                                    "RESET_CONTENT",
+                                    "PARTIAL_CONTENT",
+                                    "MULTI_STATUS",
+                                    "ALREADY_REPORTED",
+                                    "IM_USED",
+                                    "MULTIPLE_CHOICES",
+                                    "MOVED_PERMANENTLY",
+                                    "FOUND",
+                                    "MOVED_TEMPORARILY",
+                                    "SEE_OTHER",
+                                    "NOT_MODIFIED",
+                                    "USE_PROXY",
+                                    "TEMPORARY_REDIRECT",
+                                    "PERMANENT_REDIRECT",
+                                    "BAD_REQUEST",
+                                    "UNAUTHORIZED",
+                                    "PAYMENT_REQUIRED",
+                                    "FORBIDDEN",
+                                    "NOT_FOUND",
+                                    "METHOD_NOT_ALLOWED",
+                                    "NOT_ACCEPTABLE",
+                                    "PROXY_AUTHENTICATION_REQUIRED",
+                                    "REQUEST_TIMEOUT",
+                                    "CONFLICT",
+                                    "GONE",
+                                    "LENGTH_REQUIRED",
+                                    "PRECONDITION_FAILED",
+                                    "PAYLOAD_TOO_LARGE",
+                                    "REQUEST_ENTITY_TOO_LARGE",
+                                    "URI_TOO_LONG",
+                                    "REQUEST_URI_TOO_LONG",
+                                    "UNSUPPORTED_MEDIA_TYPE",
+                                    "REQUESTED_RANGE_NOT_SATISFIABLE",
+                                    "EXPECTATION_FAILED",
+                                    "I_AM_A_TEAPOT",
+                                    "INSUFFICIENT_SPACE_ON_RESOURCE",
+                                    "METHOD_FAILURE",
+                                    "DESTINATION_LOCKED",
+                                    "UNPROCESSABLE_ENTITY",
+                                    "LOCKED",
+                                    "FAILED_DEPENDENCY",
+                                    "TOO_EARLY",
+                                    "UPGRADE_REQUIRED",
+                                    "PRECONDITION_REQUIRED",
+                                    "TOO_MANY_REQUESTS",
+                                    "REQUEST_HEADER_FIELDS_TOO_LARGE",
+                                    "UNAVAILABLE_FOR_LEGAL_REASONS",
+                                    "INTERNAL_SERVER_ERROR",
+                                    "NOT_IMPLEMENTED",
+                                    "BAD_GATEWAY",
+                                    "SERVICE_UNAVAILABLE",
+                                    "GATEWAY_TIMEOUT",
+                                    "HTTP_VERSION_NOT_SUPPORTED",
+                                    "VARIANT_ALSO_NEGOTIATES",
+                                    "INSUFFICIENT_STORAGE",
+                                    "LOOP_DETECTED",
+                                    "BANDWIDTH_LIMIT_EXCEEDED",
+                                    "NOT_EXTENDED",
+                                    "NETWORK_AUTHENTICATION_REQUIRED"
+                                  ],
+                                  "title": "DefaultStatus",
+                                  "description": "Sets the default status returned by the server.",
+                                  "$comment": "group:advanced"
+                                },
+                                "endpointAdapter": {
+                                  "type": "string",
+                                  "title": "EndpointAdapter",
+                                  "description": "Sets a custom endpoint adapter to handle requests.",
+                                  "$comment": "group:advanced"
+                                },
+                                "filterMappings": {
+                                  "type": "object",
+                                  "title": "FilterMappings",
+                                  "description": "Filter mapping used on this server.",
+                                  "additionalProperties": {
+                                    "type": "string",
+                                    "title": "FilterMappings",
+                                    "description": "Filter mapping used on this server.",
+                                    "$comment": "group:filter"
+                                  },
+                                  "$comment": "group:filter"
+                                },
+                                "filters": {
+                                  "type": "object",
+                                  "title": "Filters",
+                                  "description": "Map of Http filters used on this server.",
+                                  "additionalProperties": {
+                                    "type": "string",
+                                    "title": "Filters",
+                                    "description": "Map of Http filters used on this server.",
+                                    "$comment": "group:filter"
+                                  },
+                                  "$comment": "group:filter"
+                                },
+                                "handleAttributeHeaders": {
+                                  "type": "boolean",
+                                  "title": "HandleAttributeHeaders",
+                                  "description": "When enabled the server handles attribute headers.",
+                                  "$comment": "group:advanced"
+                                },
+                                "handleCookies": {
+                                  "type": "boolean",
+                                  "title": "HandleCookies",
+                                  "description": "When enabled the server handles cookies.",
+                                  "$comment": "group:advanced"
+                                },
+                                "interceptor": {
+                                  "type": "string",
+                                  "title": "Interceptor",
+                                  "description": "Sets a handler interceptor.",
+                                  "$comment": "group:intercept"
+                                },
+                                "interceptors": {
+                                  "title": "Interceptors",
+                                  "description": "Sets the list of handler interceptor bean references.",
+                                  "$comment": "group:intercept",
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string",
+                                    "title": "Interceptors",
+                                    "description": "Sets the list of handler interceptor bean references.",
+                                    "$comment": "group:intercept"
+                                  }
+                                },
+                                "messageConverter": {
+                                  "type": "string",
+                                  "title": "MessageConverter",
+                                  "description": "Sets the Http message converter bean reference.",
+                                  "$comment": "group:advanced"
+                                },
+                                "name": {
+                                  "type": "string",
+                                  "title": "Name",
+                                  "description": "The name of the endpoint"
+                                },
+                                "port": {
+                                  "type": "integer",
+                                  "title": "Port",
+                                  "description": "The Http server port."
+                                },
+                                "removeSemicolonPathContent": {
+                                  "type": "boolean",
+                                  "title": "RemoveSemicolonPathContent",
+                                  "description": "When enabled the server removes semicolon path content from headers.",
+                                  "$comment": "group:advanced"
+                                },
+                                "resourceBase": {
+                                  "type": "string",
+                                  "title": "ResourceBase",
+                                  "description": "The server resource base path where resources get loaded from.",
+                                  "$comment": "group:advanced"
+                                },
+                                "responseCacheSize": {
+                                  "type": "integer",
+                                  "title": "ResponseCacheSize",
+                                  "description": "Sets the response cache size.",
+                                  "$comment": "group:advanced"
+                                },
+                                "rootParentContext": {
+                                  "type": "boolean",
+                                  "title": "RootParentContext",
+                                  "description": "When enabled the server uses the root Spring application context.",
+                                  "$comment": "group:advanced"
+                                },
+                                "securePort": {
+                                  "type": "integer",
+                                  "title": "SecurePort",
+                                  "description": "The secured port.",
+                                  "$comment": "group:security"
+                                },
+                                "securedConnection": {
+                                  "type": "string",
+                                  "title": "SecuredConnection",
+                                  "description": "Secure the connections on given secured port with given security mechanism.",
+                                  "$comment": "group:security"
+                                },
+                                "securityHandler": {
+                                  "type": "string",
+                                  "title": "SecurityHandler",
+                                  "description": "Sets the security handler as a bean reference.",
+                                  "$comment": "group:security"
+                                },
+                                "serServletHandler": {
+                                  "type": "string",
+                                  "title": "SerServletHandler",
+                                  "description": "Sets a custom servlet handler as a bean reference.",
+                                  "$comment": "group:servlet"
+                                },
+                                "servletMappingPath": {
+                                  "type": "string",
+                                  "title": "ServletMappingPath",
+                                  "description": "Sets the servlet mapping path.",
+                                  "$comment": "group:servlet"
+                                },
+                                "servletName": {
+                                  "type": "string",
+                                  "title": "ServletName",
+                                  "description": "Sets the servlet name.",
+                                  "$comment": "group:servlet"
+                                },
+                                "timeout": {
+                                  "type": "integer",
+                                  "title": "Timeout",
+                                  "description": "Sets the server timeout while waiting for incoming requests.",
+                                  "default": "5000"
+                                },
+                                "useDefaultFilters": {
+                                  "type": "boolean",
+                                  "title": "UseDefaultFilters",
+                                  "description": "When enabled the server uses the default set of Http servlet filters.",
+                                  "$comment": "group:filter"
+                                },
+                                "webSockets": {
+                                  "title": "WebSockets",
+                                  "description": "Sets the list of web sockets for this server.",
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string",
+                                    "title": "WebSockets",
+                                    "description": "Sets the list of web sockets for this server."
+                                  }
+                                }
+                              },
+                              "additionalProperties": false,
+                              "title": "Server",
+                              "description": "Sets the WebSocket server endpoint."
+                            }
+                          }
+                        }
+                      ]
+                    }
+                  ],
+                  "title": "WebSocket",
+                  "description": "WebSocket client and server endpoints"
+                }
+              }
+            },
+            {
+              "type": "object",
+              "properties": {
+                "context": {
+                  "type": "object",
+                  "properties": {
+                    "messageStore": {
+                      "type": "object",
+                      "properties": {
+                        "messageName": {
+                          "type": "string",
+                          "title": "MessageName",
+                          "description": "The message name."
+                        },
+                        "name": {
+                          "type": "string",
+                          "title": "Name",
+                          "description": "The name of the endpoint"
+                        },
+                        "timeout": {
+                          "type": "integer",
+                          "title": "Timeout",
+                          "description": "The timeout when receiving messages from the message store."
+                        }
+                      },
+                      "additionalProperties": false,
+                      "title": "MessageStore",
+                      "description": "Sets a message store endpoint ."
+                    }
+                  },
+                  "additionalProperties": false,
+                  "title": "Context",
+                  "description": "Context endpoint."
+                }
+              }
+            },
+            {
+              "type": "object",
+              "properties": {
+                "mail": {
+                  "type": "object",
+                  "properties": {
+                    "client": {
+                    },
+                    "server": {
+                    }
+                  },
+                  "additionalProperties": false,
+                  "anyOf": [
+                    {
+                      "oneOf": [
+                        {
+                          "type": "object",
+                          "properties": {
+                            "client": {
+                              "type": "object",
+                              "properties": {
+                                "host": {
+                                  "type": "string",
+                                  "title": "Host",
+                                  "description": "The mail server host to connect to."
+                                },
+                                "javaMailProperties": {
+                                  "type": "object",
+                                  "title": "JavaMailProperties",
+                                  "description": "Custom properties passed to the java mail implementation.",
+                                  "$comment": "group:advanced"
+                                },
+                                "marshaller": {
+                                  "type": "string",
+                                  "title": "Marshaller",
+                                  "description": "Sets a custom mail message marshaller.",
+                                  "$comment": "group:advanced"
+                                },
+                                "messageConverter": {
+                                  "type": "string",
+                                  "title": "MessageConverter",
+                                  "description": "Sets custom message converter.",
+                                  "$comment": "group:advanced"
+                                },
+                                "name": {
+                                  "type": "string",
+                                  "title": "Name",
+                                  "description": "The name of the endpoint"
+                                },
+                                "password": {
+                                  "type": "string",
+                                  "title": "Password",
+                                  "description": "The client user password.",
+                                  "$comment": "group:security"
+                                },
+                                "port": {
+                                  "type": "integer",
+                                  "title": "Port",
+                                  "description": "The mail server port."
+                                },
+                                "protocol": {
+                                  "type": "string",
+                                  "title": "Protocol",
+                                  "description": "The mail protocol."
+                                },
+                                "timeout": {
+                                  "type": "integer",
+                                  "title": "Timeout",
+                                  "description": "Mail client timeout when waiting for a response."
+                                },
+                                "username": {
+                                  "type": "string",
+                                  "title": "Username",
+                                  "description": "The client user name.",
+                                  "$comment": "group:security"
+                                }
+                              },
+                              "additionalProperties": false,
+                              "title": "Client",
+                              "description": "Sets the mail client endpoint."
+                            }
+                          }
+                        },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "server": {
+                              "type": "object",
+                              "properties": {
+                                "authRequired": {
+                                  "type": "boolean",
+                                  "title": "AuthRequired",
+                                  "description": "When enabled users must authenticate with the server.",
+                                  "$comment": "group:security"
+                                },
+                                "autoAccept": {
+                                  "type": "boolean",
+                                  "title": "AutoAccept",
+                                  "description": "When enabled server will auto accept client connections.",
+                                  "$comment": "group:security"
+                                },
+                                "autoStart": {
+                                  "type": "boolean",
+                                  "title": "AutoStart",
+                                  "description": "When enabled the server is automatically started after creation."
+                                },
+                                "debugLogging": {
+                                  "type": "boolean",
+                                  "title": "DebugLogging",
+                                  "description": "When enabled the server prints debug logging output.",
+                                  "$comment": "group:advanced"
+                                },
+                                "endpointAdapter": {
+                                  "type": "string",
+                                  "title": "EndpointAdapter",
+                                  "description": "Sets a custom endpoint adapter to handle requests.",
+                                  "$comment": "group:advanced"
+                                },
+                                "javaMailProperties": {
+                                  "type": "object",
+                                  "title": "JavaMailProperties",
+                                  "description": "Custom properties passed to the java mail implementation.",
+                                  "$comment": "group:advanced"
+                                },
+                                "knownUsers": {
+                                  "title": "KnownUsers",
+                                  "description": "Sets a list of known users that will be accepted when establishing a connection.",
+                                  "$comment": "group:security",
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string",
+                                    "title": "KnownUsers",
+                                    "description": "Sets a list of known users that will be accepted when establishing a connection.",
+                                    "$comment": "group:security"
+                                  }
+                                },
+                                "marshaller": {
+                                  "type": "string",
+                                  "title": "Marshaller",
+                                  "description": "Sets a custom mail message marshaller.",
+                                  "$comment": "group:advanced"
+                                },
+                                "messageConverter": {
+                                  "type": "string",
+                                  "title": "MessageConverter",
+                                  "description": "Sets custom message converter.",
+                                  "$comment": "group:advanced"
+                                },
+                                "name": {
+                                  "type": "string",
+                                  "title": "Name",
+                                  "description": "The name of the endpoint"
+                                },
+                                "port": {
+                                  "type": "integer",
+                                  "title": "Port",
+                                  "description": "The mail server port."
+                                },
+                                "smtp": {
+                                  "type": "string",
+                                  "title": "Smtp",
+                                  "description": "Sets the SMTP implementation.",
+                                  "$comment": "group:advanced"
+                                },
+                                "splitMultipart": {
+                                  "type": "boolean",
+                                  "title": "SplitMultipart",
+                                  "description": "When enabled the server splits multipart messages into individual parts.",
+                                  "$comment": "group:advanced"
+                                },
+                                "timeout": {
+                                  "type": "integer",
+                                  "title": "Timeout",
+                                  "description": "The server timeout.",
+                                  "default": "5000"
+                                }
+                              },
+                              "additionalProperties": false,
+                              "title": "Server",
+                              "description": "Sets the mail server endpoint."
+                            }
+                          }
+                        }
+                      ]
+                    }
+                  ],
+                  "title": "Mail",
+                  "description": "Mail client and server endpoints"
+                }
+              }
+            },
+            {
+              "type": "object",
+              "properties": {
+                "ftp": {
+                  "type": "object",
+                  "properties": {
+                    "client": {
+                    },
+                    "server": {
+                    }
+                  },
+                  "additionalProperties": false,
+                  "anyOf": [
+                    {
+                      "oneOf": [
+                        {
+                          "type": "object",
+                          "properties": {
+                            "client": {
+                              "type": "object",
+                              "properties": {
+                                "autoReadFiles": {
+                                  "type": "boolean",
+                                  "title": "AutoReadFiles",
+                                  "description": "When enabled the client automatically reads new files."
+                                },
+                                "correlator": {
+                                  "type": "string",
+                                  "title": "Correlator",
+                                  "description": "Sets the message correlator.",
+                                  "$comment": "group:advanced"
+                                },
+                                "errorHandlingStrategy": {
+                                  "type": "string",
+                                  "enum": [
+                                    "THROWS_EXCEPTION",
+                                    "PROPAGATE"
+                                  ],
+                                  "title": "ErrorHandlingStrategy",
+                                  "description": "Sets the error handling strategy.",
+                                  "$comment": "group:errorHandler"
+                                },
+                                "host": {
+                                  "type": "string",
+                                  "title": "Host",
+                                  "description": "The Ftp server host."
+                                },
+                                "localPassiveMode": {
+                                  "type": "boolean",
+                                  "title": "LocalPassiveMode",
+                                  "description": "SEnables the local passive mode."
+                                },
+                                "name": {
+                                  "type": "string",
+                                  "title": "Name",
+                                  "description": "The name of the endpoint"
+                                },
+                                "password": {
+                                  "type": "string",
+                                  "title": "Password",
+                                  "description": "Sets the user password.",
+                                  "$comment": "group:security"
+                                },
+                                "pollingInterval": {
+                                  "type": "integer",
+                                  "title": "PollingInterval",
+                                  "description": "Sets the polling interval when consuming messages."
+                                },
+                                "port": {
+                                  "type": "integer",
+                                  "title": "Port",
+                                  "description": "The Ftp server port."
+                                },
+                                "timeout": {
+                                  "type": "integer",
+                                  "title": "Timeout",
+                                  "description": "The endpoint timeout when waiting for messages."
+                                },
+                                "username": {
+                                  "type": "string",
+                                  "title": "Username",
+                                  "description": "Sets the user name.",
+                                  "$comment": "group:security"
+                                }
+                              },
+                              "additionalProperties": false,
+                              "title": "Client",
+                              "description": "Sets the ftp client endpoint."
+                            }
+                          }
+                        },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "server": {
+                              "type": "object",
+                              "properties": {
+                                "autoConnect": {
+                                  "type": "boolean",
+                                  "title": "AutoConnect",
+                                  "description": "When enabled the server uses automatic connect mode."
+                                },
+                                "autoHandleCommands": {
+                                  "type": "string",
+                                  "title": "AutoHandleCommands",
+                                  "description": "Enables the auto handle commands mode."
+                                },
+                                "autoLogin": {
+                                  "type": "boolean",
+                                  "title": "AutoLogin",
+                                  "description": "When enabled the server uses automatic login mode."
+                                },
+                                "autoReadFiles": {
+                                  "type": "boolean",
+                                  "title": "AutoReadFiles",
+                                  "description": "When enabled the client automatically reads new files."
+                                },
+                                "autoStart": {
+                                  "type": "boolean",
+                                  "title": "AutoStart",
+                                  "description": "When enabled the server is automatically started after creation."
+                                },
+                                "correlator": {
+                                  "type": "string",
+                                  "title": "Correlator",
+                                  "description": "Sets the message correlator.",
+                                  "$comment": "group:advanced"
+                                },
+                                "debugLogging": {
+                                  "type": "boolean",
+                                  "title": "DebugLogging",
+                                  "description": "When enabled the server prints debug logging output.",
+                                  "$comment": "group:advanced"
+                                },
+                                "endpointAdapter": {
+                                  "type": "string",
+                                  "title": "EndpointAdapter",
+                                  "description": "Sets a custom endpoint adapter to handle requests.",
+                                  "$comment": "group:advanced"
+                                },
+                                "errorHandlingStrategy": {
+                                  "type": "string",
+                                  "enum": [
+                                    "THROWS_EXCEPTION",
+                                    "PROPAGATE"
+                                  ],
+                                  "title": "ErrorHandlingStrategy",
+                                  "description": "Sets the error handling strategy.",
+                                  "$comment": "group:errorHandler"
+                                },
+                                "host": {
+                                  "type": "string",
+                                  "title": "Host",
+                                  "description": "The Ftp server host."
+                                },
+                                "listenerFactory": {
+                                  "type": "string",
+                                  "title": "ListenerFactory",
+                                  "description": "Sets a custom listener factory implementation.",
+                                  "$comment": "group:advanced"
+                                },
+                                "localPassiveMode": {
+                                  "type": "boolean",
+                                  "title": "LocalPassiveMode",
+                                  "description": "Enables the local passive mode."
+                                },
+                                "marshaller": {
+                                  "type": "string",
+                                  "title": "Marshaller",
+                                  "description": "Sets a custom Ftp message marshaller.",
+                                  "$comment": "group:advanced"
+                                },
+                                "name": {
+                                  "type": "string",
+                                  "title": "Name",
+                                  "description": "The name of the endpoint"
+                                },
+                                "password": {
+                                  "type": "string",
+                                  "title": "Password",
+                                  "description": "Sets the allowed user password.",
+                                  "$comment": "group:security"
+                                },
+                                "port": {
+                                  "type": "integer",
+                                  "title": "Port",
+                                  "description": "The Ftp server port."
+                                },
+                                "server": {
+                                  "type": "string",
+                                  "title": "Server",
+                                  "description": "Sets the Ftp server implementation.",
+                                  "$comment": "group:advanced"
+                                },
+                                "timeout": {
+                                  "type": "integer",
+                                  "title": "Timeout",
+                                  "description": "The server timeout.",
+                                  "default": "5000"
+                                },
+                                "user": {
+                                  "type": "string",
+                                  "title": "User",
+                                  "description": "Sets the allowed user name."
+                                },
+                                "userManager": {
+                                  "type": "string",
+                                  "title": "UserManager",
+                                  "description": "Sets a custom user manager implementation.",
+                                  "$comment": "group:advanced"
+                                },
+                                "userManagerProperties": {
+                                  "type": "string",
+                                  "title": "UserManagerProperties",
+                                  "description": "Loads user manage properties from a file resource.",
+                                  "$comment": "group:advanced"
+                                }
+                              },
+                              "additionalProperties": false,
+                              "title": "Server",
+                              "description": "Sets the ftp server endpoint."
+                            }
+                          }
+                        }
+                      ]
+                    }
+                  ],
+                  "title": "Ftp",
+                  "description": "Ftp client and server endpoints"
+                }
+              }
+            },
+            {
+              "type": "object",
+              "properties": {
+                "sftp": {
+                  "type": "object",
+                  "properties": {
+                    "client": {
+                    },
+                    "server": {
+                    }
+                  },
+                  "additionalProperties": false,
+                  "anyOf": [
+                    {
+                      "oneOf": [
+                        {
+                          "type": "object",
+                          "properties": {
+                            "client": {
+                              "type": "object",
+                              "properties": {
+                                "autoReadFiles": {
+                                  "type": "boolean",
+                                  "title": "AutoReadFiles",
+                                  "description": "When enabled the client automatically reads new files."
+                                },
+                                "correlator": {
+                                  "type": "string",
+                                  "title": "Correlator",
+                                  "description": "Sets the message correlator.",
+                                  "$comment": "group:advanced"
+                                },
+                                "errorHandlingStrategy": {
+                                  "type": "string",
+                                  "enum": [
+                                    "THROWS_EXCEPTION",
+                                    "PROPAGATE"
+                                  ],
+                                  "title": "ErrorHandlingStrategy",
+                                  "description": "Sets the error handling strategy.",
+                                  "$comment": "group:errorHandler"
+                                },
+                                "host": {
+                                  "type": "string",
+                                  "title": "Host",
+                                  "description": "The Ftp server host."
+                                },
+                                "knownHosts": {
+                                  "type": "string",
+                                  "title": "KnownHosts",
+                                  "description": "List of known hosts.",
+                                  "$comment": "group:security"
+                                },
+                                "localPassiveMode": {
+                                  "type": "boolean",
+                                  "title": "LocalPassiveMode",
+                                  "description": "SEnables the local passive mode."
+                                },
+                                "name": {
+                                  "type": "string",
+                                  "title": "Name",
+                                  "description": "The name of the endpoint"
+                                },
+                                "password": {
+                                  "type": "string",
+                                  "title": "Password",
+                                  "description": "Sets the user password.",
+                                  "$comment": "group:security"
+                                },
+                                "pollingInterval": {
+                                  "type": "integer",
+                                  "title": "PollingInterval",
+                                  "description": "Sets the polling interval when consuming messages."
+                                },
+                                "port": {
+                                  "type": "integer",
+                                  "title": "Port",
+                                  "description": "The Ftp server port."
+                                },
+                                "preferredAuthentications": {
+                                  "type": "string",
+                                  "title": "PreferredAuthentications",
+                                  "description": "Sets the preferred authentication mechanism.",
+                                  "$comment": "group:security"
+                                },
+                                "privateKeyPassword": {
+                                  "type": "string",
+                                  "title": "PrivateKeyPassword",
+                                  "description": "Sets the private key password.",
+                                  "$comment": "group:security"
+                                },
+                                "privateKeyPath": {
+                                  "type": "string",
+                                  "title": "PrivateKeyPath",
+                                  "description": "Sets the private key path.",
+                                  "$comment": "group:security"
+                                },
+                                "sessionConfigs": {
+                                  "type": "object",
+                                  "title": "SessionConfigs",
+                                  "description": "The session configuration.",
+                                  "additionalProperties": {
+                                    "type": "string",
+                                    "title": "SessionConfigs",
+                                    "description": "The session configuration."
+                                  }
+                                },
+                                "strictHostChecking": {
+                                  "type": "boolean",
+                                  "title": "StrictHostChecking",
+                                  "description": "Enable strict host checking.",
+                                  "$comment": "group:security"
+                                },
+                                "timeout": {
+                                  "type": "integer",
+                                  "title": "Timeout",
+                                  "description": "The endpoint timeout when waiting for messages."
+                                },
+                                "username": {
+                                  "type": "string",
+                                  "title": "Username",
+                                  "description": "Sets the user name.",
+                                  "$comment": "group:security"
+                                }
+                              },
+                              "additionalProperties": false,
+                              "title": "Client",
+                              "description": "Sets the sftp client endpoint."
+                            }
+                          }
+                        },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "server": {
+                              "type": "object",
+                              "properties": {
+                                "allowedKeyPath": {
+                                  "type": "string",
+                                  "title": "AllowedKeyPath",
+                                  "description": "Sets the allowed key certificate path.",
+                                  "$comment": "group:security"
+                                },
+                                "autoConnect": {
+                                  "type": "boolean",
+                                  "title": "AutoConnect",
+                                  "description": "When enabled the server uses automatic connect mode."
+                                },
+                                "autoLogin": {
+                                  "type": "boolean",
+                                  "title": "AutoLogin",
+                                  "description": "When enabled the server uses automatic login mode."
+                                },
+                                "autoStart": {
+                                  "type": "boolean",
+                                  "title": "AutoStart",
+                                  "description": "When enabled the server is automatically started after creation."
+                                },
+                                "debugLogging": {
+                                  "type": "boolean",
+                                  "title": "DebugLogging",
+                                  "description": "When enabled the server prints debug logging output.",
+                                  "$comment": "group:advanced"
+                                },
+                                "endpointAdapter": {
+                                  "type": "string",
+                                  "title": "EndpointAdapter",
+                                  "description": "Sets a custom endpoint adapter to handle requests.",
+                                  "$comment": "group:advanced"
+                                },
+                                "hostKeyPath": {
+                                  "type": "string",
+                                  "title": "HostKeyPath",
+                                  "description": "Sets the host key certificate path.",
+                                  "$comment": "group:security"
+                                },
+                                "knownHosts": {
+                                  "type": "string",
+                                  "title": "KnownHosts",
+                                  "description": "List of known hosts.",
+                                  "$comment": "group:security"
+                                },
+                                "name": {
+                                  "type": "string",
+                                  "title": "Name",
+                                  "description": "The name of the endpoint"
+                                },
+                                "password": {
+                                  "type": "string",
+                                  "title": "Password",
+                                  "description": "Sets the allowed user password.",
+                                  "$comment": "group:security"
+                                },
+                                "pollingInterval": {
+                                  "type": "integer",
+                                  "title": "PollingInterval",
+                                  "description": "Sets the polling interval when consuming messages."
+                                },
+                                "port": {
+                                  "type": "integer",
+                                  "title": "Port",
+                                  "description": "The Ftp server port."
+                                },
+                                "preferredAuthentications": {
+                                  "type": "string",
+                                  "title": "PreferredAuthentications",
+                                  "description": "Sets the preferred authentication mechanism.",
+                                  "$comment": "group:security"
+                                },
+                                "privateKeyPassword": {
+                                  "type": "string",
+                                  "title": "PrivateKeyPassword",
+                                  "description": "Sets the private key password.",
+                                  "$comment": "group:security"
+                                },
+                                "privateKeyPath": {
+                                  "type": "string",
+                                  "title": "PrivateKeyPath",
+                                  "description": "Sets the private key certificate path.",
+                                  "$comment": "group:security"
+                                },
+                                "sessionConfigs": {
+                                  "type": "object",
+                                  "title": "SessionConfigs",
+                                  "description": "The session configuration.",
+                                  "additionalProperties": {
+                                    "type": "string",
+                                    "title": "SessionConfigs",
+                                    "description": "The session configuration."
+                                  }
+                                },
+                                "strictHostChecking": {
+                                  "type": "boolean",
+                                  "title": "StrictHostChecking",
+                                  "description": "Enable strict host checking.",
+                                  "$comment": "group:security"
+                                },
+                                "timeout": {
+                                  "type": "integer",
+                                  "title": "Timeout",
+                                  "description": "The server timeout.",
+                                  "default": "5000"
+                                },
+                                "user": {
+                                  "type": "string",
+                                  "title": "User",
+                                  "description": "Sets the allowed user name."
+                                },
+                                "userHomePath": {
+                                  "type": "string",
+                                  "title": "UserHomePath",
+                                  "description": "Sets the user home path directory."
+                                }
+                              },
+                              "additionalProperties": false,
+                              "title": "Server",
+                              "description": "Sets the sftp server endpoint."
+                            }
+                          }
+                        }
+                      ]
+                    }
+                  ],
+                  "title": "Sftp",
+                  "description": "Sftp client and server endpoints"
+                }
+              }
+            },
+            {
+              "type": "object",
+              "properties": {
+                "scp": {
+                  "type": "object",
+                  "properties": {
+                    "client": {
+                    },
+                    "server": {
+                    }
+                  },
+                  "additionalProperties": false,
+                  "anyOf": [
+                    {
+                      "oneOf": [
+                        {
+                          "type": "object",
+                          "properties": {
+                            "client": {
+                              "type": "object",
+                              "properties": {
+                                "autoReadFiles": {
+                                  "type": "boolean",
+                                  "title": "AutoReadFiles",
+                                  "description": "When enabled the client automatically reads new files."
+                                },
+                                "correlator": {
+                                  "type": "string",
+                                  "title": "Correlator",
+                                  "description": "Sets the message correlator.",
+                                  "$comment": "group:advanced"
+                                },
+                                "errorHandlingStrategy": {
+                                  "type": "string",
+                                  "enum": [
+                                    "THROWS_EXCEPTION",
+                                    "PROPAGATE"
+                                  ],
+                                  "title": "ErrorHandlingStrategy",
+                                  "description": "Sets the error handling strategy.",
+                                  "$comment": "group:errorHandler"
+                                },
+                                "host": {
+                                  "type": "string",
+                                  "title": "Host",
+                                  "description": "The Ftp server host."
+                                },
+                                "knownHosts": {
+                                  "type": "string",
+                                  "title": "KnownHosts",
+                                  "description": "List of known hosts.",
+                                  "$comment": "group:security"
+                                },
+                                "name": {
+                                  "type": "string",
+                                  "title": "Name",
+                                  "description": "The name of the endpoint"
+                                },
+                                "password": {
+                                  "type": "string",
+                                  "title": "Password",
+                                  "description": "Sets the user password.",
+                                  "$comment": "group:security"
+                                },
+                                "pollingInterval": {
+                                  "type": "integer",
+                                  "title": "PollingInterval",
+                                  "description": "Sets the polling interval when consuming messages."
+                                },
+                                "port": {
+                                  "type": "integer",
+                                  "title": "Port",
+                                  "description": "The Ftp server port."
+                                },
+                                "portOption": {
+                                  "type": "string",
+                                  "title": "PortOption",
+                                  "description": "Sets the port option.",
+                                  "$comment": "group:advanced"
+                                },
+                                "privateKeyPassword": {
+                                  "type": "string",
+                                  "title": "PrivateKeyPassword",
+                                  "description": "Sets the private key password.",
+                                  "$comment": "group:security"
+                                },
+                                "privateKeyPath": {
+                                  "type": "string",
+                                  "title": "PrivateKeyPath",
+                                  "description": "Sets the private key path.",
+                                  "$comment": "group:security"
+                                },
+                                "strictHostChecking": {
+                                  "type": "boolean",
+                                  "title": "StrictHostChecking",
+                                  "description": "Enable strict host checking.",
+                                  "$comment": "group:security"
+                                },
+                                "timeout": {
+                                  "type": "integer",
+                                  "title": "Timeout",
+                                  "description": "The endpoint timeout when waiting for messages."
+                                },
+                                "username": {
+                                  "type": "string",
+                                  "title": "Username",
+                                  "description": "Sets the user name.",
+                                  "$comment": "group:security"
+                                }
+                              },
+                              "additionalProperties": false,
+                              "title": "Client",
+                              "description": "Sets the scp client endpoint."
+                            }
+                          }
+                        },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "server": {
+                              "type": "object",
+                              "properties": {
+                                "allowedKeyPath": {
+                                  "type": "string",
+                                  "title": "AllowedKeyPath",
+                                  "description": "Sets the allowed key certificate path.",
+                                  "$comment": "group:security"
+                                },
+                                "autoConnect": {
+                                  "type": "boolean",
+                                  "title": "AutoConnect",
+                                  "description": "When enabled the server uses automatic connect mode."
+                                },
+                                "autoLogin": {
+                                  "type": "boolean",
+                                  "title": "AutoLogin",
+                                  "description": "When enabled the server uses automatic login mode."
+                                },
+                                "autoStart": {
+                                  "type": "boolean",
+                                  "title": "AutoStart",
+                                  "description": "When enabled the server is automatically started after creation."
+                                },
+                                "debugLogging": {
+                                  "type": "boolean",
+                                  "title": "DebugLogging",
+                                  "description": "When enabled the server prints debug logging output.",
+                                  "$comment": "group:advanced"
+                                },
+                                "endpointAdapter": {
+                                  "type": "string",
+                                  "title": "EndpointAdapter",
+                                  "description": "Sets a custom endpoint adapter to handle requests.",
+                                  "$comment": "group:advanced"
+                                },
+                                "hostKeyPath": {
+                                  "type": "string",
+                                  "title": "HostKeyPath",
+                                  "description": "Sets the host key certificate path.",
+                                  "$comment": "group:security"
+                                },
+                                "knownHosts": {
+                                  "type": "string",
+                                  "title": "KnownHosts",
+                                  "description": "List of known hosts.",
+                                  "$comment": "group:security"
+                                },
+                                "name": {
+                                  "type": "string",
+                                  "title": "Name",
+                                  "description": "The name of the endpoint"
+                                },
+                                "password": {
+                                  "type": "string",
+                                  "title": "Password",
+                                  "description": "Sets the allowed user password.",
+                                  "$comment": "group:security"
+                                },
+                                "pollingInterval": {
+                                  "type": "integer",
+                                  "title": "PollingInterval",
+                                  "description": "Sets the polling interval when consuming messages."
+                                },
+                                "port": {
+                                  "type": "integer",
+                                  "title": "Port",
+                                  "description": "The Ftp server port."
+                                },
+                                "preferredAuthentications": {
+                                  "type": "string",
+                                  "title": "PreferredAuthentications",
+                                  "description": "Sets the preferred authentication mechanism.",
+                                  "$comment": "group:security"
+                                },
+                                "privateKeyPassword": {
+                                  "type": "string",
+                                  "title": "PrivateKeyPassword",
+                                  "description": "Sets the private key password.",
+                                  "$comment": "group:security"
+                                },
+                                "privateKeyPath": {
+                                  "type": "string",
+                                  "title": "PrivateKeyPath",
+                                  "description": "Sets the private key certificate path.",
+                                  "$comment": "group:security"
+                                },
+                                "sessionConfigs": {
+                                  "type": "object",
+                                  "title": "SessionConfigs",
+                                  "description": "The session configuration.",
+                                  "additionalProperties": {
+                                    "type": "string",
+                                    "title": "SessionConfigs",
+                                    "description": "The session configuration."
+                                  }
+                                },
+                                "strictHostChecking": {
+                                  "type": "boolean",
+                                  "title": "StrictHostChecking",
+                                  "description": "Enable strict host checking.",
+                                  "$comment": "group:security"
+                                },
+                                "timeout": {
+                                  "type": "integer",
+                                  "title": "Timeout",
+                                  "description": "The server timeout.",
+                                  "default": "5000"
+                                },
+                                "user": {
+                                  "type": "string",
+                                  "title": "User",
+                                  "description": "Sets the allowed user name."
+                                },
+                                "userHomePath": {
+                                  "type": "string",
+                                  "title": "UserHomePath",
+                                  "description": "Sets the user home path directory."
+                                }
+                              },
+                              "additionalProperties": false,
+                              "title": "Server",
+                              "description": "Sets the sftp server endpoint."
+                            }
+                          }
+                        }
+                      ]
+                    }
+                  ],
+                  "title": "Scp",
+                  "description": "Scp client and server endpoint"
+                }
+              }
+            },
+            {
+              "type": "object",
+              "properties": {
+                "docker": {
+                  "type": "object",
+                  "properties": {
+                    "client": {
+                      "type": "object",
+                      "properties": {
+                        "certPath": {
+                          "type": "string",
+                          "title": "CertPath",
+                          "description": "Sets the path to the client certificate.",
+                          "$comment": "group:security"
+                        },
+                        "configPath": {
+                          "type": "string",
+                          "title": "ConfigPath",
+                          "description": "Sets the path to the client configuration file.",
+                          "$comment": "group:advanced"
+                        },
+                        "email": {
+                          "type": "string",
+                          "title": "Email",
+                          "description": "The Docker client email.",
+                          "$comment": "group:security"
+                        },
+                        "name": {
+                          "type": "string",
+                          "title": "Name",
+                          "description": "The name of the endpoint"
+                        },
+                        "password": {
+                          "type": "string",
+                          "title": "Password",
+                          "description": "The Docker client password.",
+                          "$comment": "group:security"
+                        },
+                        "registry": {
+                          "type": "string",
+                          "title": "Registry",
+                          "description": "The Docker registry URL."
+                        },
+                        "url": {
+                          "type": "string",
+                          "title": "Url",
+                          "description": "The Docker host engine URL."
+                        },
+                        "username": {
+                          "type": "string",
+                          "title": "Username",
+                          "description": "The Docker client username.",
+                          "$comment": "group:security"
+                        },
+                        "verifyTls": {
+                          "type": "boolean",
+                          "title": "VerifyTls",
+                          "description": "When enabled the client verifies the Docker host TLS.",
+                          "$comment": "group:security"
+                        },
+                        "version": {
+                          "type": "string",
+                          "title": "Version",
+                          "description": "The Docker client version."
+                        }
+                      },
+                      "additionalProperties": false,
+                      "title": "Client",
+                      "description": "Sets the Docker client endpoint."
+                    }
+                  },
+                  "additionalProperties": false,
+                  "title": "Docker",
+                  "description": "Docker client"
+                }
+              }
+            },
+            {
+              "type": "object",
+              "properties": {
+                "kubernetes": {
+                  "type": "object",
+                  "properties": {
+                    "client": {
+                      "type": "object",
+                      "properties": {
+                        "certFile": {
+                          "type": "string",
+                          "title": "CertFile",
+                          "description": "Sets the client certificate.",
+                          "$comment": "group:security"
+                        },
+                        "client": {
+                          "type": "string",
+                          "title": "Client",
+                          "description": "Sets the reference to the Kubernetes client implementation.",
+                          "$comment": "group:advanced"
+                        },
+                        "messageConverter": {
+                          "type": "string",
+                          "title": "MessageConverter",
+                          "description": "Sets the message converter as a bean reference.",
+                          "$comment": "group:advanced"
+                        },
+                        "name": {
+                          "type": "string",
+                          "title": "Name",
+                          "description": "The name of the endpoint"
+                        },
+                        "namespace": {
+                          "type": "string",
+                          "title": "Namespace",
+                          "description": "Sets the namespace on the cluster."
+                        },
+                        "oAuthToken": {
+                          "type": "string",
+                          "title": "OAuthToken",
+                          "description": "Sets the OAuth token used to connect to the Kubernetes cluster.",
+                          "$comment": "group:security"
+                        },
+                        "objectMapper": {
+                          "type": "string",
+                          "title": "ObjectMapper",
+                          "description": "Sets the object mapper.",
+                          "$comment": "group:advanced"
+                        },
+                        "password": {
+                          "type": "string",
+                          "title": "Password",
+                          "description": "Sets the user password used to connect to the Kubernetes cluster.",
+                          "$comment": "group:security"
+                        },
+                        "url": {
+                          "type": "string",
+                          "title": "Url",
+                          "description": "Sets the master URL in the client configuration.",
+                          "$comment": "group:advanced"
+                        },
+                        "username": {
+                          "type": "string",
+                          "title": "Username",
+                          "description": "Sets the user name used to connect to the Kubernetes cluster.",
+                          "$comment": "group:security"
+                        },
+                        "version": {
+                          "type": "string",
+                          "title": "Version",
+                          "description": "Sets the Kubernetes client version.",
+                          "$comment": "group:advanced"
+                        }
+                      },
+                      "additionalProperties": false,
+                      "title": "Client",
+                      "description": "Sets the Kubernetes client endpoint."
+                    }
+                  },
+                  "additionalProperties": false,
+                  "title": "Kubernetes",
+                  "description": "Kubernetes client"
+                }
+              }
+            },
+            {
+              "type": "object",
+              "properties": {
+                "jms": {
+                  "type": "object",
+                  "properties": {
+                    "asynchronous": {
+                    },
+                    "synchronous": {
+                    }
+                  },
+                  "additionalProperties": false,
+                  "anyOf": [
+                    {
+                      "oneOf": [
+                        {
+                          "type": "object",
+                          "properties": {
+                            "asynchronous": {
+                              "type": "object",
+                              "properties": {
+                                "autoStart": {
+                                  "type": "boolean",
+                                  "title": "AutoStart",
+                                  "description": "When enabled the JMS consumer is started right after the endpoint is created.",
+                                  "$comment": "group:publishSubscribe"
+                                },
+                                "connectionFactory": {
+                                  "type": "string",
+                                  "title": "ConnectionFactory",
+                                  "description": "The JMS connection factory."
+                                },
+                                "destination": {
+                                  "type": "string",
+                                  "title": "Destination",
+                                  "description": "The JMS destination name."
+                                },
+                                "destinationNameResolver": {
+                                  "type": "string",
+                                  "title": "DestinationNameResolver",
+                                  "description": "Sets the destination name resolver.",
+                                  "$comment": "group:advanced"
+                                },
+                                "destinationResolver": {
+                                  "type": "string",
+                                  "title": "DestinationResolver",
+                                  "description": "Sets the destination resolver.",
+                                  "$comment": "group:advanced"
+                                },
+                                "durableSubscriberName": {
+                                  "type": "string",
+                                  "title": "DurableSubscriberName",
+                                  "description": "Sets the durable subscriber name.",
+                                  "$comment": "group:publishSubscribe"
+                                },
+                                "durableSubscription": {
+                                  "type": "boolean",
+                                  "title": "DurableSubscription",
+                                  "description": "Enables/disables durable subscription mode.",
+                                  "$comment": "group:publishSubscribe"
+                                },
+                                "filterInternalHeaders": {
+                                  "type": "boolean",
+                                  "title": "FilterInternalHeaders",
+                                  "description": "Filter internal headers.",
+                                  "$comment": "group:advanced"
+                                },
+                                "jmsTemplate": {
+                                  "type": "string",
+                                  "title": "JmsTemplate",
+                                  "description": "Sets the JMS template.",
+                                  "$comment": "group:advanced"
+                                },
+                                "messageConverter": {
+                                  "type": "string",
+                                  "title": "MessageConverter",
+                                  "description": "Sets the message converter bean reference.",
+                                  "$comment": "group:advanced"
+                                },
+                                "name": {
+                                  "type": "string",
+                                  "title": "Name",
+                                  "description": "The name of the endpoint"
+                                },
+                                "pubSubDomain": {
+                                  "type": "boolean",
+                                  "title": "PubSubDomain",
+                                  "description": "When enabled the endpoint uses publish/subscribe mode.",
+                                  "$comment": "group:publishSubscribe"
+                                },
+                                "timeout": {
+                                  "type": "integer",
+                                  "title": "Timeout",
+                                  "description": "Sets the receive timeout when the consumer waits for messages to arrive.",
+                                  "default": "5000"
+                                },
+                                "useObjectMessages": {
+                                  "type": "boolean",
+                                  "title": "UseObjectMessages",
+                                  "description": "When enabled the endpoint uses object messages.",
+                                  "$comment": "group:advanced"
+                                }
+                              },
+                              "additionalProperties": false,
+                              "title": "Asynchronous",
+                              "description": "Sets the Jms endpoint."
+                            }
+                          }
+                        },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "synchronous": {
+                              "type": "object",
+                              "properties": {
+                                "connectionFactory": {
+                                  "type": "string",
+                                  "title": "ConnectionFactory",
+                                  "description": "The JMS connection factory."
+                                },
+                                "correlator": {
+                                  "type": "string",
+                                  "title": "Correlator",
+                                  "description": "Sets the message correlator.",
+                                  "$comment": "group:advanced"
+                                },
+                                "destination": {
+                                  "type": "string",
+                                  "title": "Destination",
+                                  "description": "The JMS destination name."
+                                },
+                                "destinationNameResolver": {
+                                  "type": "string",
+                                  "title": "DestinationNameResolver",
+                                  "description": "Sets the destination name resolver.",
+                                  "$comment": "group:advanced"
+                                },
+                                "destinationResolver": {
+                                  "type": "string",
+                                  "title": "DestinationResolver",
+                                  "description": "Sets the destination resolver.",
+                                  "$comment": "group:advanced"
+                                },
+                                "filterInternalHeaders": {
+                                  "type": "boolean",
+                                  "title": "FilterInternalHeaders",
+                                  "description": "When enabled the endpoint removes all internal headers before sending a message.",
+                                  "$comment": "group:advanced"
+                                },
+                                "jmsTemplate": {
+                                  "type": "string",
+                                  "title": "JmsTemplate",
+                                  "description": "Sets the JMS template.",
+                                  "$comment": "group:advanced"
+                                },
+                                "messageConverter": {
+                                  "type": "string",
+                                  "title": "MessageConverter",
+                                  "description": "Sets the message converter bean reference.",
+                                  "$comment": "group:advanced"
+                                },
+                                "name": {
+                                  "type": "string",
+                                  "title": "Name",
+                                  "description": "The name of the endpoint"
+                                },
+                                "pollingInterval": {
+                                  "type": "integer",
+                                  "title": "PollingInterval",
+                                  "description": "Sets the polling interval.",
+                                  "$comment": "group:advanced"
+                                },
+                                "pubSubDomain": {
+                                  "type": "boolean",
+                                  "title": "PubSubDomain",
+                                  "description": "When enabled the endpoint uses publish/subscribe mode.",
+                                  "$comment": "group:advanced"
+                                },
+                                "replyDestination": {
+                                  "type": "string",
+                                  "title": "ReplyDestination",
+                                  "description": "Sets the reply destination name."
+                                },
+                                "timeout": {
+                                  "type": "integer",
+                                  "title": "Timeout",
+                                  "description": "Sets the receive timeout when the consumer waits for messages to arrive."
+                                },
+                                "useObjectMessages": {
+                                  "type": "boolean",
+                                  "title": "UseObjectMessages",
+                                  "description": "When enabled the endpoint uses object messages.",
+                                  "$comment": "group:advanced"
+                                }
+                              },
+                              "additionalProperties": false,
+                              "title": "Synchronous",
+                              "description": "Sets the synchronous Jms endpoint."
+                            }
+                          }
+                        }
+                      ]
+                    }
+                  ],
+                  "title": "JMS",
+                  "description": "JMS endpoint"
+                }
+              }
+            },
+            {
+              "type": "object",
+              "properties": {
+                "vertx": {
+                  "type": "object",
+                  "properties": {
+                    "asynchronous": {
+                    },
+                    "synchronous": {
+                    }
+                  },
+                  "additionalProperties": false,
+                  "anyOf": [
+                    {
+                      "oneOf": [
+                        {
+                          "type": "object",
+                          "properties": {
+                            "asynchronous": {
+                              "type": "object",
+                              "properties": {
+                                "address": {
+                                  "type": "string",
+                                  "title": "Address",
+                                  "description": "The event bus address."
+                                },
+                                "host": {
+                                  "type": "string",
+                                  "title": "Host",
+                                  "description": "The Vert.x event bus host."
+                                },
+                                "messageConverter": {
+                                  "type": "string",
+                                  "title": "MessageConverter",
+                                  "description": "Sets the message converter as a bean reference.",
+                                  "$comment": "group:advanced"
+                                },
+                                "name": {
+                                  "type": "string",
+                                  "title": "Name",
+                                  "description": "The name of the endpoint"
+                                },
+                                "pollingInterval": {
+                                  "type": "integer",
+                                  "title": "PollingInterval",
+                                  "description": "Sets the polling interval when consuming messages."
+                                },
+                                "port": {
+                                  "type": "integer",
+                                  "title": "Port",
+                                  "description": "The Vert.x event bus port."
+                                },
+                                "pubSubDomain": {
+                                  "type": "boolean",
+                                  "title": "PubSubDomain",
+                                  "description": "When enabled the endpoint uses publish/subscribe mode.",
+                                  "$comment": "group:advanced"
+                                },
+                                "timeout": {
+                                  "type": "integer",
+                                  "title": "Timeout",
+                                  "description": "The endpoint timeout when waiting for messages."
+                                },
+                                "vertxFactory": {
+                                  "type": "string",
+                                  "title": "VertxFactory",
+                                  "description": "Sets a custom Vert.x factory.",
+                                  "$comment": "group:advanced"
+                                }
+                              },
+                              "additionalProperties": false,
+                              "title": "Asynchronous",
+                              "description": "Sets the Vert.x endpoint."
+                            }
+                          }
+                        },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "synchronous": {
+                              "type": "object",
+                              "properties": {
+                                "address": {
+                                  "type": "string",
+                                  "title": "Address",
+                                  "description": "The event bus address."
+                                },
+                                "correlator": {
+                                  "type": "string",
+                                  "title": "Correlator",
+                                  "description": "Sets the message correlator.",
+                                  "$comment": "group:advanced"
+                                },
+                                "host": {
+                                  "type": "string",
+                                  "title": "Host",
+                                  "description": "The Vert.x event bus host."
+                                },
+                                "messageConverter": {
+                                  "type": "string",
+                                  "title": "MessageConverter",
+                                  "description": "Sets the message converter as a bean reference.",
+                                  "$comment": "group:advanced"
+                                },
+                                "name": {
+                                  "type": "string",
+                                  "title": "Name",
+                                  "description": "The name of the endpoint"
+                                },
+                                "pollingInterval": {
+                                  "type": "integer",
+                                  "title": "PollingInterval",
+                                  "description": "Sets the polling interval when consuming messages."
+                                },
+                                "port": {
+                                  "type": "integer",
+                                  "title": "Port",
+                                  "description": "The Vert.x event bus port."
+                                },
+                                "pubSubDomain": {
+                                  "type": "boolean",
+                                  "title": "PubSubDomain",
+                                  "description": "When enabled the endpoint uses publish/subscribe mode.",
+                                  "$comment": "group:advanced"
+                                },
+                                "timeout": {
+                                  "type": "integer",
+                                  "title": "Timeout",
+                                  "description": "The endpoint timeout when waiting for messages."
+                                },
+                                "vertxFactory": {
+                                  "type": "string",
+                                  "title": "VertxFactory",
+                                  "description": "Sets a custom Vert.x factory.",
+                                  "$comment": "group:advanced"
+                                }
+                              },
+                              "additionalProperties": false,
+                              "title": "Synchronous",
+                              "description": "Sets the synchronous Vert.x endpoint."
+                            }
+                          }
+                        }
+                      ]
+                    }
+                  ],
+                  "title": "Vert.x",
+                  "description": "Vert.x endpoint."
+                }
+              }
+            },
+            {
+              "type": "object",
+              "properties": {
+                "direct": {
+                  "type": "object",
+                  "properties": {
+                    "asynchronous": {
+                    },
+                    "synchronous": {
+                    }
+                  },
+                  "additionalProperties": false,
+                  "anyOf": [
+                    {
+                      "oneOf": [
+                        {
+                          "type": "object",
+                          "properties": {
+                            "asynchronous": {
+                              "type": "object",
+                              "properties": {
+                                "autoCreateQueue": {
+                                  "type": "boolean",
+                                  "title": "AutoCreateQueue",
+                                  "description": "When set the queue is automatically created when it does not exist in bean registry."
+                                },
+                                "name": {
+                                  "type": "string",
+                                  "title": "Name",
+                                  "description": "The name of the endpoint"
+                                },
+                                "queue": {
+                                  "type": "string",
+                                  "title": "Queue",
+                                  "description": "The queue name."
+                                },
+                                "timeout": {
+                                  "type": "integer",
+                                  "title": "Timeout",
+                                  "description": "The timeout when receiving messages from the queue."
+                                }
+                              },
+                              "additionalProperties": false,
+                              "title": "Asynchronous",
+                              "description": "Sets the direct endpoint."
+                            }
+                          }
+                        },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "synchronous": {
+                              "type": "object",
+                              "properties": {
+                                "autoCreateQueue": {
+                                  "type": "boolean",
+                                  "title": "AutoCreateQueue",
+                                  "description": "When set the queue is automatically created when it does not exist in bean registry."
+                                },
+                                "correlator": {
+                                  "type": "string",
+                                  "title": "Correlator",
+                                  "description": "Sets the message correlator.",
+                                  "$comment": "group:advanced"
+                                },
+                                "name": {
+                                  "type": "string",
+                                  "title": "Name",
+                                  "description": "The name of the endpoint"
+                                },
+                                "pollingInterval": {
+                                  "type": "integer",
+                                  "title": "PollingInterval",
+                                  "description": "Sets the polling interval when consuming messages."
+                                },
+                                "queue": {
+                                  "type": "string",
+                                  "title": "Queue",
+                                  "description": "The queue name."
+                                },
+                                "timeout": {
+                                  "type": "integer",
+                                  "title": "Timeout",
+                                  "description": "The timeout when receiving messages from the queue."
+                                }
+                              },
+                              "additionalProperties": false,
+                              "title": "Synchronous",
+                              "description": "Sets the synchronous direct endpoint."
+                            }
+                          }
+                        }
+                      ]
+                    }
+                  ],
+                  "title": "Direct",
+                  "description": "Direct endpoint."
+                }
+              }
+            },
+            {
+              "type": "object",
+              "properties": {
+                "kafka": {
+                  "type": "object",
+                  "properties": {
+                    "asynchronous": {
+                    },
+                    "synchronous": {
+                    }
+                  },
+                  "additionalProperties": false,
+                  "anyOf": [
+                    {
+                      "oneOf": [
+                        {
+                          "type": "object",
+                          "properties": {
+                            "asynchronous": {
+                              "type": "object",
+                              "properties": {
+                                "autoCommit": {
+                                  "type": "boolean",
+                                  "title": "AutoCommit",
+                                  "description": "Sets auto commit handling for this endpoint.",
+                                  "$comment": "group:consume"
+                                },
+                                "autoCommitInterval": {
+                                  "type": "integer",
+                                  "title": "AutoCommitInterval",
+                                  "description": "Sets the auto commit interval.",
+                                  "$comment": "group:consume"
+                                },
+                                "clientId": {
+                                  "type": "string",
+                                  "title": "ClientId",
+                                  "description": "Sets the client id used to connect to the Kafka server.",
+                                  "$comment": "group:advanced"
+                                },
+                                "consumerGroup": {
+                                  "type": "string",
+                                  "title": "ConsumerGroup",
+                                  "description": "Sets the consumer group used by the endpoint.",
+                                  "$comment": "group:consume"
+                                },
+                                "consumerProperties": {
+                                  "type": "object",
+                                  "title": "ConsumerProperties",
+                                  "description": "Sets the Kafka consumer properties.",
+                                  "$comment": "group:consume"
+                                },
+                                "headerMapper": {
+                                  "type": "string",
+                                  "title": "HeaderMapper",
+                                  "description": "Sets the Kafka header mapper.",
+                                  "$comment": "group:advanced"
+                                },
+                                "keyDeserializer": {
+                                  "type": "string",
+                                  "title": "KeyDeserializer",
+                                  "description": "Sets the fully qualified key deserializer type class name.",
+                                  "$comment": "group:deserialize"
+                                },
+                                "keySerializer": {
+                                  "type": "string",
+                                  "title": "KeySerializer",
+                                  "description": "Sets the fully qualified key serializer type class name.",
+                                  "$comment": "group:serialize"
+                                },
+                                "messageConverter": {
+                                  "type": "string",
+                                  "title": "MessageConverter",
+                                  "description": "Sets the message converter as a bean reference.",
+                                  "$comment": "group:advanced"
+                                },
+                                "name": {
+                                  "type": "string",
+                                  "title": "Name",
+                                  "description": "The name of the endpoint"
+                                },
+                                "offsetReset": {
+                                  "type": "string",
+                                  "title": "OffsetReset",
+                                  "description": "Sets the offset reset.",
+                                  "$comment": "group:consume"
+                                },
+                                "partition": {
+                                  "type": "integer",
+                                  "title": "Partition",
+                                  "description": "Sets the Kafka topic partition."
+                                },
+                                "producerProperties": {
+                                  "type": "object",
+                                  "title": "ProducerProperties",
+                                  "description": "Sets the Kafka producer properties.",
+                                  "$comment": "group:produce"
+                                },
+                                "server": {
+                                  "type": "string",
+                                  "title": "Server",
+                                  "description": "Sets the Kafka bootstrap server."
+                                },
+                                "timeout": {
+                                  "type": "integer",
+                                  "title": "Timeout",
+                                  "description": "Sets the Kafka consumer timeout.",
+                                  "$comment": "group:consume"
+                                },
+                                "topic": {
+                                  "type": "string",
+                                  "title": "Topic",
+                                  "description": "Sets the Kafka topic."
+                                },
+                                "valueDeserializer": {
+                                  "type": "string",
+                                  "title": "ValueDeserializer",
+                                  "description": "Sets the fully qualified value deserializer type class name.",
+                                  "$comment": "group:deserialize"
+                                },
+                                "valueSerializer": {
+                                  "type": "string",
+                                  "title": "ValueSerializer",
+                                  "description": "Sets the fully qualified value serializer type class name.",
+                                  "$comment": "group:serialize"
+                                }
+                              },
+                              "additionalProperties": false,
+                              "title": "Asynchronous",
+                              "description": "Sets the Kafka endpoint."
+                            }
+                          }
+                        },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "synchronous": {
+                              "type": "object",
+                              "properties": {
+                                "autoCommit": {
+                                  "type": "boolean",
+                                  "title": "AutoCommit",
+                                  "description": "Sets auto commit handling for this endpoint.",
+                                  "$comment": "group:consume"
+                                },
+                                "autoCommitInterval": {
+                                  "type": "integer",
+                                  "title": "AutoCommitInterval",
+                                  "description": "Sets the auto commit interval.",
+                                  "$comment": "group:consume"
+                                },
+                                "clientId": {
+                                  "type": "string",
+                                  "title": "ClientId",
+                                  "description": "Sets the client id used to connect to the Kafka server.",
+                                  "$comment": "group:advanced"
+                                },
+                                "consumerGroup": {
+                                  "type": "string",
+                                  "title": "ConsumerGroup",
+                                  "description": "Sets the consumer group used by the endpoint.",
+                                  "$comment": "group:consume"
+                                },
+                                "consumerProperties": {
+                                  "type": "object",
+                                  "title": "ConsumerProperties",
+                                  "description": "Sets the Kafka consumer properties.",
+                                  "$comment": "group:consume"
+                                },
+                                "headerMapper": {
+                                  "type": "string",
+                                  "title": "HeaderMapper",
+                                  "description": "Sets the Kafka header mapper.",
+                                  "$comment": "group:advanced"
+                                },
+                                "keyDeserializer": {
+                                  "type": "string",
+                                  "title": "KeyDeserializer",
+                                  "description": "Sets the fully qualified key deserializer type class name.",
+                                  "$comment": "group:deserialize"
+                                },
+                                "keySerializer": {
+                                  "type": "string",
+                                  "title": "KeySerializer",
+                                  "description": "Sets the fully qualified key serializer type class name.",
+                                  "$comment": "group:serialize"
+                                },
+                                "messageConverter": {
+                                  "type": "string",
+                                  "title": "MessageConverter",
+                                  "description": "Sets the message converter as a bean reference.",
+                                  "$comment": "group:advanced"
+                                },
+                                "name": {
+                                  "type": "string",
+                                  "title": "Name",
+                                  "description": "The name of the endpoint"
+                                },
+                                "offsetReset": {
+                                  "type": "string",
+                                  "title": "OffsetReset",
+                                  "description": "Sets the offset reset.",
+                                  "$comment": "group:consume"
+                                },
+                                "partition": {
+                                  "type": "integer",
+                                  "title": "Partition",
+                                  "description": "Sets the Kafka topic partition."
+                                },
+                                "producerProperties": {
+                                  "type": "object",
+                                  "title": "ProducerProperties",
+                                  "description": "Sets the Kafka producer properties.",
+                                  "$comment": "group:produce"
+                                },
+                                "server": {
+                                  "type": "string",
+                                  "title": "Server",
+                                  "description": "Sets the Kafka bootstrap server."
+                                },
+                                "timeout": {
+                                  "type": "integer",
+                                  "title": "Timeout",
+                                  "description": "Sets the Kafka consumer timeout.",
+                                  "$comment": "group:consume"
+                                },
+                                "topic": {
+                                  "type": "string",
+                                  "title": "Topic",
+                                  "description": "Sets the Kafka topic."
+                                },
+                                "valueDeserializer": {
+                                  "type": "string",
+                                  "title": "ValueDeserializer",
+                                  "description": "Sets the fully qualified value deserializer type class name.",
+                                  "$comment": "group:deserialize"
+                                },
+                                "valueSerializer": {
+                                  "type": "string",
+                                  "title": "ValueSerializer",
+                                  "description": "Sets the fully qualified value serializer type class name.",
+                                  "$comment": "group:serialize"
+                                }
+                              },
+                              "additionalProperties": false,
+                              "title": "Synchronous",
+                              "description": "Sets the synchronous Kafka endpoint."
+                            }
+                          }
+                        }
+                      ]
+                    }
+                  ],
+                  "title": "Kafka",
+                  "description": "Kafka endpoint."
+                }
+              }
+            },
+            {
+              "type": "object",
+              "properties": {
+                "camel": {
+                  "type": "object",
+                  "properties": {
+                    "asynchronous": {
+                    },
+                    "synchronous": {
+                    }
+                  },
+                  "additionalProperties": false,
+                  "anyOf": [
+                    {
+                      "oneOf": [
+                        {
+                          "type": "object",
+                          "properties": {
+                            "asynchronous": {
+                              "type": "object",
+                              "properties": {
+                                "camelContext": {
+                                  "type": "string",
+                                  "title": "CamelContext",
+                                  "description": "The Camel context to use."
+                                },
+                                "endpointUri": {
+                                  "type": "string",
+                                  "title": "EndpointUri",
+                                  "description": "The Camel endpoint uri."
+                                },
+                                "messageConverter": {
+                                  "type": "string",
+                                  "title": "MessageConverter",
+                                  "description": "Sets the message converter as a bean reference.",
+                                  "$comment": "group:advanced"
+                                },
+                                "name": {
+                                  "type": "string",
+                                  "title": "Name",
+                                  "description": "The name of the endpoint"
+                                },
+                                "timeout": {
+                                  "type": "integer",
+                                  "title": "Timeout",
+                                  "description": "The endpoint timeout when waiting for messages."
+                                }
+                              },
+                              "additionalProperties": false,
+                              "title": "Asynchronous",
+                              "description": "Sets the Camel endpoint."
+                            }
+                          }
+                        },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "synchronous": {
+                              "type": "object",
+                              "properties": {
+                                "camelContext": {
+                                  "type": "string",
+                                  "title": "CamelContext",
+                                  "description": "The Camel context to use."
+                                },
+                                "correlator": {
+                                  "type": "string",
+                                  "title": "Correlator",
+                                  "description": "Sets the message correlator.",
+                                  "$comment": "group:advanced"
+                                },
+                                "endpointUri": {
+                                  "type": "string",
+                                  "title": "EndpointUri",
+                                  "description": "The Camel endpoint uri."
+                                },
+                                "messageConverter": {
+                                  "type": "string",
+                                  "title": "MessageConverter",
+                                  "description": "Sets the message converter as a bean reference.",
+                                  "$comment": "group:advanced"
+                                },
+                                "name": {
+                                  "type": "string",
+                                  "title": "Name",
+                                  "description": "The name of the endpoint"
+                                },
+                                "pollingInterval": {
+                                  "type": "integer",
+                                  "title": "PollingInterval",
+                                  "description": "Sets the polling interval when consuming messages."
+                                },
+                                "timeout": {
+                                  "type": "integer",
+                                  "title": "Timeout",
+                                  "description": "The endpoint timeout when waiting for messages."
+                                }
+                              },
+                              "additionalProperties": false,
+                              "title": "Synchronous",
+                              "description": "Sets the synchronous Camel endpoint."
+                            }
+                          }
+                        }
+                      ]
+                    }
+                  ],
+                  "title": "Camel",
+                  "description": "Camel endpoint."
+                }
+              }
+            },
+            {
+              "type": "object",
+              "properties": {
+                "channel": {
+                  "type": "object",
+                  "properties": {
+                    "asynchronous": {
+                    },
+                    "synchronous": {
+                    }
+                  },
+                  "additionalProperties": false,
+                  "anyOf": [
+                    {
+                      "oneOf": [
+                        {
+                          "type": "object",
+                          "properties": {
+                            "asynchronous": {
+                              "type": "object",
+                              "properties": {
+                                "channel": {
+                                  "type": "string",
+                                  "title": "Channel",
+                                  "description": "The Spring message channel name."
+                                },
+                                "channelResolver": {
+                                  "type": "string",
+                                  "title": "ChannelResolver",
+                                  "description": "The channel destination resolver.",
+                                  "$comment": "group:advanced"
+                                },
+                                "filterInternalHeaders": {
+                                  "type": "boolean",
+                                  "title": "FilterInternalHeaders",
+                                  "description": "When enabled the endpoint removes all internal headers before sending a message.",
+                                  "$comment": "group:advanced"
+                                },
+                                "messageConverter": {
+                                  "type": "string",
+                                  "title": "MessageConverter",
+                                  "description": "Sets the message converter as a bean reference.",
+                                  "$comment": "group:advanced"
+                                },
+                                "messagingTemplate": {
+                                  "type": "string",
+                                  "title": "MessagingTemplate",
+                                  "description": "Sets a custom messaging template.",
+                                  "$comment": "group:advanced"
+                                },
+                                "name": {
+                                  "type": "string",
+                                  "title": "Name",
+                                  "description": "The name of the endpoint"
+                                },
+                                "timeout": {
+                                  "type": "integer",
+                                  "title": "Timeout",
+                                  "description": "Sets the receive timeout when waiting for messages.",
+                                  "default": "5000"
+                                },
+                                "useObjectMessages": {
+                                  "type": "boolean",
+                                  "title": "UseObjectMessages",
+                                  "description": "When enabled the endpoint uses object messages.",
+                                  "$comment": "group:advanced"
+                                }
+                              },
+                              "additionalProperties": false,
+                              "title": "Asynchronous",
+                              "description": "Sets the Spring message channel endpoint."
+                            }
+                          }
+                        },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "synchronous": {
+                              "type": "object",
+                              "properties": {
+                                "channel": {
+                                  "type": "string",
+                                  "title": "Channel",
+                                  "description": "The Spring message channel name."
+                                },
+                                "channelResolver": {
+                                  "type": "string",
+                                  "title": "ChannelResolver",
+                                  "description": "The channel destination resolver.",
+                                  "$comment": "group:advanced"
+                                },
+                                "correlator": {
+                                  "type": "string",
+                                  "title": "Correlator",
+                                  "description": "Sets the message correlator.",
+                                  "$comment": "group:advanced"
+                                },
+                                "filterInternalHeaders": {
+                                  "type": "boolean",
+                                  "title": "FilterInternalHeaders",
+                                  "description": "When enabled the endpoint removes all internal headers before sending a message.",
+                                  "$comment": "group:advanced"
+                                },
+                                "messageConverter": {
+                                  "type": "string",
+                                  "title": "MessageConverter",
+                                  "description": "Sets the message converter as a bean reference.",
+                                  "$comment": "group:advanced"
+                                },
+                                "messagingTemplate": {
+                                  "type": "string",
+                                  "title": "MessagingTemplate",
+                                  "description": "Sets a custom messaging template.",
+                                  "$comment": "group:advanced"
+                                },
+                                "name": {
+                                  "type": "string",
+                                  "title": "Name",
+                                  "description": "The name of the endpoint"
+                                },
+                                "pollingInterval": {
+                                  "type": "integer",
+                                  "title": "PollingInterval",
+                                  "description": "Sets the polling interval.",
+                                  "$comment": "group:advanced"
+                                },
+                                "timeout": {
+                                  "type": "integer",
+                                  "title": "Timeout",
+                                  "description": "Sets the receive timeout when waiting for messages.",
+                                  "default": "5000"
+                                },
+                                "useObjectMessages": {
+                                  "type": "boolean",
+                                  "title": "UseObjectMessages",
+                                  "description": "When enabled the endpoint uses object messages.",
+                                  "$comment": "group:advanced"
+                                }
+                              },
+                              "additionalProperties": false,
+                              "title": "Synchronous",
+                              "description": "Sets the synchronous Spring message channel endpoint."
+                            }
+                          }
+                        }
+                      ]
+                    }
+                  ],
+                  "title": "Spring channel",
+                  "description": "Spring channel endpoint."
+                }
+              }
+            },
+            {
+              "type": "object",
+              "properties": {
+                "selenium": {
+                  "type": "object",
+                  "properties": {
+                    "browser": {
+                      "type": "object",
+                      "properties": {
+                        "eventListeners": {
+                          "title": "EventListeners",
+                          "description": "Sets the list of event listeners.",
+                          "$comment": "group:advanced",
+                          "type": "array",
+                          "items": {
+                            "type": "string",
+                            "title": "EventListeners",
+                            "description": "Sets the list of event listeners.",
+                            "$comment": "group:advanced"
+                          }
+                        },
+                        "javaScript": {
+                          "type": "boolean",
+                          "title": "JavaScript",
+                          "description": "When enabled the browser supports JavaScript."
+                        },
+                        "name": {
+                          "type": "string",
+                          "title": "Name",
+                          "description": "The name of the endpoint"
+                        },
+                        "profile": {
+                          "type": "string",
+                          "title": "Profile",
+                          "description": "The Firefox profile.",
+                          "$comment": "group:firefox"
+                        },
+                        "remoteServerUrl": {
+                          "type": "string",
+                          "title": "RemoteServerUrl",
+                          "description": "The remote server URL."
+                        },
+                        "startPage": {
+                          "type": "string",
+                          "title": "StartPage",
+                          "description": "The URL to the start page."
+                        },
+                        "timeout": {
+                          "type": "integer",
+                          "title": "Timeout",
+                          "description": "The browser timeout."
+                        },
+                        "type": {
+                          "type": "string",
+                          "title": "Type",
+                          "description": "The Selenium browser type.",
+                          "default": "htmlunit"
+                        },
+                        "version": {
+                          "type": "string",
+                          "title": "Version",
+                          "description": "The browser version.",
+                          "$comment": "group:advanced"
+                        },
+                        "webDriver": {
+                          "type": "string",
+                          "title": "WebDriver",
+                          "description": "Sets a custom web driver as a bean reference.",
+                          "$comment": "group:advanced"
+                        }
+                      },
+                      "additionalProperties": false,
+                      "title": "Browser",
+                      "description": "Sets the Selenium browser endpoint."
+                    }
+                  },
+                  "additionalProperties": false,
+                  "title": "Selenium",
+                  "description": "Selenium endpoint."
+                }
+              }
+            }
+          ]
+        }
+      ]
+    }
+  },
+  "createVariables": {
+    "kind": "testAction",
+    "version": "4.10.1",
+    "name": "createVariables",
+    "title": "CreateVariables",
+    "description": "Create variables test action.",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "description": {
+          "type": "string",
+          "title": "Description",
+          "description": "Test action description printed when the action is executed.",
+          "$comment": "group:advanced"
+        },
+        "variables": {
+          "title": "Variables",
+          "description": "List of test variables.",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string",
+                "title": "Name",
+                "description": "The test variable name."
+              },
+              "script": {
+                "type": "object",
+                "properties": {
+                  "file": {
+                    "type": "string",
+                    "title": "File",
+                    "description": "The script loaded from a file resource."
+                  },
+                  "type": {
+                    "type": "string",
+                    "title": "Type",
+                    "description": "The script type.",
+                    "$comment": "group:advanced"
+                  },
+                  "value": {
+                    "type": "string",
+                    "title": "Value",
+                    "description": "The script content."
+                  }
+                },
+                "additionalProperties": false,
+                "title": "Script",
+                "description": "Script to build the variable value.",
+                "$comment": "group:advanced"
+              },
+              "value": {
+                "type": "string",
+                "title": "Value",
+                "description": "The test variable value."
+              }
+            },
+            "required": [
+              "name"
+            ],
+            "additionalProperties": false,
+            "title": "Variables",
+            "description": "List of test variables."
+          }
+        }
+      },
+      "required": [
+        "variables"
+      ],
+      "additionalProperties": false    }
+  },
+  "delay": {
+    "kind": "testAction",
+    "version": "4.10.1",
+    "name": "delay",
+    "title": "Delay",
+    "description": "Delay test action.",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "description": {
+          "type": "string",
+          "title": "Description",
+          "description": "Test action description printed when the action is executed.",
+          "$comment": "group:advanced"
+        },
+        "milliseconds": {
+          "type": "string",
+          "title": "Milliseconds",
+          "description": "Time to sleep in milliseconds."
+        },
+        "seconds": {
+          "type": "string",
+          "title": "Seconds",
+          "description": "Time to sleep in seconds."
+        }
+      },
+      "additionalProperties": false    }
+  },
+  "echo": {
+    "kind": "testAction",
+    "version": "4.10.1",
+    "name": "echo",
+    "title": "Echo",
+    "description": "Echo test action.",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "description": {
+          "type": "string",
+          "title": "Description",
+          "description": "Test action description printed when the action is executed.",
+          "$comment": "group:advanced"
+        },
+        "message": {
+          "type": "string",
+          "title": "Message",
+          "description": "The message to print."
+        }
+      },
+      "required": [
+        "message"
+      ],
+      "additionalProperties": false    }
+  },
+  "expectTimeout": {
+    "kind": "testAction",
+    "version": "4.10.1",
+    "name": "expectTimeout",
+    "title": "ExpectTimeout",
+    "description": "Expect timeout test action.",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "endpoint": {
+          "type": "string",
+          "title": "Endpoint",
+          "description": "The message endpoint to consume messages from. Uses an endpoint URI or references an endpoint name."
+        },
+        "select": {
+          "type": "string",
+          "title": "Select",
+          "description": "Optional message selector expression to selectively consume messages.",
+          "$comment": "group:advanced"
+        },
+        "selector": {
+          "type": "object",
+          "properties": {
+            "elements": {
+              "title": "Elements",
+              "description": "Selector elements building the selector expression.",
+              "$comment": "group:advanced",
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "title": "Name",
+                    "description": "Selector key name."
+                  },
+                  "value": {
+                    "type": "string",
+                    "title": "Value",
+                    "description": "Selector expression value that the expression must match."
+                  }
+                },
+                "required": [
+                  "name",
+                  "value"
+                ],
+                "additionalProperties": false,
+                "title": "Elements",
+                "description": "Selector elements building the selector expression.",
+                "$comment": "group:advanced"
+              }
+            },
+            "value": {
+              "type": "string",
+              "title": "Value",
+              "description": "Selector expression value."
+            }
+          },
+          "additionalProperties": false,
+          "title": "Selector",
+          "description": "Message selector to selectively consume messages.",
+          "$comment": "group:advanced"
+        },
+        "wait": {
+          "type": "integer",
+          "title": "Wait",
+          "description": "Time in milliseconds to wait for messages."
+        }
+      },
+      "required": [
+        "endpoint"
+      ],
+      "additionalProperties": false    }
+  },
+  "fail": {
+    "kind": "testAction",
+    "version": "4.10.1",
+    "name": "fail",
+    "title": "Fail",
+    "description": "Fail test action.",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "description": {
+          "type": "string",
+          "title": "Description",
+          "description": "Test action description printed when the action is executed.",
+          "$comment": "group:advanced"
+        },
+        "message": {
+          "type": "string",
+          "title": "Message",
+          "description": "Error message describing the failure."
+        }
+      },
+      "additionalProperties": false    }
+  },
+  "groovy": {
+    "kind": "testAction",
+    "version": "4.10.1",
+    "name": "groovy",
+    "module": "citrus-groovy",
+    "title": "Groovy",
+    "description": "Groovy test action.",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "actor": {
+          "type": "string",
+          "title": "Actor",
+          "$comment": "group:advanced"
+        },
+        "beans": {
+          "type": "object",
+          "properties": {
+            "file": {
+              "type": "string",
+              "title": "File"
+            },
+            "script": {
+              "type": "string",
+              "title": "Script"
+            },
+            "template": {
+              "type": "string",
+              "title": "Template"
+            },
+            "useScriptTemplate": {
+              "type": "boolean",
+              "title": "UseScriptTemplate"
+            },
+            "value": {
+              "type": "string",
+              "title": "Value"
+            }
+          },
+          "additionalProperties": false,
+          "title": "Beans",
+          "description": "Script that creates beans in the bean registry.",
+          "$comment": "group:advanced"
+        },
+        "description": {
+          "type": "string",
+          "title": "Description",
+          "description": "Test action description printed when the action is executed.",
+          "$comment": "group:advanced"
+        },
+        "endpoints": {
+          "type": "object",
+          "properties": {
+            "file": {
+              "type": "string",
+              "title": "File"
+            },
+            "script": {
+              "type": "string",
+              "title": "Script"
+            },
+            "template": {
+              "type": "string",
+              "title": "Template"
+            },
+            "useScriptTemplate": {
+              "type": "boolean",
+              "title": "UseScriptTemplate"
+            },
+            "value": {
+              "type": "string",
+              "title": "Value"
+            }
+          },
+          "additionalProperties": false,
+          "title": "Endpoints",
+          "description": "Script that creates endpoints.",
+          "$comment": "group:advanced"
+        },
+        "script": {
+          "type": "object",
+          "properties": {
+            "file": {
+              "type": "string",
+              "title": "File"
+            },
+            "script": {
+              "type": "string",
+              "title": "Script"
+            },
+            "template": {
+              "type": "string",
+              "title": "Template"
+            },
+            "useScriptTemplate": {
+              "type": "boolean",
+              "title": "UseScriptTemplate"
+            },
+            "value": {
+              "type": "string",
+              "title": "Value"
+            }
+          },
+          "additionalProperties": false,
+          "title": "Script",
+          "description": "The Groovy script to execute."
+        }
+      },
+      "additionalProperties": false    }
+  },
+  "http": {
+    "kind": "testActionGroup",
+    "version": "4.10.1",
+    "name": "http",
+    "module": "citrus-http",
+    "title": "Http",
+    "description": "Http related test actions.",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "actor": {
+          "type": "string",
+          "title": "Actor",
+          "$comment": "group:advanced"
+        },
+        "client": {
+          "type": "string",
+          "title": "Client",
+          "description": "The Http client. Uses an endpoint URI or references an endpoint name."
+        },
+        "description": {
+          "type": "string",
+          "title": "Description",
+          "description": "Test action description printed when the action is executed.",
+          "$comment": "group:advanced"
+        },
+        "server": {
+          "type": "string",
+          "title": "Server",
+          "description": "The Http server. Uses an endpoint URI or references an endpoint name."
+        }
+      },
+      "additionalProperties": false    }
+  },
+  "http-receiveRequest": {
+    "kind": "testAction",
+    "version": "4.10.1",
+    "name": "http-receiveRequest",
+    "group": "http",
+    "module": "citrus-http",
+    "title": "ReceiveRequest",
+    "description": "Receive an Http request as a server.",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "DELETE": {
+        },
+        "GET": {
+        },
+        "HEAD": {
+        },
+        "OPTIONS": {
+        },
+        "PATCH": {
+        },
+        "POST": {
+        },
+        "PUT": {
+        },
+        "TRACE": {
+        },
+        "extract": {
+          "type": "object",
+          "properties": {
+            "body": {
+              "title": "Body",
+              "description": "Extract elements from the message body into test variables.",
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "path": {
+                    "type": "string",
+                    "title": "Path",
+                    "description": "The path expression to evaluate."
+                  },
+                  "resultType": {
+                    "type": "string",
+                    "title": "ResultType",
+                    "description": "The expression result type. By default the path expression evaluate to String values.With this setting you can force another expression result type.",
+                    "$comment": "group:advanced"
+                  },
+                  "variable": {
+                    "type": "string",
+                    "title": "Variable",
+                    "description": "The test variable name."
+                  }
+                },
+                "required": [
+                  "variable"
+                ],
+                "additionalProperties": false,
+                "title": "Body",
+                "description": "Extract elements from the message body into test variables."
+              }
+            },
+            "header": {
+              "title": "Header",
+              "description": "Extract elements from the message header into test variables.",
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "title": "Name",
+                    "description": "The name of the message header."
+                  },
+                  "variable": {
+                    "type": "string",
+                    "title": "Variable",
+                    "description": "The test variable name."
+                  }
+                },
+                "required": [
+                  "name",
+                  "variable"
+                ],
+                "additionalProperties": false,
+                "title": "Header",
+                "description": "Extract elements from the message header into test variables."
+              }
+            }
+          },
+          "additionalProperties": false,
+          "title": "Extract",
+          "description": "Extract message content to test variables.",
+          "$comment": "group:advanced"
+        },
+        "headerValidator": {
+          "type": "string",
+          "title": "HeaderValidator",
+          "description": "Explicit message header validator.",
+          "$comment": "group:advanced"
+        },
+        "headerValidators": {
+          "type": "string",
+          "title": "HeaderValidators",
+          "description": "List of message header validators used to validate the message.",
+          "$comment": "group:advanced"
+        },
+        "select": {
+          "type": "string",
+          "title": "Select",
+          "description": "Message select expression to selectively consume messages.",
+          "$comment": "group:advanced"
+        },
+        "selector": {
+          "type": "object",
+          "properties": {
+            "element": {
+              "title": "Element",
+              "description": "List of elements to build the selector expression.",
+              "$comment": "group:advanced",
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "title": "Name",
+                    "description": "Select element key name."
+                  },
+                  "value": {
+                    "type": "string",
+                    "title": "Value",
+                    "description": "Select expression value."
+                  }
+                },
+                "required": [
+                  "name",
+                  "value"
+                ],
+                "additionalProperties": false,
+                "title": "Element",
+                "description": "List of elements to build the selector expression.",
+                "$comment": "group:advanced"
+              }
+            },
+            "value": {
+              "type": "string",
+              "title": "Value",
+              "description": "Selector expression value."
+            }
+          },
+          "additionalProperties": false,
+          "title": "Selector",
+          "description": "Message selector expression to selectively consume messages.",
+          "$comment": "group:advanced"
+        },
+        "timeout": {
+          "type": "integer",
+          "title": "Timeout",
+          "description": "Http request timeout."
+        },
+        "validate": {
+          "title": "Validate",
+          "description": "Validate expressions.",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "jsonPath": {
+                "title": "JsonPath",
+                "description": "JsonPath validation expression.",
+                "$comment": "group:jsonPath",
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "expression": {
+                      "type": "string",
+                      "title": "Expression",
+                      "description": "The Json path expression to evaluate."
+                    },
+                    "value": {
+                      "type": "string",
+                      "title": "Value",
+                      "description": "The expected result."
+                    }
+                  },
+                  "required": [
+                    "expression",
+                    "value"
+                  ],
+                  "additionalProperties": false,
+                  "title": "JsonPath",
+                  "description": "JsonPath validation expression.",
+                  "$comment": "group:jsonPath"
+                }
+              },
+              "namespace": {
+                "title": "Namespace",
+                "description": "List of expected namespaces.",
+                "$comment": "group:xml",
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "prefix": {
+                      "type": "string",
+                      "title": "Prefix",
+                      "description": "The expected namespace prefix."
+                    },
+                    "value": {
+                      "type": "string",
+                      "title": "Value",
+                      "description": "The expected namespace value."
+                    }
+                  },
+                  "required": [
+                    "prefix",
+                    "value"
+                  ],
+                  "additionalProperties": false,
+                  "title": "Namespace",
+                  "description": "List of expected namespaces.",
+                  "$comment": "group:xml"
+                }
+              },
+              "path": {
+                "type": "string",
+                "title": "Path",
+                "description": "Message validation expression."
+              },
+              "resultType": {
+                "type": "string",
+                "title": "ResultType",
+                "description": "Expected expression result type.",
+                "$comment": "group:advanced"
+              },
+              "script": {
+                "type": "object",
+                "properties": {
+                  "charset": {
+                    "type": "string",
+                    "title": "Charset",
+                    "description": "The charset used to load the file resource.",
+                    "$comment": "group:advanced"
+                  },
+                  "content": {
+                    "type": "string",
+                    "title": "Content",
+                    "description": "The script content as inline data."
+                  },
+                  "file": {
+                    "type": "string",
+                    "title": "File",
+                    "description": "The script content loaded as a file resource."
+                  },
+                  "type": {
+                    "type": "string",
+                    "title": "Type",
+                    "description": "The script type.",
+                    "default": "groovy"
+                  }
+                },
+                "additionalProperties": false,
+                "title": "Script",
+                "description": "Script that builds the expected validate value.",
+                "$comment": "group:script"
+              },
+              "value": {
+                "type": "string",
+                "title": "Value",
+                "description": "Expected message validation expression value."
+              },
+              "xpath": {
+                "title": "Xpath",
+                "description": "Xpath validation expression.",
+                "$comment": "group:xml",
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "expression": {
+                      "type": "string",
+                      "title": "Expression",
+                      "description": "The Xpath expression to evaluate."
+                    },
+                    "resultType": {
+                      "type": "string",
+                      "title": "ResultType",
+                      "description": "The expected result type.",
+                      "$comment": "group:advanced"
+                    },
+                    "value": {
+                      "type": "string",
+                      "title": "Value",
+                      "description": "The expected result."
+                    }
+                  },
+                  "required": [
+                    "expression",
+                    "value"
+                  ],
+                  "additionalProperties": false,
+                  "title": "Xpath",
+                  "description": "Xpath validation expression.",
+                  "$comment": "group:xml"
+                }
+              }
+            },
+            "additionalProperties": false,
+            "title": "Validate",
+            "description": "Validate expressions."
+          }
+        },
+        "validator": {
+          "type": "string",
+          "title": "Validator",
+          "description": "Explicit message validator.",
+          "$comment": "group:advanced"
+        },
+        "validators": {
+          "type": "string",
+          "title": "Validators",
+          "description": "List of message validators used to validate the message.",
+          "$comment": "group:advanced"
+        }
+      },
+      "additionalProperties": false,
+      "anyOf": [
+        {
+          "oneOf": [
+            {
+              "type": "object",
+              "properties": {
+                "GET": {
+                  "type": "object",
+                  "properties": {
+                    "accept": {
+                      "type": "string",
+                      "title": "Accept",
+                      "description": "Http accept header.",
+                      "$comment": "group:advanced"
+                    },
+                    "body": {
+                      "type": "object",
+                      "properties": {
+                        "data": {
+                        },
+                        "resource": {
+                        },
+                        "script": {
+                        }
+                      },
+                      "additionalProperties": false,
+                      "anyOf": [
+                        {
+                          "oneOf": [
+                            {
+                              "type": "object",
+                              "properties": {
+                                "data": {
+                                  "type": "string",
+                                  "title": "Data",
+                                  "description": "The message body content as inline data."
+                                }
+                              }
+                            },
+                            {
+                              "type": "object",
+                              "properties": {
+                                "resource": {
+                                  "type": "object",
+                                  "properties": {
+                                    "charset": {
+                                      "type": "string",
+                                      "title": "Charset",
+                                      "$comment": "group:advanced"
+                                    },
+                                    "file": {
+                                      "type": "string",
+                                      "title": "File"
+                                    }
+                                  },
+                                  "additionalProperties": false,
+                                  "title": "Resource",
+                                  "description": "The message body loaded from a file resource."
+                                }
+                              }
+                            },
+                            {
+                              "type": "object",
+                              "properties": {
+                                "script": {
+                                  "type": "object",
+                                  "properties": {
+                                    "charset": {
+                                      "type": "string",
+                                      "title": "Charset",
+                                      "description": "The charset used to load the file resource.",
+                                      "$comment": "group:advanced"
+                                    },
+                                    "content": {
+                                      "type": "string",
+                                      "title": "Content",
+                                      "description": "The script content as inline data."
+                                    },
+                                    "file": {
+                                      "type": "string",
+                                      "title": "File",
+                                      "description": "The script content loaded as a file resource."
+                                    },
+                                    "type": {
+                                      "type": "string",
+                                      "title": "Type",
+                                      "description": "The script type.",
+                                      "default": "groovy"
+                                    }
+                                  },
+                                  "additionalProperties": false,
+                                  "title": "Script",
+                                  "description": "The message body set via script."
+                                }
+                              }
+                            }
+                          ]
+                        }
+                      ],
+                      "title": "Body",
+                      "description": "The message body."
+                    },
+                    "contentType": {
+                      "type": "string",
+                      "title": "ContentType",
+                      "description": "Http content type."
+                    },
+                    "dataDictionary": {
+                      "type": "string",
+                      "title": "DataDictionary",
+                      "description": "Sets a data dictionary that transforms message content before it is being processed.",
+                      "$comment": "group:dictionary"
+                    },
+                    "expression": {
+                      "title": "Expression",
+                      "description": "List of path expressions to evaluate on the message content before processing the message.",
+                      "$comment": "group:advanced",
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "path": {
+                            "type": "string",
+                            "title": "Path",
+                            "description": "The path expression to evaluate."
+                          },
+                          "value": {
+                            "type": "string",
+                            "title": "Value",
+                            "description": "The expected expression result value."
+                          }
+                        },
+                        "required": [
+                          "path",
+                          "value"
+                        ],
+                        "additionalProperties": false,
+                        "title": "Expression",
+                        "description": "List of path expressions to evaluate on the message content before processing the message.",
+                        "$comment": "group:advanced"
+                      }
+                    },
+                    "headerIgnoreCase": {
+                      "type": "string",
+                      "title": "HeaderIgnoreCase",
+                      "description": "When enabled the header case is not verified.",
+                      "$comment": "group:advanced"
+                    },
+                    "headers": {
+                      "title": "Headers",
+                      "description": "The message headers.",
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "data": {
+                          },
+                          "name": {
+                            "type": "string",
+                            "title": "Name",
+                            "description": "The message header name."
+                          },
+                          "resource": {
+                          },
+                          "type": {
+                            "type": "string",
+                            "title": "Type",
+                            "description": "The message header type to create typed message headers.",
+                            "$comment": "group:advanced"
+                          },
+                          "value": {
+                          }
+                        },
+                        "additionalProperties": false,
+                        "anyOf": [
+                          {
+                            "oneOf": [
+                              {
+                                "type": "object",
+                                "properties": {
+                                  "value": {
+                                    "type": "string",
+                                    "title": "Value",
+                                    "description": "The message header value."
+                                  }
+                                }
+                              },
+                              {
+                                "type": "object",
+                                "properties": {
+                                  "resource": {
+                                    "type": "object",
+                                    "properties": {
+                                      "charset": {
+                                        "type": "string",
+                                        "title": "Charset",
+                                        "description": "Optional file resource charset used to read the file content.",
+                                        "$comment": "group:advanced"
+                                      },
+                                      "file": {
+                                        "type": "string",
+                                        "title": "File",
+                                        "description": "The file resource path."
+                                      }
+                                    },
+                                    "required": [
+                                      "file"
+                                    ],
+                                    "additionalProperties": false,
+                                    "title": "Resource",
+                                    "description": "The header data loaded from a file resource."
+                                  }
+                                }
+                              },
+                              {
+                                "type": "object",
+                                "properties": {
+                                  "data": {
+                                    "type": "string",
+                                    "title": "Data",
+                                    "description": "The message header value as inline data."
+                                  }
+                                }
+                              }
+                            ]
+                          }
+                        ],
+                        "title": "Headers",
+                        "description": "The message headers."
+                      }
+                    },
+                    "name": {
+                      "type": "string",
+                      "title": "Name",
+                      "description": "The message name. Named messages may be referenced in subsequent test steps."
+                    },
+                    "parameters": {
+                      "title": "Parameters",
+                      "description": "List of Http query parameters.",
+                      "$comment": "group:advanced",
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "name": {
+                            "type": "string",
+                            "title": "Name",
+                            "description": "Http query parameter name."
+                          },
+                          "value": {
+                            "type": "string",
+                            "title": "Value",
+                            "description": "Http query parameter value."
+                          }
+                        },
+                        "required": [
+                          "name",
+                          "value"
+                        ],
+                        "additionalProperties": false,
+                        "title": "Parameters",
+                        "description": "List of Http query parameters.",
+                        "$comment": "group:advanced"
+                      }
+                    },
+                    "path": {
+                      "type": "string",
+                      "title": "Path",
+                      "description": "Http request path."
+                    },
+                    "schema": {
+                      "type": "string",
+                      "title": "Schema",
+                      "description": "The reference to a schema in the bean registry that should be used for validation.",
+                      "$comment": "group:schema"
+                    },
+                    "schemaRepository": {
+                      "type": "string",
+                      "title": "SchemaRepository",
+                      "description": "The schema repository holding the schema.",
+                      "$comment": "group:schema"
+                    },
+                    "schemaValidation": {
+                      "type": "boolean",
+                      "title": "SchemaValidation",
+                      "description": "Enables the schema validation.",
+                      "$comment": "group:schema"
+                    },
+                    "type": {
+                      "type": "string",
+                      "title": "Type",
+                      "description": "The message type. Gives the validator a hint which validatory are capable of performing proper message validation.",
+                      "$comment": "group:advanced"
+                    },
+                    "version": {
+                      "type": "string",
+                      "title": "Version",
+                      "description": "Http version.",
+                      "$comment": "group:advanced"
+                    }
+                  },
+                  "additionalProperties": false,
+                  "title": "GET",
+                  "description": "Http GET request"
+                }
+              }
+            },
+            {
+              "type": "object",
+              "properties": {
+                "POST": {
+                  "type": "object",
+                  "properties": {
+                    "accept": {
+                      "type": "string",
+                      "title": "Accept",
+                      "description": "Http accept header.",
+                      "$comment": "group:advanced"
+                    },
+                    "body": {
+                      "type": "object",
+                      "properties": {
+                        "data": {
+                        },
+                        "resource": {
+                        },
+                        "script": {
+                        }
+                      },
+                      "additionalProperties": false,
+                      "anyOf": [
+                        {
+                          "oneOf": [
+                            {
+                              "type": "object",
+                              "properties": {
+                                "data": {
+                                  "type": "string",
+                                  "title": "Data",
+                                  "description": "The message body content as inline data."
+                                }
+                              }
+                            },
+                            {
+                              "type": "object",
+                              "properties": {
+                                "resource": {
+                                  "type": "object",
+                                  "properties": {
+                                    "charset": {
+                                      "type": "string",
+                                      "title": "Charset",
+                                      "$comment": "group:advanced"
+                                    },
+                                    "file": {
+                                      "type": "string",
+                                      "title": "File"
+                                    }
+                                  },
+                                  "additionalProperties": false,
+                                  "title": "Resource",
+                                  "description": "The message body loaded from a file resource."
+                                }
+                              }
+                            },
+                            {
+                              "type": "object",
+                              "properties": {
+                                "script": {
+                                  "type": "object",
+                                  "properties": {
+                                    "charset": {
+                                      "type": "string",
+                                      "title": "Charset",
+                                      "description": "The charset used to load the file resource.",
+                                      "$comment": "group:advanced"
+                                    },
+                                    "content": {
+                                      "type": "string",
+                                      "title": "Content",
+                                      "description": "The script content as inline data."
+                                    },
+                                    "file": {
+                                      "type": "string",
+                                      "title": "File",
+                                      "description": "The script content loaded as a file resource."
+                                    },
+                                    "type": {
+                                      "type": "string",
+                                      "title": "Type",
+                                      "description": "The script type.",
+                                      "default": "groovy"
+                                    }
+                                  },
+                                  "additionalProperties": false,
+                                  "title": "Script",
+                                  "description": "The message body set via script."
+                                }
+                              }
+                            }
+                          ]
+                        }
+                      ],
+                      "title": "Body",
+                      "description": "The message body."
+                    },
+                    "contentType": {
+                      "type": "string",
+                      "title": "ContentType",
+                      "description": "Http content type."
+                    },
+                    "dataDictionary": {
+                      "type": "string",
+                      "title": "DataDictionary",
+                      "description": "Sets a data dictionary that transforms message content before it is being processed.",
+                      "$comment": "group:dictionary"
+                    },
+                    "expression": {
+                      "title": "Expression",
+                      "description": "List of path expressions to evaluate on the message content before processing the message.",
+                      "$comment": "group:advanced",
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "path": {
+                            "type": "string",
+                            "title": "Path",
+                            "description": "The path expression to evaluate."
+                          },
+                          "value": {
+                            "type": "string",
+                            "title": "Value",
+                            "description": "The expected expression result value."
+                          }
+                        },
+                        "required": [
+                          "path",
+                          "value"
+                        ],
+                        "additionalProperties": false,
+                        "title": "Expression",
+                        "description": "List of path expressions to evaluate on the message content before processing the message.",
+                        "$comment": "group:advanced"
+                      }
+                    },
+                    "headerIgnoreCase": {
+                      "type": "string",
+                      "title": "HeaderIgnoreCase",
+                      "description": "When enabled the header case is not verified.",
+                      "$comment": "group:advanced"
+                    },
+                    "headers": {
+                      "title": "Headers",
+                      "description": "The message headers.",
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "data": {
+                          },
+                          "name": {
+                            "type": "string",
+                            "title": "Name",
+                            "description": "The message header name."
+                          },
+                          "resource": {
+                          },
+                          "type": {
+                            "type": "string",
+                            "title": "Type",
+                            "description": "The message header type to create typed message headers.",
+                            "$comment": "group:advanced"
+                          },
+                          "value": {
+                          }
+                        },
+                        "additionalProperties": false,
+                        "anyOf": [
+                          {
+                            "oneOf": [
+                              {
+                                "type": "object",
+                                "properties": {
+                                  "value": {
+                                    "type": "string",
+                                    "title": "Value",
+                                    "description": "The message header value."
+                                  }
+                                }
+                              },
+                              {
+                                "type": "object",
+                                "properties": {
+                                  "resource": {
+                                    "type": "object",
+                                    "properties": {
+                                      "charset": {
+                                        "type": "string",
+                                        "title": "Charset",
+                                        "description": "Optional file resource charset used to read the file content.",
+                                        "$comment": "group:advanced"
+                                      },
+                                      "file": {
+                                        "type": "string",
+                                        "title": "File",
+                                        "description": "The file resource path."
+                                      }
+                                    },
+                                    "required": [
+                                      "file"
+                                    ],
+                                    "additionalProperties": false,
+                                    "title": "Resource",
+                                    "description": "The header data loaded from a file resource."
+                                  }
+                                }
+                              },
+                              {
+                                "type": "object",
+                                "properties": {
+                                  "data": {
+                                    "type": "string",
+                                    "title": "Data",
+                                    "description": "The message header value as inline data."
+                                  }
+                                }
+                              }
+                            ]
+                          }
+                        ],
+                        "title": "Headers",
+                        "description": "The message headers."
+                      }
+                    },
+                    "name": {
+                      "type": "string",
+                      "title": "Name",
+                      "description": "The message name. Named messages may be referenced in subsequent test steps."
+                    },
+                    "parameters": {
+                      "title": "Parameters",
+                      "description": "List of Http query parameters.",
+                      "$comment": "group:advanced",
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "name": {
+                            "type": "string",
+                            "title": "Name",
+                            "description": "Http query parameter name."
+                          },
+                          "value": {
+                            "type": "string",
+                            "title": "Value",
+                            "description": "Http query parameter value."
+                          }
+                        },
+                        "required": [
+                          "name",
+                          "value"
+                        ],
+                        "additionalProperties": false,
+                        "title": "Parameters",
+                        "description": "List of Http query parameters.",
+                        "$comment": "group:advanced"
+                      }
+                    },
+                    "path": {
+                      "type": "string",
+                      "title": "Path",
+                      "description": "Http request path."
+                    },
+                    "schema": {
+                      "type": "string",
+                      "title": "Schema",
+                      "description": "The reference to a schema in the bean registry that should be used for validation.",
+                      "$comment": "group:schema"
+                    },
+                    "schemaRepository": {
+                      "type": "string",
+                      "title": "SchemaRepository",
+                      "description": "The schema repository holding the schema.",
+                      "$comment": "group:schema"
+                    },
+                    "schemaValidation": {
+                      "type": "boolean",
+                      "title": "SchemaValidation",
+                      "description": "Enables the schema validation.",
+                      "$comment": "group:schema"
+                    },
+                    "type": {
+                      "type": "string",
+                      "title": "Type",
+                      "description": "The message type. Gives the validator a hint which validatory are capable of performing proper message validation.",
+                      "$comment": "group:advanced"
+                    },
+                    "version": {
+                      "type": "string",
+                      "title": "Version",
+                      "description": "Http version.",
+                      "$comment": "group:advanced"
+                    }
+                  },
+                  "additionalProperties": false,
+                  "title": "POST",
+                  "description": "Http POST request"
+                }
+              }
+            },
+            {
+              "type": "object",
+              "properties": {
+                "PUT": {
+                  "type": "object",
+                  "properties": {
+                    "accept": {
+                      "type": "string",
+                      "title": "Accept",
+                      "description": "Http accept header.",
+                      "$comment": "group:advanced"
+                    },
+                    "body": {
+                      "type": "object",
+                      "properties": {
+                        "data": {
+                        },
+                        "resource": {
+                        },
+                        "script": {
+                        }
+                      },
+                      "additionalProperties": false,
+                      "anyOf": [
+                        {
+                          "oneOf": [
+                            {
+                              "type": "object",
+                              "properties": {
+                                "data": {
+                                  "type": "string",
+                                  "title": "Data",
+                                  "description": "The message body content as inline data."
+                                }
+                              }
+                            },
+                            {
+                              "type": "object",
+                              "properties": {
+                                "resource": {
+                                  "type": "object",
+                                  "properties": {
+                                    "charset": {
+                                      "type": "string",
+                                      "title": "Charset",
+                                      "$comment": "group:advanced"
+                                    },
+                                    "file": {
+                                      "type": "string",
+                                      "title": "File"
+                                    }
+                                  },
+                                  "additionalProperties": false,
+                                  "title": "Resource",
+                                  "description": "The message body loaded from a file resource."
+                                }
+                              }
+                            },
+                            {
+                              "type": "object",
+                              "properties": {
+                                "script": {
+                                  "type": "object",
+                                  "properties": {
+                                    "charset": {
+                                      "type": "string",
+                                      "title": "Charset",
+                                      "description": "The charset used to load the file resource.",
+                                      "$comment": "group:advanced"
+                                    },
+                                    "content": {
+                                      "type": "string",
+                                      "title": "Content",
+                                      "description": "The script content as inline data."
+                                    },
+                                    "file": {
+                                      "type": "string",
+                                      "title": "File",
+                                      "description": "The script content loaded as a file resource."
+                                    },
+                                    "type": {
+                                      "type": "string",
+                                      "title": "Type",
+                                      "description": "The script type.",
+                                      "default": "groovy"
+                                    }
+                                  },
+                                  "additionalProperties": false,
+                                  "title": "Script",
+                                  "description": "The message body set via script."
+                                }
+                              }
+                            }
+                          ]
+                        }
+                      ],
+                      "title": "Body",
+                      "description": "The message body."
+                    },
+                    "contentType": {
+                      "type": "string",
+                      "title": "ContentType",
+                      "description": "Http content type."
+                    },
+                    "dataDictionary": {
+                      "type": "string",
+                      "title": "DataDictionary",
+                      "description": "Sets a data dictionary that transforms message content before it is being processed.",
+                      "$comment": "group:dictionary"
+                    },
+                    "expression": {
+                      "title": "Expression",
+                      "description": "List of path expressions to evaluate on the message content before processing the message.",
+                      "$comment": "group:advanced",
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "path": {
+                            "type": "string",
+                            "title": "Path",
+                            "description": "The path expression to evaluate."
+                          },
+                          "value": {
+                            "type": "string",
+                            "title": "Value",
+                            "description": "The expected expression result value."
+                          }
+                        },
+                        "required": [
+                          "path",
+                          "value"
+                        ],
+                        "additionalProperties": false,
+                        "title": "Expression",
+                        "description": "List of path expressions to evaluate on the message content before processing the message.",
+                        "$comment": "group:advanced"
+                      }
+                    },
+                    "headerIgnoreCase": {
+                      "type": "string",
+                      "title": "HeaderIgnoreCase",
+                      "description": "When enabled the header case is not verified.",
+                      "$comment": "group:advanced"
+                    },
+                    "headers": {
+                      "title": "Headers",
+                      "description": "The message headers.",
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "data": {
+                          },
+                          "name": {
+                            "type": "string",
+                            "title": "Name",
+                            "description": "The message header name."
+                          },
+                          "resource": {
+                          },
+                          "type": {
+                            "type": "string",
+                            "title": "Type",
+                            "description": "The message header type to create typed message headers.",
+                            "$comment": "group:advanced"
+                          },
+                          "value": {
+                          }
+                        },
+                        "additionalProperties": false,
+                        "anyOf": [
+                          {
+                            "oneOf": [
+                              {
+                                "type": "object",
+                                "properties": {
+                                  "value": {
+                                    "type": "string",
+                                    "title": "Value",
+                                    "description": "The message header value."
+                                  }
+                                }
+                              },
+                              {
+                                "type": "object",
+                                "properties": {
+                                  "resource": {
+                                    "type": "object",
+                                    "properties": {
+                                      "charset": {
+                                        "type": "string",
+                                        "title": "Charset",
+                                        "description": "Optional file resource charset used to read the file content.",
+                                        "$comment": "group:advanced"
+                                      },
+                                      "file": {
+                                        "type": "string",
+                                        "title": "File",
+                                        "description": "The file resource path."
+                                      }
+                                    },
+                                    "required": [
+                                      "file"
+                                    ],
+                                    "additionalProperties": false,
+                                    "title": "Resource",
+                                    "description": "The header data loaded from a file resource."
+                                  }
+                                }
+                              },
+                              {
+                                "type": "object",
+                                "properties": {
+                                  "data": {
+                                    "type": "string",
+                                    "title": "Data",
+                                    "description": "The message header value as inline data."
+                                  }
+                                }
+                              }
+                            ]
+                          }
+                        ],
+                        "title": "Headers",
+                        "description": "The message headers."
+                      }
+                    },
+                    "name": {
+                      "type": "string",
+                      "title": "Name",
+                      "description": "The message name. Named messages may be referenced in subsequent test steps."
+                    },
+                    "parameters": {
+                      "title": "Parameters",
+                      "description": "List of Http query parameters.",
+                      "$comment": "group:advanced",
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "name": {
+                            "type": "string",
+                            "title": "Name",
+                            "description": "Http query parameter name."
+                          },
+                          "value": {
+                            "type": "string",
+                            "title": "Value",
+                            "description": "Http query parameter value."
+                          }
+                        },
+                        "required": [
+                          "name",
+                          "value"
+                        ],
+                        "additionalProperties": false,
+                        "title": "Parameters",
+                        "description": "List of Http query parameters.",
+                        "$comment": "group:advanced"
+                      }
+                    },
+                    "path": {
+                      "type": "string",
+                      "title": "Path",
+                      "description": "Http request path."
+                    },
+                    "schema": {
+                      "type": "string",
+                      "title": "Schema",
+                      "description": "The reference to a schema in the bean registry that should be used for validation.",
+                      "$comment": "group:schema"
+                    },
+                    "schemaRepository": {
+                      "type": "string",
+                      "title": "SchemaRepository",
+                      "description": "The schema repository holding the schema.",
+                      "$comment": "group:schema"
+                    },
+                    "schemaValidation": {
+                      "type": "boolean",
+                      "title": "SchemaValidation",
+                      "description": "Enables the schema validation.",
+                      "$comment": "group:schema"
+                    },
+                    "type": {
+                      "type": "string",
+                      "title": "Type",
+                      "description": "The message type. Gives the validator a hint which validatory are capable of performing proper message validation.",
+                      "$comment": "group:advanced"
+                    },
+                    "version": {
+                      "type": "string",
+                      "title": "Version",
+                      "description": "Http version.",
+                      "$comment": "group:advanced"
+                    }
+                  },
+                  "additionalProperties": false,
+                  "title": "PUT",
+                  "description": "Http PUT request"
+                }
+              }
+            },
+            {
+              "type": "object",
+              "properties": {
+                "PUT": {
+                }
+              }
+            },
+            {
+              "type": "object",
+              "properties": {
+                "DELETE": {
+                  "type": "object",
+                  "properties": {
+                    "accept": {
+                      "type": "string",
+                      "title": "Accept",
+                      "description": "Http accept header.",
+                      "$comment": "group:advanced"
+                    },
+                    "body": {
+                      "type": "object",
+                      "properties": {
+                        "data": {
+                        },
+                        "resource": {
+                        },
+                        "script": {
+                        }
+                      },
+                      "additionalProperties": false,
+                      "anyOf": [
+                        {
+                          "oneOf": [
+                            {
+                              "type": "object",
+                              "properties": {
+                                "data": {
+                                  "type": "string",
+                                  "title": "Data",
+                                  "description": "The message body content as inline data."
+                                }
+                              }
+                            },
+                            {
+                              "type": "object",
+                              "properties": {
+                                "resource": {
+                                  "type": "object",
+                                  "properties": {
+                                    "charset": {
+                                      "type": "string",
+                                      "title": "Charset",
+                                      "$comment": "group:advanced"
+                                    },
+                                    "file": {
+                                      "type": "string",
+                                      "title": "File"
+                                    }
+                                  },
+                                  "additionalProperties": false,
+                                  "title": "Resource",
+                                  "description": "The message body loaded from a file resource."
+                                }
+                              }
+                            },
+                            {
+                              "type": "object",
+                              "properties": {
+                                "script": {
+                                  "type": "object",
+                                  "properties": {
+                                    "charset": {
+                                      "type": "string",
+                                      "title": "Charset",
+                                      "description": "The charset used to load the file resource.",
+                                      "$comment": "group:advanced"
+                                    },
+                                    "content": {
+                                      "type": "string",
+                                      "title": "Content",
+                                      "description": "The script content as inline data."
+                                    },
+                                    "file": {
+                                      "type": "string",
+                                      "title": "File",
+                                      "description": "The script content loaded as a file resource."
+                                    },
+                                    "type": {
+                                      "type": "string",
+                                      "title": "Type",
+                                      "description": "The script type.",
+                                      "default": "groovy"
+                                    }
+                                  },
+                                  "additionalProperties": false,
+                                  "title": "Script",
+                                  "description": "The message body set via script."
+                                }
+                              }
+                            }
+                          ]
+                        }
+                      ],
+                      "title": "Body",
+                      "description": "The message body."
+                    },
+                    "contentType": {
+                      "type": "string",
+                      "title": "ContentType",
+                      "description": "Http content type."
+                    },
+                    "dataDictionary": {
+                      "type": "string",
+                      "title": "DataDictionary",
+                      "description": "Sets a data dictionary that transforms message content before it is being processed.",
+                      "$comment": "group:dictionary"
+                    },
+                    "expression": {
+                      "title": "Expression",
+                      "description": "List of path expressions to evaluate on the message content before processing the message.",
+                      "$comment": "group:advanced",
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "path": {
+                            "type": "string",
+                            "title": "Path",
+                            "description": "The path expression to evaluate."
+                          },
+                          "value": {
+                            "type": "string",
+                            "title": "Value",
+                            "description": "The expected expression result value."
+                          }
+                        },
+                        "required": [
+                          "path",
+                          "value"
+                        ],
+                        "additionalProperties": false,
+                        "title": "Expression",
+                        "description": "List of path expressions to evaluate on the message content before processing the message.",
+                        "$comment": "group:advanced"
+                      }
+                    },
+                    "headerIgnoreCase": {
+                      "type": "string",
+                      "title": "HeaderIgnoreCase",
+                      "description": "When enabled the header case is not verified.",
+                      "$comment": "group:advanced"
+                    },
+                    "headers": {
+                      "title": "Headers",
+                      "description": "The message headers.",
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "data": {
+                          },
+                          "name": {
+                            "type": "string",
+                            "title": "Name",
+                            "description": "The message header name."
+                          },
+                          "resource": {
+                          },
+                          "type": {
+                            "type": "string",
+                            "title": "Type",
+                            "description": "The message header type to create typed message headers.",
+                            "$comment": "group:advanced"
+                          },
+                          "value": {
+                          }
+                        },
+                        "additionalProperties": false,
+                        "anyOf": [
+                          {
+                            "oneOf": [
+                              {
+                                "type": "object",
+                                "properties": {
+                                  "value": {
+                                    "type": "string",
+                                    "title": "Value",
+                                    "description": "The message header value."
+                                  }
+                                }
+                              },
+                              {
+                                "type": "object",
+                                "properties": {
+                                  "resource": {
+                                    "type": "object",
+                                    "properties": {
+                                      "charset": {
+                                        "type": "string",
+                                        "title": "Charset",
+                                        "description": "Optional file resource charset used to read the file content.",
+                                        "$comment": "group:advanced"
+                                      },
+                                      "file": {
+                                        "type": "string",
+                                        "title": "File",
+                                        "description": "The file resource path."
+                                      }
+                                    },
+                                    "required": [
+                                      "file"
+                                    ],
+                                    "additionalProperties": false,
+                                    "title": "Resource",
+                                    "description": "The header data loaded from a file resource."
+                                  }
+                                }
+                              },
+                              {
+                                "type": "object",
+                                "properties": {
+                                  "data": {
+                                    "type": "string",
+                                    "title": "Data",
+                                    "description": "The message header value as inline data."
+                                  }
+                                }
+                              }
+                            ]
+                          }
+                        ],
+                        "title": "Headers",
+                        "description": "The message headers."
+                      }
+                    },
+                    "name": {
+                      "type": "string",
+                      "title": "Name",
+                      "description": "The message name. Named messages may be referenced in subsequent test steps."
+                    },
+                    "parameters": {
+                      "title": "Parameters",
+                      "description": "List of Http query parameters.",
+                      "$comment": "group:advanced",
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "name": {
+                            "type": "string",
+                            "title": "Name",
+                            "description": "Http query parameter name."
+                          },
+                          "value": {
+                            "type": "string",
+                            "title": "Value",
+                            "description": "Http query parameter value."
+                          }
+                        },
+                        "required": [
+                          "name",
+                          "value"
+                        ],
+                        "additionalProperties": false,
+                        "title": "Parameters",
+                        "description": "List of Http query parameters.",
+                        "$comment": "group:advanced"
+                      }
+                    },
+                    "path": {
+                      "type": "string",
+                      "title": "Path",
+                      "description": "Http request path."
+                    },
+                    "schema": {
+                      "type": "string",
+                      "title": "Schema",
+                      "description": "The reference to a schema in the bean registry that should be used for validation.",
+                      "$comment": "group:schema"
+                    },
+                    "schemaRepository": {
+                      "type": "string",
+                      "title": "SchemaRepository",
+                      "description": "The schema repository holding the schema.",
+                      "$comment": "group:schema"
+                    },
+                    "schemaValidation": {
+                      "type": "boolean",
+                      "title": "SchemaValidation",
+                      "description": "Enables the schema validation.",
+                      "$comment": "group:schema"
+                    },
+                    "type": {
+                      "type": "string",
+                      "title": "Type",
+                      "description": "The message type. Gives the validator a hint which validatory are capable of performing proper message validation.",
+                      "$comment": "group:advanced"
+                    },
+                    "version": {
+                      "type": "string",
+                      "title": "Version",
+                      "description": "Http version.",
+                      "$comment": "group:advanced"
+                    }
+                  },
+                  "additionalProperties": false,
+                  "title": "DELETE",
+                  "description": "Http DELETE request"
+                }
+              }
+            },
+            {
+              "type": "object",
+              "properties": {
+                "HEAD": {
+                  "type": "object",
+                  "properties": {
+                    "accept": {
+                      "type": "string",
+                      "title": "Accept",
+                      "description": "Http accept header.",
+                      "$comment": "group:advanced"
+                    },
+                    "body": {
+                      "type": "object",
+                      "properties": {
+                        "data": {
+                        },
+                        "resource": {
+                        },
+                        "script": {
+                        }
+                      },
+                      "additionalProperties": false,
+                      "anyOf": [
+                        {
+                          "oneOf": [
+                            {
+                              "type": "object",
+                              "properties": {
+                                "data": {
+                                  "type": "string",
+                                  "title": "Data",
+                                  "description": "The message body content as inline data."
+                                }
+                              }
+                            },
+                            {
+                              "type": "object",
+                              "properties": {
+                                "resource": {
+                                  "type": "object",
+                                  "properties": {
+                                    "charset": {
+                                      "type": "string",
+                                      "title": "Charset",
+                                      "$comment": "group:advanced"
+                                    },
+                                    "file": {
+                                      "type": "string",
+                                      "title": "File"
+                                    }
+                                  },
+                                  "additionalProperties": false,
+                                  "title": "Resource",
+                                  "description": "The message body loaded from a file resource."
+                                }
+                              }
+                            },
+                            {
+                              "type": "object",
+                              "properties": {
+                                "script": {
+                                  "type": "object",
+                                  "properties": {
+                                    "charset": {
+                                      "type": "string",
+                                      "title": "Charset",
+                                      "description": "The charset used to load the file resource.",
+                                      "$comment": "group:advanced"
+                                    },
+                                    "content": {
+                                      "type": "string",
+                                      "title": "Content",
+                                      "description": "The script content as inline data."
+                                    },
+                                    "file": {
+                                      "type": "string",
+                                      "title": "File",
+                                      "description": "The script content loaded as a file resource."
+                                    },
+                                    "type": {
+                                      "type": "string",
+                                      "title": "Type",
+                                      "description": "The script type.",
+                                      "default": "groovy"
+                                    }
+                                  },
+                                  "additionalProperties": false,
+                                  "title": "Script",
+                                  "description": "The message body set via script."
+                                }
+                              }
+                            }
+                          ]
+                        }
+                      ],
+                      "title": "Body",
+                      "description": "The message body."
+                    },
+                    "contentType": {
+                      "type": "string",
+                      "title": "ContentType",
+                      "description": "Http content type."
+                    },
+                    "dataDictionary": {
+                      "type": "string",
+                      "title": "DataDictionary",
+                      "description": "Sets a data dictionary that transforms message content before it is being processed.",
+                      "$comment": "group:dictionary"
+                    },
+                    "expression": {
+                      "title": "Expression",
+                      "description": "List of path expressions to evaluate on the message content before processing the message.",
+                      "$comment": "group:advanced",
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "path": {
+                            "type": "string",
+                            "title": "Path",
+                            "description": "The path expression to evaluate."
+                          },
+                          "value": {
+                            "type": "string",
+                            "title": "Value",
+                            "description": "The expected expression result value."
+                          }
+                        },
+                        "required": [
+                          "path",
+                          "value"
+                        ],
+                        "additionalProperties": false,
+                        "title": "Expression",
+                        "description": "List of path expressions to evaluate on the message content before processing the message.",
+                        "$comment": "group:advanced"
+                      }
+                    },
+                    "headerIgnoreCase": {
+                      "type": "string",
+                      "title": "HeaderIgnoreCase",
+                      "description": "When enabled the header case is not verified.",
+                      "$comment": "group:advanced"
+                    },
+                    "headers": {
+                      "title": "Headers",
+                      "description": "The message headers.",
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "data": {
+                          },
+                          "name": {
+                            "type": "string",
+                            "title": "Name",
+                            "description": "The message header name."
+                          },
+                          "resource": {
+                          },
+                          "type": {
+                            "type": "string",
+                            "title": "Type",
+                            "description": "The message header type to create typed message headers.",
+                            "$comment": "group:advanced"
+                          },
+                          "value": {
+                          }
+                        },
+                        "additionalProperties": false,
+                        "anyOf": [
+                          {
+                            "oneOf": [
+                              {
+                                "type": "object",
+                                "properties": {
+                                  "value": {
+                                    "type": "string",
+                                    "title": "Value",
+                                    "description": "The message header value."
+                                  }
+                                }
+                              },
+                              {
+                                "type": "object",
+                                "properties": {
+                                  "resource": {
+                                    "type": "object",
+                                    "properties": {
+                                      "charset": {
+                                        "type": "string",
+                                        "title": "Charset",
+                                        "description": "Optional file resource charset used to read the file content.",
+                                        "$comment": "group:advanced"
+                                      },
+                                      "file": {
+                                        "type": "string",
+                                        "title": "File",
+                                        "description": "The file resource path."
+                                      }
+                                    },
+                                    "required": [
+                                      "file"
+                                    ],
+                                    "additionalProperties": false,
+                                    "title": "Resource",
+                                    "description": "The header data loaded from a file resource."
+                                  }
+                                }
+                              },
+                              {
+                                "type": "object",
+                                "properties": {
+                                  "data": {
+                                    "type": "string",
+                                    "title": "Data",
+                                    "description": "The message header value as inline data."
+                                  }
+                                }
+                              }
+                            ]
+                          }
+                        ],
+                        "title": "Headers",
+                        "description": "The message headers."
+                      }
+                    },
+                    "name": {
+                      "type": "string",
+                      "title": "Name",
+                      "description": "The message name. Named messages may be referenced in subsequent test steps."
+                    },
+                    "parameters": {
+                      "title": "Parameters",
+                      "description": "List of Http query parameters.",
+                      "$comment": "group:advanced",
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "name": {
+                            "type": "string",
+                            "title": "Name",
+                            "description": "Http query parameter name."
+                          },
+                          "value": {
+                            "type": "string",
+                            "title": "Value",
+                            "description": "Http query parameter value."
+                          }
+                        },
+                        "required": [
+                          "name",
+                          "value"
+                        ],
+                        "additionalProperties": false,
+                        "title": "Parameters",
+                        "description": "List of Http query parameters.",
+                        "$comment": "group:advanced"
+                      }
+                    },
+                    "path": {
+                      "type": "string",
+                      "title": "Path",
+                      "description": "Http request path."
+                    },
+                    "schema": {
+                      "type": "string",
+                      "title": "Schema",
+                      "description": "The reference to a schema in the bean registry that should be used for validation.",
+                      "$comment": "group:schema"
+                    },
+                    "schemaRepository": {
+                      "type": "string",
+                      "title": "SchemaRepository",
+                      "description": "The schema repository holding the schema.",
+                      "$comment": "group:schema"
+                    },
+                    "schemaValidation": {
+                      "type": "boolean",
+                      "title": "SchemaValidation",
+                      "description": "Enables the schema validation.",
+                      "$comment": "group:schema"
+                    },
+                    "type": {
+                      "type": "string",
+                      "title": "Type",
+                      "description": "The message type. Gives the validator a hint which validatory are capable of performing proper message validation.",
+                      "$comment": "group:advanced"
+                    },
+                    "version": {
+                      "type": "string",
+                      "title": "Version",
+                      "description": "Http version.",
+                      "$comment": "group:advanced"
+                    }
+                  },
+                  "additionalProperties": false,
+                  "title": "HEAD",
+                  "description": "Http HEAD request"
+                }
+              }
+            },
+            {
+              "type": "object",
+              "properties": {
+                "OPTIONS": {
+                  "type": "object",
+                  "properties": {
+                    "accept": {
+                      "type": "string",
+                      "title": "Accept",
+                      "description": "Http accept header.",
+                      "$comment": "group:advanced"
+                    },
+                    "body": {
+                      "type": "object",
+                      "properties": {
+                        "data": {
+                        },
+                        "resource": {
+                        },
+                        "script": {
+                        }
+                      },
+                      "additionalProperties": false,
+                      "anyOf": [
+                        {
+                          "oneOf": [
+                            {
+                              "type": "object",
+                              "properties": {
+                                "data": {
+                                  "type": "string",
+                                  "title": "Data",
+                                  "description": "The message body content as inline data."
+                                }
+                              }
+                            },
+                            {
+                              "type": "object",
+                              "properties": {
+                                "resource": {
+                                  "type": "object",
+                                  "properties": {
+                                    "charset": {
+                                      "type": "string",
+                                      "title": "Charset",
+                                      "$comment": "group:advanced"
+                                    },
+                                    "file": {
+                                      "type": "string",
+                                      "title": "File"
+                                    }
+                                  },
+                                  "additionalProperties": false,
+                                  "title": "Resource",
+                                  "description": "The message body loaded from a file resource."
+                                }
+                              }
+                            },
+                            {
+                              "type": "object",
+                              "properties": {
+                                "script": {
+                                  "type": "object",
+                                  "properties": {
+                                    "charset": {
+                                      "type": "string",
+                                      "title": "Charset",
+                                      "description": "The charset used to load the file resource.",
+                                      "$comment": "group:advanced"
+                                    },
+                                    "content": {
+                                      "type": "string",
+                                      "title": "Content",
+                                      "description": "The script content as inline data."
+                                    },
+                                    "file": {
+                                      "type": "string",
+                                      "title": "File",
+                                      "description": "The script content loaded as a file resource."
+                                    },
+                                    "type": {
+                                      "type": "string",
+                                      "title": "Type",
+                                      "description": "The script type.",
+                                      "default": "groovy"
+                                    }
+                                  },
+                                  "additionalProperties": false,
+                                  "title": "Script",
+                                  "description": "The message body set via script."
+                                }
+                              }
+                            }
+                          ]
+                        }
+                      ],
+                      "title": "Body",
+                      "description": "The message body."
+                    },
+                    "contentType": {
+                      "type": "string",
+                      "title": "ContentType",
+                      "description": "Http content type."
+                    },
+                    "dataDictionary": {
+                      "type": "string",
+                      "title": "DataDictionary",
+                      "description": "Sets a data dictionary that transforms message content before it is being processed.",
+                      "$comment": "group:dictionary"
+                    },
+                    "expression": {
+                      "title": "Expression",
+                      "description": "List of path expressions to evaluate on the message content before processing the message.",
+                      "$comment": "group:advanced",
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "path": {
+                            "type": "string",
+                            "title": "Path",
+                            "description": "The path expression to evaluate."
+                          },
+                          "value": {
+                            "type": "string",
+                            "title": "Value",
+                            "description": "The expected expression result value."
+                          }
+                        },
+                        "required": [
+                          "path",
+                          "value"
+                        ],
+                        "additionalProperties": false,
+                        "title": "Expression",
+                        "description": "List of path expressions to evaluate on the message content before processing the message.",
+                        "$comment": "group:advanced"
+                      }
+                    },
+                    "headerIgnoreCase": {
+                      "type": "string",
+                      "title": "HeaderIgnoreCase",
+                      "description": "When enabled the header case is not verified.",
+                      "$comment": "group:advanced"
+                    },
+                    "headers": {
+                      "title": "Headers",
+                      "description": "The message headers.",
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "data": {
+                          },
+                          "name": {
+                            "type": "string",
+                            "title": "Name",
+                            "description": "The message header name."
+                          },
+                          "resource": {
+                          },
+                          "type": {
+                            "type": "string",
+                            "title": "Type",
+                            "description": "The message header type to create typed message headers.",
+                            "$comment": "group:advanced"
+                          },
+                          "value": {
+                          }
+                        },
+                        "additionalProperties": false,
+                        "anyOf": [
+                          {
+                            "oneOf": [
+                              {
+                                "type": "object",
+                                "properties": {
+                                  "value": {
+                                    "type": "string",
+                                    "title": "Value",
+                                    "description": "The message header value."
+                                  }
+                                }
+                              },
+                              {
+                                "type": "object",
+                                "properties": {
+                                  "resource": {
+                                    "type": "object",
+                                    "properties": {
+                                      "charset": {
+                                        "type": "string",
+                                        "title": "Charset",
+                                        "description": "Optional file resource charset used to read the file content.",
+                                        "$comment": "group:advanced"
+                                      },
+                                      "file": {
+                                        "type": "string",
+                                        "title": "File",
+                                        "description": "The file resource path."
+                                      }
+                                    },
+                                    "required": [
+                                      "file"
+                                    ],
+                                    "additionalProperties": false,
+                                    "title": "Resource",
+                                    "description": "The header data loaded from a file resource."
+                                  }
+                                }
+                              },
+                              {
+                                "type": "object",
+                                "properties": {
+                                  "data": {
+                                    "type": "string",
+                                    "title": "Data",
+                                    "description": "The message header value as inline data."
+                                  }
+                                }
+                              }
+                            ]
+                          }
+                        ],
+                        "title": "Headers",
+                        "description": "The message headers."
+                      }
+                    },
+                    "name": {
+                      "type": "string",
+                      "title": "Name",
+                      "description": "The message name. Named messages may be referenced in subsequent test steps."
+                    },
+                    "parameters": {
+                      "title": "Parameters",
+                      "description": "List of Http query parameters.",
+                      "$comment": "group:advanced",
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "name": {
+                            "type": "string",
+                            "title": "Name",
+                            "description": "Http query parameter name."
+                          },
+                          "value": {
+                            "type": "string",
+                            "title": "Value",
+                            "description": "Http query parameter value."
+                          }
+                        },
+                        "required": [
+                          "name",
+                          "value"
+                        ],
+                        "additionalProperties": false,
+                        "title": "Parameters",
+                        "description": "List of Http query parameters.",
+                        "$comment": "group:advanced"
+                      }
+                    },
+                    "path": {
+                      "type": "string",
+                      "title": "Path",
+                      "description": "Http request path."
+                    },
+                    "schema": {
+                      "type": "string",
+                      "title": "Schema",
+                      "description": "The reference to a schema in the bean registry that should be used for validation.",
+                      "$comment": "group:schema"
+                    },
+                    "schemaRepository": {
+                      "type": "string",
+                      "title": "SchemaRepository",
+                      "description": "The schema repository holding the schema.",
+                      "$comment": "group:schema"
+                    },
+                    "schemaValidation": {
+                      "type": "boolean",
+                      "title": "SchemaValidation",
+                      "description": "Enables the schema validation.",
+                      "$comment": "group:schema"
+                    },
+                    "type": {
+                      "type": "string",
+                      "title": "Type",
+                      "description": "The message type. Gives the validator a hint which validatory are capable of performing proper message validation.",
+                      "$comment": "group:advanced"
+                    },
+                    "version": {
+                      "type": "string",
+                      "title": "Version",
+                      "description": "Http version.",
+                      "$comment": "group:advanced"
+                    }
+                  },
+                  "additionalProperties": false,
+                  "title": "OPTIONS",
+                  "description": "Http OPTIONS request"
+                }
+              }
+            },
+            {
+              "type": "object",
+              "properties": {
+                "PATCH": {
+                  "type": "object",
+                  "properties": {
+                    "accept": {
+                      "type": "string",
+                      "title": "Accept",
+                      "description": "Http accept header.",
+                      "$comment": "group:advanced"
+                    },
+                    "body": {
+                      "type": "object",
+                      "properties": {
+                        "data": {
+                        },
+                        "resource": {
+                        },
+                        "script": {
+                        }
+                      },
+                      "additionalProperties": false,
+                      "anyOf": [
+                        {
+                          "oneOf": [
+                            {
+                              "type": "object",
+                              "properties": {
+                                "data": {
+                                  "type": "string",
+                                  "title": "Data",
+                                  "description": "The message body content as inline data."
+                                }
+                              }
+                            },
+                            {
+                              "type": "object",
+                              "properties": {
+                                "resource": {
+                                  "type": "object",
+                                  "properties": {
+                                    "charset": {
+                                      "type": "string",
+                                      "title": "Charset",
+                                      "$comment": "group:advanced"
+                                    },
+                                    "file": {
+                                      "type": "string",
+                                      "title": "File"
+                                    }
+                                  },
+                                  "additionalProperties": false,
+                                  "title": "Resource",
+                                  "description": "The message body loaded from a file resource."
+                                }
+                              }
+                            },
+                            {
+                              "type": "object",
+                              "properties": {
+                                "script": {
+                                  "type": "object",
+                                  "properties": {
+                                    "charset": {
+                                      "type": "string",
+                                      "title": "Charset",
+                                      "description": "The charset used to load the file resource.",
+                                      "$comment": "group:advanced"
+                                    },
+                                    "content": {
+                                      "type": "string",
+                                      "title": "Content",
+                                      "description": "The script content as inline data."
+                                    },
+                                    "file": {
+                                      "type": "string",
+                                      "title": "File",
+                                      "description": "The script content loaded as a file resource."
+                                    },
+                                    "type": {
+                                      "type": "string",
+                                      "title": "Type",
+                                      "description": "The script type.",
+                                      "default": "groovy"
+                                    }
+                                  },
+                                  "additionalProperties": false,
+                                  "title": "Script",
+                                  "description": "The message body set via script."
+                                }
+                              }
+                            }
+                          ]
+                        }
+                      ],
+                      "title": "Body",
+                      "description": "The message body."
+                    },
+                    "contentType": {
+                      "type": "string",
+                      "title": "ContentType",
+                      "description": "Http content type."
+                    },
+                    "dataDictionary": {
+                      "type": "string",
+                      "title": "DataDictionary",
+                      "description": "Sets a data dictionary that transforms message content before it is being processed.",
+                      "$comment": "group:dictionary"
+                    },
+                    "expression": {
+                      "title": "Expression",
+                      "description": "List of path expressions to evaluate on the message content before processing the message.",
+                      "$comment": "group:advanced",
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "path": {
+                            "type": "string",
+                            "title": "Path",
+                            "description": "The path expression to evaluate."
+                          },
+                          "value": {
+                            "type": "string",
+                            "title": "Value",
+                            "description": "The expected expression result value."
+                          }
+                        },
+                        "required": [
+                          "path",
+                          "value"
+                        ],
+                        "additionalProperties": false,
+                        "title": "Expression",
+                        "description": "List of path expressions to evaluate on the message content before processing the message.",
+                        "$comment": "group:advanced"
+                      }
+                    },
+                    "headerIgnoreCase": {
+                      "type": "string",
+                      "title": "HeaderIgnoreCase",
+                      "description": "When enabled the header case is not verified.",
+                      "$comment": "group:advanced"
+                    },
+                    "headers": {
+                      "title": "Headers",
+                      "description": "The message headers.",
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "data": {
+                          },
+                          "name": {
+                            "type": "string",
+                            "title": "Name",
+                            "description": "The message header name."
+                          },
+                          "resource": {
+                          },
+                          "type": {
+                            "type": "string",
+                            "title": "Type",
+                            "description": "The message header type to create typed message headers.",
+                            "$comment": "group:advanced"
+                          },
+                          "value": {
+                          }
+                        },
+                        "additionalProperties": false,
+                        "anyOf": [
+                          {
+                            "oneOf": [
+                              {
+                                "type": "object",
+                                "properties": {
+                                  "value": {
+                                    "type": "string",
+                                    "title": "Value",
+                                    "description": "The message header value."
+                                  }
+                                }
+                              },
+                              {
+                                "type": "object",
+                                "properties": {
+                                  "resource": {
+                                    "type": "object",
+                                    "properties": {
+                                      "charset": {
+                                        "type": "string",
+                                        "title": "Charset",
+                                        "description": "Optional file resource charset used to read the file content.",
+                                        "$comment": "group:advanced"
+                                      },
+                                      "file": {
+                                        "type": "string",
+                                        "title": "File",
+                                        "description": "The file resource path."
+                                      }
+                                    },
+                                    "required": [
+                                      "file"
+                                    ],
+                                    "additionalProperties": false,
+                                    "title": "Resource",
+                                    "description": "The header data loaded from a file resource."
+                                  }
+                                }
+                              },
+                              {
+                                "type": "object",
+                                "properties": {
+                                  "data": {
+                                    "type": "string",
+                                    "title": "Data",
+                                    "description": "The message header value as inline data."
+                                  }
+                                }
+                              }
+                            ]
+                          }
+                        ],
+                        "title": "Headers",
+                        "description": "The message headers."
+                      }
+                    },
+                    "name": {
+                      "type": "string",
+                      "title": "Name",
+                      "description": "The message name. Named messages may be referenced in subsequent test steps."
+                    },
+                    "parameters": {
+                      "title": "Parameters",
+                      "description": "List of Http query parameters.",
+                      "$comment": "group:advanced",
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "name": {
+                            "type": "string",
+                            "title": "Name",
+                            "description": "Http query parameter name."
+                          },
+                          "value": {
+                            "type": "string",
+                            "title": "Value",
+                            "description": "Http query parameter value."
+                          }
+                        },
+                        "required": [
+                          "name",
+                          "value"
+                        ],
+                        "additionalProperties": false,
+                        "title": "Parameters",
+                        "description": "List of Http query parameters.",
+                        "$comment": "group:advanced"
+                      }
+                    },
+                    "path": {
+                      "type": "string",
+                      "title": "Path",
+                      "description": "Http request path."
+                    },
+                    "schema": {
+                      "type": "string",
+                      "title": "Schema",
+                      "description": "The reference to a schema in the bean registry that should be used for validation.",
+                      "$comment": "group:schema"
+                    },
+                    "schemaRepository": {
+                      "type": "string",
+                      "title": "SchemaRepository",
+                      "description": "The schema repository holding the schema.",
+                      "$comment": "group:schema"
+                    },
+                    "schemaValidation": {
+                      "type": "boolean",
+                      "title": "SchemaValidation",
+                      "description": "Enables the schema validation.",
+                      "$comment": "group:schema"
+                    },
+                    "type": {
+                      "type": "string",
+                      "title": "Type",
+                      "description": "The message type. Gives the validator a hint which validatory are capable of performing proper message validation.",
+                      "$comment": "group:advanced"
+                    },
+                    "version": {
+                      "type": "string",
+                      "title": "Version",
+                      "description": "Http version.",
+                      "$comment": "group:advanced"
+                    }
+                  },
+                  "additionalProperties": false,
+                  "title": "PATCH",
+                  "description": "Http PATCH request"
+                }
+              }
+            },
+            {
+              "type": "object",
+              "properties": {
+                "TRACE": {
+                  "type": "object",
+                  "properties": {
+                    "accept": {
+                      "type": "string",
+                      "title": "Accept",
+                      "description": "Http accept header.",
+                      "$comment": "group:advanced"
+                    },
+                    "body": {
+                      "type": "object",
+                      "properties": {
+                        "data": {
+                        },
+                        "resource": {
+                        },
+                        "script": {
+                        }
+                      },
+                      "additionalProperties": false,
+                      "anyOf": [
+                        {
+                          "oneOf": [
+                            {
+                              "type": "object",
+                              "properties": {
+                                "data": {
+                                  "type": "string",
+                                  "title": "Data",
+                                  "description": "The message body content as inline data."
+                                }
+                              }
+                            },
+                            {
+                              "type": "object",
+                              "properties": {
+                                "resource": {
+                                  "type": "object",
+                                  "properties": {
+                                    "charset": {
+                                      "type": "string",
+                                      "title": "Charset",
+                                      "$comment": "group:advanced"
+                                    },
+                                    "file": {
+                                      "type": "string",
+                                      "title": "File"
+                                    }
+                                  },
+                                  "additionalProperties": false,
+                                  "title": "Resource",
+                                  "description": "The message body loaded from a file resource."
+                                }
+                              }
+                            },
+                            {
+                              "type": "object",
+                              "properties": {
+                                "script": {
+                                  "type": "object",
+                                  "properties": {
+                                    "charset": {
+                                      "type": "string",
+                                      "title": "Charset",
+                                      "description": "The charset used to load the file resource.",
+                                      "$comment": "group:advanced"
+                                    },
+                                    "content": {
+                                      "type": "string",
+                                      "title": "Content",
+                                      "description": "The script content as inline data."
+                                    },
+                                    "file": {
+                                      "type": "string",
+                                      "title": "File",
+                                      "description": "The script content loaded as a file resource."
+                                    },
+                                    "type": {
+                                      "type": "string",
+                                      "title": "Type",
+                                      "description": "The script type.",
+                                      "default": "groovy"
+                                    }
+                                  },
+                                  "additionalProperties": false,
+                                  "title": "Script",
+                                  "description": "The message body set via script."
+                                }
+                              }
+                            }
+                          ]
+                        }
+                      ],
+                      "title": "Body",
+                      "description": "The message body."
+                    },
+                    "contentType": {
+                      "type": "string",
+                      "title": "ContentType",
+                      "description": "Http content type."
+                    },
+                    "dataDictionary": {
+                      "type": "string",
+                      "title": "DataDictionary",
+                      "description": "Sets a data dictionary that transforms message content before it is being processed.",
+                      "$comment": "group:dictionary"
+                    },
+                    "expression": {
+                      "title": "Expression",
+                      "description": "List of path expressions to evaluate on the message content before processing the message.",
+                      "$comment": "group:advanced",
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "path": {
+                            "type": "string",
+                            "title": "Path",
+                            "description": "The path expression to evaluate."
+                          },
+                          "value": {
+                            "type": "string",
+                            "title": "Value",
+                            "description": "The expected expression result value."
+                          }
+                        },
+                        "required": [
+                          "path",
+                          "value"
+                        ],
+                        "additionalProperties": false,
+                        "title": "Expression",
+                        "description": "List of path expressions to evaluate on the message content before processing the message.",
+                        "$comment": "group:advanced"
+                      }
+                    },
+                    "headerIgnoreCase": {
+                      "type": "string",
+                      "title": "HeaderIgnoreCase",
+                      "description": "When enabled the header case is not verified.",
+                      "$comment": "group:advanced"
+                    },
+                    "headers": {
+                      "title": "Headers",
+                      "description": "The message headers.",
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "data": {
+                          },
+                          "name": {
+                            "type": "string",
+                            "title": "Name",
+                            "description": "The message header name."
+                          },
+                          "resource": {
+                          },
+                          "type": {
+                            "type": "string",
+                            "title": "Type",
+                            "description": "The message header type to create typed message headers.",
+                            "$comment": "group:advanced"
+                          },
+                          "value": {
+                          }
+                        },
+                        "additionalProperties": false,
+                        "anyOf": [
+                          {
+                            "oneOf": [
+                              {
+                                "type": "object",
+                                "properties": {
+                                  "value": {
+                                    "type": "string",
+                                    "title": "Value",
+                                    "description": "The message header value."
+                                  }
+                                }
+                              },
+                              {
+                                "type": "object",
+                                "properties": {
+                                  "resource": {
+                                    "type": "object",
+                                    "properties": {
+                                      "charset": {
+                                        "type": "string",
+                                        "title": "Charset",
+                                        "description": "Optional file resource charset used to read the file content.",
+                                        "$comment": "group:advanced"
+                                      },
+                                      "file": {
+                                        "type": "string",
+                                        "title": "File",
+                                        "description": "The file resource path."
+                                      }
+                                    },
+                                    "required": [
+                                      "file"
+                                    ],
+                                    "additionalProperties": false,
+                                    "title": "Resource",
+                                    "description": "The header data loaded from a file resource."
+                                  }
+                                }
+                              },
+                              {
+                                "type": "object",
+                                "properties": {
+                                  "data": {
+                                    "type": "string",
+                                    "title": "Data",
+                                    "description": "The message header value as inline data."
+                                  }
+                                }
+                              }
+                            ]
+                          }
+                        ],
+                        "title": "Headers",
+                        "description": "The message headers."
+                      }
+                    },
+                    "name": {
+                      "type": "string",
+                      "title": "Name",
+                      "description": "The message name. Named messages may be referenced in subsequent test steps."
+                    },
+                    "parameters": {
+                      "title": "Parameters",
+                      "description": "List of Http query parameters.",
+                      "$comment": "group:advanced",
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "name": {
+                            "type": "string",
+                            "title": "Name",
+                            "description": "Http query parameter name."
+                          },
+                          "value": {
+                            "type": "string",
+                            "title": "Value",
+                            "description": "Http query parameter value."
+                          }
+                        },
+                        "required": [
+                          "name",
+                          "value"
+                        ],
+                        "additionalProperties": false,
+                        "title": "Parameters",
+                        "description": "List of Http query parameters.",
+                        "$comment": "group:advanced"
+                      }
+                    },
+                    "path": {
+                      "type": "string",
+                      "title": "Path",
+                      "description": "Http request path."
+                    },
+                    "schema": {
+                      "type": "string",
+                      "title": "Schema",
+                      "description": "The reference to a schema in the bean registry that should be used for validation.",
+                      "$comment": "group:schema"
+                    },
+                    "schemaRepository": {
+                      "type": "string",
+                      "title": "SchemaRepository",
+                      "description": "The schema repository holding the schema.",
+                      "$comment": "group:schema"
+                    },
+                    "schemaValidation": {
+                      "type": "boolean",
+                      "title": "SchemaValidation",
+                      "description": "Enables the schema validation.",
+                      "$comment": "group:schema"
+                    },
+                    "type": {
+                      "type": "string",
+                      "title": "Type",
+                      "description": "The message type. Gives the validator a hint which validatory are capable of performing proper message validation.",
+                      "$comment": "group:advanced"
+                    },
+                    "version": {
+                      "type": "string",
+                      "title": "Version",
+                      "description": "Http version.",
+                      "$comment": "group:advanced"
+                    }
+                  },
+                  "additionalProperties": false,
+                  "title": "TRACE",
+                  "description": "Http TRACE request"
+                }
+              }
+            }
+          ]
+        }
+      ]
+    }
+  },
+  "http-receiveResponse": {
+    "kind": "testAction",
+    "version": "4.10.1",
+    "name": "http-receiveResponse",
+    "group": "http",
+    "module": "citrus-http",
+    "title": "ReceiveResponse",
+    "description": "Receive an Http response as a client.",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "extract": {
+          "type": "object",
+          "properties": {
+            "body": {
+              "title": "Body",
+              "description": "Extract elements from the message body into test variables.",
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "path": {
+                    "type": "string",
+                    "title": "Path",
+                    "description": "The path expression to evaluate."
+                  },
+                  "resultType": {
+                    "type": "string",
+                    "title": "ResultType",
+                    "description": "The expression result type. By default the path expression evaluate to String values.With this setting you can force another expression result type.",
+                    "$comment": "group:advanced"
+                  },
+                  "variable": {
+                    "type": "string",
+                    "title": "Variable",
+                    "description": "The test variable name."
+                  }
+                },
+                "required": [
+                  "variable"
+                ],
+                "additionalProperties": false,
+                "title": "Body",
+                "description": "Extract elements from the message body into test variables."
+              }
+            },
+            "header": {
+              "title": "Header",
+              "description": "Extract elements from the message header into test variables.",
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "title": "Name",
+                    "description": "The name of the message header."
+                  },
+                  "variable": {
+                    "type": "string",
+                    "title": "Variable",
+                    "description": "The test variable name."
+                  }
+                },
+                "required": [
+                  "name",
+                  "variable"
+                ],
+                "additionalProperties": false,
+                "title": "Header",
+                "description": "Extract elements from the message header into test variables."
+              }
+            }
+          },
+          "additionalProperties": false,
+          "title": "Extract",
+          "description": "Extract message content to test variables.",
+          "$comment": "group:advanced"
+        },
+        "headerValidator": {
+          "type": "string",
+          "title": "HeaderValidator",
+          "description": "Explicit message header validator.",
+          "$comment": "group:advanced"
+        },
+        "headerValidators": {
+          "type": "string",
+          "title": "HeaderValidators",
+          "description": "List of message header validators used to validate the message.",
+          "$comment": "group:advanced"
+        },
+        "response": {
+          "type": "object",
+          "properties": {
+            "body": {
+              "type": "object",
+              "properties": {
+                "data": {
+                },
+                "resource": {
+                },
+                "script": {
+                }
+              },
+              "additionalProperties": false,
+              "anyOf": [
+                {
+                  "oneOf": [
+                    {
+                      "type": "object",
+                      "properties": {
+                        "data": {
+                          "type": "string",
+                          "title": "Data",
+                          "description": "The message body content as inline data."
+                        }
+                      }
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "resource": {
+                          "type": "object",
+                          "properties": {
+                            "charset": {
+                              "type": "string",
+                              "title": "Charset",
+                              "$comment": "group:advanced"
+                            },
+                            "file": {
+                              "type": "string",
+                              "title": "File"
+                            }
+                          },
+                          "additionalProperties": false,
+                          "title": "Resource",
+                          "description": "The message body loaded from a file resource."
+                        }
+                      }
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "script": {
+                          "type": "object",
+                          "properties": {
+                            "charset": {
+                              "type": "string",
+                              "title": "Charset",
+                              "description": "The charset used to load the file resource.",
+                              "$comment": "group:advanced"
+                            },
+                            "content": {
+                              "type": "string",
+                              "title": "Content",
+                              "description": "The script content as inline data."
+                            },
+                            "file": {
+                              "type": "string",
+                              "title": "File",
+                              "description": "The script content loaded as a file resource."
+                            },
+                            "type": {
+                              "type": "string",
+                              "title": "Type",
+                              "description": "The script type.",
+                              "default": "groovy"
+                            }
+                          },
+                          "additionalProperties": false,
+                          "title": "Script",
+                          "description": "The message body set via script."
+                        }
+                      }
+                    }
+                  ]
+                }
+              ],
+              "title": "Body",
+              "description": "The message body."
+            },
+            "contentType": {
+              "type": "string",
+              "title": "ContentType",
+              "description": "Http content type."
+            },
+            "dataDictionary": {
+              "type": "string",
+              "title": "DataDictionary",
+              "description": "Sets a data dictionary that transforms message content before it is being processed.",
+              "$comment": "group:dictionary"
+            },
+            "expression": {
+              "title": "Expression",
+              "description": "List of path expressions to evaluate on the message content before processing the message.",
+              "$comment": "group:advanced",
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "path": {
+                    "type": "string",
+                    "title": "Path",
+                    "description": "The path expression to evaluate."
+                  },
+                  "value": {
+                    "type": "string",
+                    "title": "Value",
+                    "description": "The expected expression result value."
+                  }
+                },
+                "required": [
+                  "path",
+                  "value"
+                ],
+                "additionalProperties": false,
+                "title": "Expression",
+                "description": "List of path expressions to evaluate on the message content before processing the message.",
+                "$comment": "group:advanced"
+              }
+            },
+            "headerIgnoreCase": {
+              "type": "string",
+              "title": "HeaderIgnoreCase",
+              "description": "When enabled the header case is not verified.",
+              "$comment": "group:advanced"
+            },
+            "headers": {
+              "title": "Headers",
+              "description": "The message headers.",
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "data": {
+                  },
+                  "name": {
+                    "type": "string",
+                    "title": "Name",
+                    "description": "The message header name."
+                  },
+                  "resource": {
+                  },
+                  "type": {
+                    "type": "string",
+                    "title": "Type",
+                    "description": "The message header type to create typed message headers.",
+                    "$comment": "group:advanced"
+                  },
+                  "value": {
+                  }
+                },
+                "additionalProperties": false,
+                "anyOf": [
+                  {
+                    "oneOf": [
+                      {
+                        "type": "object",
+                        "properties": {
+                          "value": {
+                            "type": "string",
+                            "title": "Value",
+                            "description": "The message header value."
+                          }
+                        }
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "resource": {
+                            "type": "object",
+                            "properties": {
+                              "charset": {
+                                "type": "string",
+                                "title": "Charset",
+                                "description": "Optional file resource charset used to read the file content.",
+                                "$comment": "group:advanced"
+                              },
+                              "file": {
+                                "type": "string",
+                                "title": "File",
+                                "description": "The file resource path."
+                              }
+                            },
+                            "required": [
+                              "file"
+                            ],
+                            "additionalProperties": false,
+                            "title": "Resource",
+                            "description": "The header data loaded from a file resource."
+                          }
+                        }
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "data": {
+                            "type": "string",
+                            "title": "Data",
+                            "description": "The message header value as inline data."
+                          }
+                        }
+                      }
+                    ]
+                  }
+                ],
+                "title": "Headers",
+                "description": "The message headers."
+              }
+            },
+            "name": {
+              "type": "string",
+              "title": "Name",
+              "description": "The message name. Named messages may be referenced in subsequent test steps."
+            },
+            "reasonPhrase": {
+              "type": "string",
+              "title": "ReasonPhrase",
+              "description": "Http reason phrase.",
+              "$comment": "group:advanced"
+            },
+            "schema": {
+              "type": "string",
+              "title": "Schema",
+              "description": "The reference to a schema in the bean registry that should be used for validation.",
+              "$comment": "group:schema"
+            },
+            "schemaRepository": {
+              "type": "string",
+              "title": "SchemaRepository",
+              "description": "The schema repository holding the schema.",
+              "$comment": "group:schema"
+            },
+            "schemaValidation": {
+              "type": "boolean",
+              "title": "SchemaValidation",
+              "description": "Enables the schema validation.",
+              "$comment": "group:schema"
+            },
+            "status": {
+              "type": "string",
+              "title": "Status",
+              "description": "The Http status code."
+            },
+            "type": {
+              "type": "string",
+              "title": "Type",
+              "description": "The message type. Gives the validator a hint which validatory are capable of performing proper message validation.",
+              "$comment": "group:advanced"
+            },
+            "version": {
+              "type": "string",
+              "title": "Version",
+              "description": "Http version.",
+              "$comment": "group:advanced"
+            }
+          },
+          "additionalProperties": false,
+          "title": "Response",
+          "description": "The expected Http response."
+        },
+        "select": {
+          "type": "string",
+          "title": "Select",
+          "description": "Message selector expression to selectively consume the Http response.",
+          "$comment": "group:advanced"
+        },
+        "selector": {
+          "type": "object",
+          "properties": {
+            "element": {
+              "title": "Element",
+              "description": "List of elements to build the selector expression.",
+              "$comment": "group:advanced",
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "title": "Name",
+                    "description": "Select element key name."
+                  },
+                  "value": {
+                    "type": "string",
+                    "title": "Value",
+                    "description": "Select expression value."
+                  }
+                },
+                "required": [
+                  "name",
+                  "value"
+                ],
+                "additionalProperties": false,
+                "title": "Element",
+                "description": "List of elements to build the selector expression.",
+                "$comment": "group:advanced"
+              }
+            },
+            "value": {
+              "type": "string",
+              "title": "Value",
+              "description": "Selector expression value."
+            }
+          },
+          "additionalProperties": false,
+          "title": "Selector",
+          "description": "Message selector to selectively consume the Http response.",
+          "$comment": "group:advanced"
+        },
+        "timeout": {
+          "type": "integer",
+          "title": "Timeout",
+          "description": "Timeout while waiting for the Http response."
+        },
+        "validate": {
+          "title": "Validate",
+          "description": "Validate expressions.",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "jsonPath": {
+                "title": "JsonPath",
+                "description": "JsonPath validation expression.",
+                "$comment": "group:jsonPath",
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "expression": {
+                      "type": "string",
+                      "title": "Expression",
+                      "description": "The Json path expression to evaluate."
+                    },
+                    "value": {
+                      "type": "string",
+                      "title": "Value",
+                      "description": "The expected result."
+                    }
+                  },
+                  "required": [
+                    "expression",
+                    "value"
+                  ],
+                  "additionalProperties": false,
+                  "title": "JsonPath",
+                  "description": "JsonPath validation expression.",
+                  "$comment": "group:jsonPath"
+                }
+              },
+              "namespace": {
+                "title": "Namespace",
+                "description": "List of expected namespaces.",
+                "$comment": "group:xml",
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "prefix": {
+                      "type": "string",
+                      "title": "Prefix",
+                      "description": "The expected namespace prefix."
+                    },
+                    "value": {
+                      "type": "string",
+                      "title": "Value",
+                      "description": "The expected namespace value."
+                    }
+                  },
+                  "required": [
+                    "prefix",
+                    "value"
+                  ],
+                  "additionalProperties": false,
+                  "title": "Namespace",
+                  "description": "List of expected namespaces.",
+                  "$comment": "group:xml"
+                }
+              },
+              "path": {
+                "type": "string",
+                "title": "Path",
+                "description": "Message validation expression."
+              },
+              "resultType": {
+                "type": "string",
+                "title": "ResultType",
+                "description": "Expected expression result type.",
+                "$comment": "group:advanced"
+              },
+              "script": {
+                "type": "object",
+                "properties": {
+                  "charset": {
+                    "type": "string",
+                    "title": "Charset",
+                    "description": "The charset used to load the file resource.",
+                    "$comment": "group:advanced"
+                  },
+                  "content": {
+                    "type": "string",
+                    "title": "Content",
+                    "description": "The script content as inline data."
+                  },
+                  "file": {
+                    "type": "string",
+                    "title": "File",
+                    "description": "The script content loaded as a file resource."
+                  },
+                  "type": {
+                    "type": "string",
+                    "title": "Type",
+                    "description": "The script type.",
+                    "default": "groovy"
+                  }
+                },
+                "additionalProperties": false,
+                "title": "Script",
+                "description": "Script that builds the expected validate value.",
+                "$comment": "group:script"
+              },
+              "value": {
+                "type": "string",
+                "title": "Value",
+                "description": "Expected message validation expression value."
+              },
+              "xpath": {
+                "title": "Xpath",
+                "description": "Xpath validation expression.",
+                "$comment": "group:xml",
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "expression": {
+                      "type": "string",
+                      "title": "Expression",
+                      "description": "The Xpath expression to evaluate."
+                    },
+                    "resultType": {
+                      "type": "string",
+                      "title": "ResultType",
+                      "description": "The expected result type.",
+                      "$comment": "group:advanced"
+                    },
+                    "value": {
+                      "type": "string",
+                      "title": "Value",
+                      "description": "The expected result."
+                    }
+                  },
+                  "required": [
+                    "expression",
+                    "value"
+                  ],
+                  "additionalProperties": false,
+                  "title": "Xpath",
+                  "description": "Xpath validation expression.",
+                  "$comment": "group:xml"
+                }
+              }
+            },
+            "additionalProperties": false,
+            "title": "Validate",
+            "description": "Validate expressions."
+          }
+        },
+        "validator": {
+          "type": "string",
+          "title": "Validator",
+          "description": "Explicit message validator.",
+          "$comment": "group:advanced"
+        },
+        "validators": {
+          "type": "string",
+          "title": "Validators",
+          "description": "List of message validators used to validate the message.",
+          "$comment": "group:advanced"
+        }
+      },
+      "additionalProperties": false    }
+  },
+  "http-sendRequest": {
+    "kind": "testAction",
+    "version": "4.10.1",
+    "name": "http-sendRequest",
+    "group": "http",
+    "module": "citrus-http",
+    "title": "SendRequest",
+    "description": "Send a Http request as a client.",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "DELETE": {
+        },
+        "GET": {
+        },
+        "HEAD": {
+        },
+        "OPTIONS": {
+        },
+        "PATCH": {
+        },
+        "POST": {
+        },
+        "PUT": {
+        },
+        "TRACE": {
+        },
+        "extract": {
+          "type": "object",
+          "properties": {
+            "body": {
+              "title": "Body",
+              "description": "Extract elements from the message body into test variables.",
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "path": {
+                    "type": "string",
+                    "title": "Path",
+                    "description": "The path expression to evaluate."
+                  },
+                  "resultType": {
+                    "type": "string",
+                    "title": "ResultType",
+                    "description": "The expression result type. By default the path expression evaluate to String values.With this setting you can force another expression result type.",
+                    "$comment": "group:advanced"
+                  },
+                  "variable": {
+                    "type": "string",
+                    "title": "Variable",
+                    "description": "The test variable name."
+                  }
+                },
+                "required": [
+                  "variable"
+                ],
+                "additionalProperties": false,
+                "title": "Body",
+                "description": "Extract elements from the message body into test variables."
+              }
+            },
+            "header": {
+              "title": "Header",
+              "description": "Extract elements from the message header into test variables.",
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "title": "Name",
+                    "description": "The name of the message header."
+                  },
+                  "variable": {
+                    "type": "string",
+                    "title": "Variable",
+                    "description": "The test variable name."
+                  }
+                },
+                "required": [
+                  "name",
+                  "variable"
+                ],
+                "additionalProperties": false,
+                "title": "Header",
+                "description": "Extract elements from the message header into test variables."
+              }
+            }
+          },
+          "additionalProperties": false,
+          "title": "Extract",
+          "description": "Extract message content to test variables.",
+          "$comment": "group:advanced"
+        },
+        "fork": {
+          "type": "boolean",
+          "title": "Fork",
+          "description": "When enabled the send operation does not block while waiting for the response."
+        },
+        "uri": {
+          "type": "string",
+          "title": "Uri",
+          "description": "Http request URI.",
+          "$comment": "group:advanced"
+        }
+      },
+      "additionalProperties": false,
+      "anyOf": [
+        {
+          "oneOf": [
+            {
+              "type": "object",
+              "properties": {
+                "GET": {
+                  "type": "object",
+                  "properties": {
+                    "accept": {
+                      "type": "string",
+                      "title": "Accept",
+                      "description": "Http accept header.",
+                      "$comment": "group:advanced"
+                    },
+                    "body": {
+                      "type": "object",
+                      "properties": {
+                        "data": {
+                        },
+                        "resource": {
+                        },
+                        "script": {
+                        }
+                      },
+                      "additionalProperties": false,
+                      "anyOf": [
+                        {
+                          "oneOf": [
+                            {
+                              "type": "object",
+                              "properties": {
+                                "data": {
+                                  "type": "string",
+                                  "title": "Data",
+                                  "description": "The message body content as inline data."
+                                }
+                              }
+                            },
+                            {
+                              "type": "object",
+                              "properties": {
+                                "resource": {
+                                  "type": "object",
+                                  "properties": {
+                                    "charset": {
+                                      "type": "string",
+                                      "title": "Charset",
+                                      "$comment": "group:advanced"
+                                    },
+                                    "file": {
+                                      "type": "string",
+                                      "title": "File"
+                                    }
+                                  },
+                                  "additionalProperties": false,
+                                  "title": "Resource",
+                                  "description": "The message body loaded from a file resource."
+                                }
+                              }
+                            },
+                            {
+                              "type": "object",
+                              "properties": {
+                                "script": {
+                                  "type": "object",
+                                  "properties": {
+                                    "charset": {
+                                      "type": "string",
+                                      "title": "Charset",
+                                      "description": "The charset used to load the file resource.",
+                                      "$comment": "group:advanced"
+                                    },
+                                    "content": {
+                                      "type": "string",
+                                      "title": "Content",
+                                      "description": "The script content as inline data."
+                                    },
+                                    "file": {
+                                      "type": "string",
+                                      "title": "File",
+                                      "description": "The script content loaded as a file resource."
+                                    },
+                                    "type": {
+                                      "type": "string",
+                                      "title": "Type",
+                                      "description": "The script type.",
+                                      "default": "groovy"
+                                    }
+                                  },
+                                  "additionalProperties": false,
+                                  "title": "Script",
+                                  "description": "The message body set via script."
+                                }
+                              }
+                            }
+                          ]
+                        }
+                      ],
+                      "title": "Body",
+                      "description": "The message body."
+                    },
+                    "contentType": {
+                      "type": "string",
+                      "title": "ContentType",
+                      "description": "Http content type."
+                    },
+                    "dataDictionary": {
+                      "type": "string",
+                      "title": "DataDictionary",
+                      "description": "Sets a data dictionary that transforms message content before it is being processed.",
+                      "$comment": "group:dictionary"
+                    },
+                    "expression": {
+                      "title": "Expression",
+                      "description": "List of path expressions to evaluate on the message content before processing the message.",
+                      "$comment": "group:advanced",
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "path": {
+                            "type": "string",
+                            "title": "Path",
+                            "description": "The path expression to evaluate."
+                          },
+                          "value": {
+                            "type": "string",
+                            "title": "Value",
+                            "description": "The expected expression result value."
+                          }
+                        },
+                        "required": [
+                          "path",
+                          "value"
+                        ],
+                        "additionalProperties": false,
+                        "title": "Expression",
+                        "description": "List of path expressions to evaluate on the message content before processing the message.",
+                        "$comment": "group:advanced"
+                      }
+                    },
+                    "headerIgnoreCase": {
+                      "type": "string",
+                      "title": "HeaderIgnoreCase",
+                      "description": "When enabled the header case is not verified.",
+                      "$comment": "group:advanced"
+                    },
+                    "headers": {
+                      "title": "Headers",
+                      "description": "The message headers.",
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "data": {
+                          },
+                          "name": {
+                            "type": "string",
+                            "title": "Name",
+                            "description": "The message header name."
+                          },
+                          "resource": {
+                          },
+                          "type": {
+                            "type": "string",
+                            "title": "Type",
+                            "description": "The message header type to create typed message headers.",
+                            "$comment": "group:advanced"
+                          },
+                          "value": {
+                          }
+                        },
+                        "additionalProperties": false,
+                        "anyOf": [
+                          {
+                            "oneOf": [
+                              {
+                                "type": "object",
+                                "properties": {
+                                  "value": {
+                                    "type": "string",
+                                    "title": "Value",
+                                    "description": "The message header value."
+                                  }
+                                }
+                              },
+                              {
+                                "type": "object",
+                                "properties": {
+                                  "resource": {
+                                    "type": "object",
+                                    "properties": {
+                                      "charset": {
+                                        "type": "string",
+                                        "title": "Charset",
+                                        "description": "Optional file resource charset used to read the file content.",
+                                        "$comment": "group:advanced"
+                                      },
+                                      "file": {
+                                        "type": "string",
+                                        "title": "File",
+                                        "description": "The file resource path."
+                                      }
+                                    },
+                                    "required": [
+                                      "file"
+                                    ],
+                                    "additionalProperties": false,
+                                    "title": "Resource",
+                                    "description": "The header data loaded from a file resource."
+                                  }
+                                }
+                              },
+                              {
+                                "type": "object",
+                                "properties": {
+                                  "data": {
+                                    "type": "string",
+                                    "title": "Data",
+                                    "description": "The message header value as inline data."
+                                  }
+                                }
+                              }
+                            ]
+                          }
+                        ],
+                        "title": "Headers",
+                        "description": "The message headers."
+                      }
+                    },
+                    "name": {
+                      "type": "string",
+                      "title": "Name",
+                      "description": "The message name. Named messages may be referenced in subsequent test steps."
+                    },
+                    "parameters": {
+                      "title": "Parameters",
+                      "description": "List of Http query parameters.",
+                      "$comment": "group:advanced",
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "name": {
+                            "type": "string",
+                            "title": "Name",
+                            "description": "Http query parameter name."
+                          },
+                          "value": {
+                            "type": "string",
+                            "title": "Value",
+                            "description": "Http query parameter value."
+                          }
+                        },
+                        "required": [
+                          "name",
+                          "value"
+                        ],
+                        "additionalProperties": false,
+                        "title": "Parameters",
+                        "description": "List of Http query parameters.",
+                        "$comment": "group:advanced"
+                      }
+                    },
+                    "path": {
+                      "type": "string",
+                      "title": "Path",
+                      "description": "Http request path."
+                    },
+                    "schema": {
+                      "type": "string",
+                      "title": "Schema",
+                      "description": "The reference to a schema in the bean registry that should be used for validation.",
+                      "$comment": "group:schema"
+                    },
+                    "schemaRepository": {
+                      "type": "string",
+                      "title": "SchemaRepository",
+                      "description": "The schema repository holding the schema.",
+                      "$comment": "group:schema"
+                    },
+                    "schemaValidation": {
+                      "type": "boolean",
+                      "title": "SchemaValidation",
+                      "description": "Enables the schema validation.",
+                      "$comment": "group:schema"
+                    },
+                    "type": {
+                      "type": "string",
+                      "title": "Type",
+                      "description": "The message type. Gives the validator a hint which validatory are capable of performing proper message validation.",
+                      "$comment": "group:advanced"
+                    },
+                    "version": {
+                      "type": "string",
+                      "title": "Version",
+                      "description": "Http version.",
+                      "$comment": "group:advanced"
+                    }
+                  },
+                  "additionalProperties": false,
+                  "title": "GET",
+                  "description": "Http GET request"
+                }
+              }
+            },
+            {
+              "type": "object",
+              "properties": {
+                "POST": {
+                  "type": "object",
+                  "properties": {
+                    "accept": {
+                      "type": "string",
+                      "title": "Accept",
+                      "description": "Http accept header.",
+                      "$comment": "group:advanced"
+                    },
+                    "body": {
+                      "type": "object",
+                      "properties": {
+                        "data": {
+                        },
+                        "resource": {
+                        },
+                        "script": {
+                        }
+                      },
+                      "additionalProperties": false,
+                      "anyOf": [
+                        {
+                          "oneOf": [
+                            {
+                              "type": "object",
+                              "properties": {
+                                "data": {
+                                  "type": "string",
+                                  "title": "Data",
+                                  "description": "The message body content as inline data."
+                                }
+                              }
+                            },
+                            {
+                              "type": "object",
+                              "properties": {
+                                "resource": {
+                                  "type": "object",
+                                  "properties": {
+                                    "charset": {
+                                      "type": "string",
+                                      "title": "Charset",
+                                      "$comment": "group:advanced"
+                                    },
+                                    "file": {
+                                      "type": "string",
+                                      "title": "File"
+                                    }
+                                  },
+                                  "additionalProperties": false,
+                                  "title": "Resource",
+                                  "description": "The message body loaded from a file resource."
+                                }
+                              }
+                            },
+                            {
+                              "type": "object",
+                              "properties": {
+                                "script": {
+                                  "type": "object",
+                                  "properties": {
+                                    "charset": {
+                                      "type": "string",
+                                      "title": "Charset",
+                                      "description": "The charset used to load the file resource.",
+                                      "$comment": "group:advanced"
+                                    },
+                                    "content": {
+                                      "type": "string",
+                                      "title": "Content",
+                                      "description": "The script content as inline data."
+                                    },
+                                    "file": {
+                                      "type": "string",
+                                      "title": "File",
+                                      "description": "The script content loaded as a file resource."
+                                    },
+                                    "type": {
+                                      "type": "string",
+                                      "title": "Type",
+                                      "description": "The script type.",
+                                      "default": "groovy"
+                                    }
+                                  },
+                                  "additionalProperties": false,
+                                  "title": "Script",
+                                  "description": "The message body set via script."
+                                }
+                              }
+                            }
+                          ]
+                        }
+                      ],
+                      "title": "Body",
+                      "description": "The message body."
+                    },
+                    "contentType": {
+                      "type": "string",
+                      "title": "ContentType",
+                      "description": "Http content type."
+                    },
+                    "dataDictionary": {
+                      "type": "string",
+                      "title": "DataDictionary",
+                      "description": "Sets a data dictionary that transforms message content before it is being processed.",
+                      "$comment": "group:dictionary"
+                    },
+                    "expression": {
+                      "title": "Expression",
+                      "description": "List of path expressions to evaluate on the message content before processing the message.",
+                      "$comment": "group:advanced",
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "path": {
+                            "type": "string",
+                            "title": "Path",
+                            "description": "The path expression to evaluate."
+                          },
+                          "value": {
+                            "type": "string",
+                            "title": "Value",
+                            "description": "The expected expression result value."
+                          }
+                        },
+                        "required": [
+                          "path",
+                          "value"
+                        ],
+                        "additionalProperties": false,
+                        "title": "Expression",
+                        "description": "List of path expressions to evaluate on the message content before processing the message.",
+                        "$comment": "group:advanced"
+                      }
+                    },
+                    "headerIgnoreCase": {
+                      "type": "string",
+                      "title": "HeaderIgnoreCase",
+                      "description": "When enabled the header case is not verified.",
+                      "$comment": "group:advanced"
+                    },
+                    "headers": {
+                      "title": "Headers",
+                      "description": "The message headers.",
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "data": {
+                          },
+                          "name": {
+                            "type": "string",
+                            "title": "Name",
+                            "description": "The message header name."
+                          },
+                          "resource": {
+                          },
+                          "type": {
+                            "type": "string",
+                            "title": "Type",
+                            "description": "The message header type to create typed message headers.",
+                            "$comment": "group:advanced"
+                          },
+                          "value": {
+                          }
+                        },
+                        "additionalProperties": false,
+                        "anyOf": [
+                          {
+                            "oneOf": [
+                              {
+                                "type": "object",
+                                "properties": {
+                                  "value": {
+                                    "type": "string",
+                                    "title": "Value",
+                                    "description": "The message header value."
+                                  }
+                                }
+                              },
+                              {
+                                "type": "object",
+                                "properties": {
+                                  "resource": {
+                                    "type": "object",
+                                    "properties": {
+                                      "charset": {
+                                        "type": "string",
+                                        "title": "Charset",
+                                        "description": "Optional file resource charset used to read the file content.",
+                                        "$comment": "group:advanced"
+                                      },
+                                      "file": {
+                                        "type": "string",
+                                        "title": "File",
+                                        "description": "The file resource path."
+                                      }
+                                    },
+                                    "required": [
+                                      "file"
+                                    ],
+                                    "additionalProperties": false,
+                                    "title": "Resource",
+                                    "description": "The header data loaded from a file resource."
+                                  }
+                                }
+                              },
+                              {
+                                "type": "object",
+                                "properties": {
+                                  "data": {
+                                    "type": "string",
+                                    "title": "Data",
+                                    "description": "The message header value as inline data."
+                                  }
+                                }
+                              }
+                            ]
+                          }
+                        ],
+                        "title": "Headers",
+                        "description": "The message headers."
+                      }
+                    },
+                    "name": {
+                      "type": "string",
+                      "title": "Name",
+                      "description": "The message name. Named messages may be referenced in subsequent test steps."
+                    },
+                    "parameters": {
+                      "title": "Parameters",
+                      "description": "List of Http query parameters.",
+                      "$comment": "group:advanced",
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "name": {
+                            "type": "string",
+                            "title": "Name",
+                            "description": "Http query parameter name."
+                          },
+                          "value": {
+                            "type": "string",
+                            "title": "Value",
+                            "description": "Http query parameter value."
+                          }
+                        },
+                        "required": [
+                          "name",
+                          "value"
+                        ],
+                        "additionalProperties": false,
+                        "title": "Parameters",
+                        "description": "List of Http query parameters.",
+                        "$comment": "group:advanced"
+                      }
+                    },
+                    "path": {
+                      "type": "string",
+                      "title": "Path",
+                      "description": "Http request path."
+                    },
+                    "schema": {
+                      "type": "string",
+                      "title": "Schema",
+                      "description": "The reference to a schema in the bean registry that should be used for validation.",
+                      "$comment": "group:schema"
+                    },
+                    "schemaRepository": {
+                      "type": "string",
+                      "title": "SchemaRepository",
+                      "description": "The schema repository holding the schema.",
+                      "$comment": "group:schema"
+                    },
+                    "schemaValidation": {
+                      "type": "boolean",
+                      "title": "SchemaValidation",
+                      "description": "Enables the schema validation.",
+                      "$comment": "group:schema"
+                    },
+                    "type": {
+                      "type": "string",
+                      "title": "Type",
+                      "description": "The message type. Gives the validator a hint which validatory are capable of performing proper message validation.",
+                      "$comment": "group:advanced"
+                    },
+                    "version": {
+                      "type": "string",
+                      "title": "Version",
+                      "description": "Http version.",
+                      "$comment": "group:advanced"
+                    }
+                  },
+                  "additionalProperties": false,
+                  "title": "POST",
+                  "description": "Http POST request"
+                }
+              }
+            },
+            {
+              "type": "object",
+              "properties": {
+                "PUT": {
+                  "type": "object",
+                  "properties": {
+                    "accept": {
+                      "type": "string",
+                      "title": "Accept",
+                      "description": "Http accept header.",
+                      "$comment": "group:advanced"
+                    },
+                    "body": {
+                      "type": "object",
+                      "properties": {
+                        "data": {
+                        },
+                        "resource": {
+                        },
+                        "script": {
+                        }
+                      },
+                      "additionalProperties": false,
+                      "anyOf": [
+                        {
+                          "oneOf": [
+                            {
+                              "type": "object",
+                              "properties": {
+                                "data": {
+                                  "type": "string",
+                                  "title": "Data",
+                                  "description": "The message body content as inline data."
+                                }
+                              }
+                            },
+                            {
+                              "type": "object",
+                              "properties": {
+                                "resource": {
+                                  "type": "object",
+                                  "properties": {
+                                    "charset": {
+                                      "type": "string",
+                                      "title": "Charset",
+                                      "$comment": "group:advanced"
+                                    },
+                                    "file": {
+                                      "type": "string",
+                                      "title": "File"
+                                    }
+                                  },
+                                  "additionalProperties": false,
+                                  "title": "Resource",
+                                  "description": "The message body loaded from a file resource."
+                                }
+                              }
+                            },
+                            {
+                              "type": "object",
+                              "properties": {
+                                "script": {
+                                  "type": "object",
+                                  "properties": {
+                                    "charset": {
+                                      "type": "string",
+                                      "title": "Charset",
+                                      "description": "The charset used to load the file resource.",
+                                      "$comment": "group:advanced"
+                                    },
+                                    "content": {
+                                      "type": "string",
+                                      "title": "Content",
+                                      "description": "The script content as inline data."
+                                    },
+                                    "file": {
+                                      "type": "string",
+                                      "title": "File",
+                                      "description": "The script content loaded as a file resource."
+                                    },
+                                    "type": {
+                                      "type": "string",
+                                      "title": "Type",
+                                      "description": "The script type.",
+                                      "default": "groovy"
+                                    }
+                                  },
+                                  "additionalProperties": false,
+                                  "title": "Script",
+                                  "description": "The message body set via script."
+                                }
+                              }
+                            }
+                          ]
+                        }
+                      ],
+                      "title": "Body",
+                      "description": "The message body."
+                    },
+                    "contentType": {
+                      "type": "string",
+                      "title": "ContentType",
+                      "description": "Http content type."
+                    },
+                    "dataDictionary": {
+                      "type": "string",
+                      "title": "DataDictionary",
+                      "description": "Sets a data dictionary that transforms message content before it is being processed.",
+                      "$comment": "group:dictionary"
+                    },
+                    "expression": {
+                      "title": "Expression",
+                      "description": "List of path expressions to evaluate on the message content before processing the message.",
+                      "$comment": "group:advanced",
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "path": {
+                            "type": "string",
+                            "title": "Path",
+                            "description": "The path expression to evaluate."
+                          },
+                          "value": {
+                            "type": "string",
+                            "title": "Value",
+                            "description": "The expected expression result value."
+                          }
+                        },
+                        "required": [
+                          "path",
+                          "value"
+                        ],
+                        "additionalProperties": false,
+                        "title": "Expression",
+                        "description": "List of path expressions to evaluate on the message content before processing the message.",
+                        "$comment": "group:advanced"
+                      }
+                    },
+                    "headerIgnoreCase": {
+                      "type": "string",
+                      "title": "HeaderIgnoreCase",
+                      "description": "When enabled the header case is not verified.",
+                      "$comment": "group:advanced"
+                    },
+                    "headers": {
+                      "title": "Headers",
+                      "description": "The message headers.",
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "data": {
+                          },
+                          "name": {
+                            "type": "string",
+                            "title": "Name",
+                            "description": "The message header name."
+                          },
+                          "resource": {
+                          },
+                          "type": {
+                            "type": "string",
+                            "title": "Type",
+                            "description": "The message header type to create typed message headers.",
+                            "$comment": "group:advanced"
+                          },
+                          "value": {
+                          }
+                        },
+                        "additionalProperties": false,
+                        "anyOf": [
+                          {
+                            "oneOf": [
+                              {
+                                "type": "object",
+                                "properties": {
+                                  "value": {
+                                    "type": "string",
+                                    "title": "Value",
+                                    "description": "The message header value."
+                                  }
+                                }
+                              },
+                              {
+                                "type": "object",
+                                "properties": {
+                                  "resource": {
+                                    "type": "object",
+                                    "properties": {
+                                      "charset": {
+                                        "type": "string",
+                                        "title": "Charset",
+                                        "description": "Optional file resource charset used to read the file content.",
+                                        "$comment": "group:advanced"
+                                      },
+                                      "file": {
+                                        "type": "string",
+                                        "title": "File",
+                                        "description": "The file resource path."
+                                      }
+                                    },
+                                    "required": [
+                                      "file"
+                                    ],
+                                    "additionalProperties": false,
+                                    "title": "Resource",
+                                    "description": "The header data loaded from a file resource."
+                                  }
+                                }
+                              },
+                              {
+                                "type": "object",
+                                "properties": {
+                                  "data": {
+                                    "type": "string",
+                                    "title": "Data",
+                                    "description": "The message header value as inline data."
+                                  }
+                                }
+                              }
+                            ]
+                          }
+                        ],
+                        "title": "Headers",
+                        "description": "The message headers."
+                      }
+                    },
+                    "name": {
+                      "type": "string",
+                      "title": "Name",
+                      "description": "The message name. Named messages may be referenced in subsequent test steps."
+                    },
+                    "parameters": {
+                      "title": "Parameters",
+                      "description": "List of Http query parameters.",
+                      "$comment": "group:advanced",
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "name": {
+                            "type": "string",
+                            "title": "Name",
+                            "description": "Http query parameter name."
+                          },
+                          "value": {
+                            "type": "string",
+                            "title": "Value",
+                            "description": "Http query parameter value."
+                          }
+                        },
+                        "required": [
+                          "name",
+                          "value"
+                        ],
+                        "additionalProperties": false,
+                        "title": "Parameters",
+                        "description": "List of Http query parameters.",
+                        "$comment": "group:advanced"
+                      }
+                    },
+                    "path": {
+                      "type": "string",
+                      "title": "Path",
+                      "description": "Http request path."
+                    },
+                    "schema": {
+                      "type": "string",
+                      "title": "Schema",
+                      "description": "The reference to a schema in the bean registry that should be used for validation.",
+                      "$comment": "group:schema"
+                    },
+                    "schemaRepository": {
+                      "type": "string",
+                      "title": "SchemaRepository",
+                      "description": "The schema repository holding the schema.",
+                      "$comment": "group:schema"
+                    },
+                    "schemaValidation": {
+                      "type": "boolean",
+                      "title": "SchemaValidation",
+                      "description": "Enables the schema validation.",
+                      "$comment": "group:schema"
+                    },
+                    "type": {
+                      "type": "string",
+                      "title": "Type",
+                      "description": "The message type. Gives the validator a hint which validatory are capable of performing proper message validation.",
+                      "$comment": "group:advanced"
+                    },
+                    "version": {
+                      "type": "string",
+                      "title": "Version",
+                      "description": "Http version.",
+                      "$comment": "group:advanced"
+                    }
+                  },
+                  "additionalProperties": false,
+                  "title": "PUT",
+                  "description": "Http PUT request"
+                }
+              }
+            },
+            {
+              "type": "object",
+              "properties": {
+                "PUT": {
+                }
+              }
+            },
+            {
+              "type": "object",
+              "properties": {
+                "DELETE": {
+                  "type": "object",
+                  "properties": {
+                    "accept": {
+                      "type": "string",
+                      "title": "Accept",
+                      "description": "Http accept header.",
+                      "$comment": "group:advanced"
+                    },
+                    "body": {
+                      "type": "object",
+                      "properties": {
+                        "data": {
+                        },
+                        "resource": {
+                        },
+                        "script": {
+                        }
+                      },
+                      "additionalProperties": false,
+                      "anyOf": [
+                        {
+                          "oneOf": [
+                            {
+                              "type": "object",
+                              "properties": {
+                                "data": {
+                                  "type": "string",
+                                  "title": "Data",
+                                  "description": "The message body content as inline data."
+                                }
+                              }
+                            },
+                            {
+                              "type": "object",
+                              "properties": {
+                                "resource": {
+                                  "type": "object",
+                                  "properties": {
+                                    "charset": {
+                                      "type": "string",
+                                      "title": "Charset",
+                                      "$comment": "group:advanced"
+                                    },
+                                    "file": {
+                                      "type": "string",
+                                      "title": "File"
+                                    }
+                                  },
+                                  "additionalProperties": false,
+                                  "title": "Resource",
+                                  "description": "The message body loaded from a file resource."
+                                }
+                              }
+                            },
+                            {
+                              "type": "object",
+                              "properties": {
+                                "script": {
+                                  "type": "object",
+                                  "properties": {
+                                    "charset": {
+                                      "type": "string",
+                                      "title": "Charset",
+                                      "description": "The charset used to load the file resource.",
+                                      "$comment": "group:advanced"
+                                    },
+                                    "content": {
+                                      "type": "string",
+                                      "title": "Content",
+                                      "description": "The script content as inline data."
+                                    },
+                                    "file": {
+                                      "type": "string",
+                                      "title": "File",
+                                      "description": "The script content loaded as a file resource."
+                                    },
+                                    "type": {
+                                      "type": "string",
+                                      "title": "Type",
+                                      "description": "The script type.",
+                                      "default": "groovy"
+                                    }
+                                  },
+                                  "additionalProperties": false,
+                                  "title": "Script",
+                                  "description": "The message body set via script."
+                                }
+                              }
+                            }
+                          ]
+                        }
+                      ],
+                      "title": "Body",
+                      "description": "The message body."
+                    },
+                    "contentType": {
+                      "type": "string",
+                      "title": "ContentType",
+                      "description": "Http content type."
+                    },
+                    "dataDictionary": {
+                      "type": "string",
+                      "title": "DataDictionary",
+                      "description": "Sets a data dictionary that transforms message content before it is being processed.",
+                      "$comment": "group:dictionary"
+                    },
+                    "expression": {
+                      "title": "Expression",
+                      "description": "List of path expressions to evaluate on the message content before processing the message.",
+                      "$comment": "group:advanced",
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "path": {
+                            "type": "string",
+                            "title": "Path",
+                            "description": "The path expression to evaluate."
+                          },
+                          "value": {
+                            "type": "string",
+                            "title": "Value",
+                            "description": "The expected expression result value."
+                          }
+                        },
+                        "required": [
+                          "path",
+                          "value"
+                        ],
+                        "additionalProperties": false,
+                        "title": "Expression",
+                        "description": "List of path expressions to evaluate on the message content before processing the message.",
+                        "$comment": "group:advanced"
+                      }
+                    },
+                    "headerIgnoreCase": {
+                      "type": "string",
+                      "title": "HeaderIgnoreCase",
+                      "description": "When enabled the header case is not verified.",
+                      "$comment": "group:advanced"
+                    },
+                    "headers": {
+                      "title": "Headers",
+                      "description": "The message headers.",
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "data": {
+                          },
+                          "name": {
+                            "type": "string",
+                            "title": "Name",
+                            "description": "The message header name."
+                          },
+                          "resource": {
+                          },
+                          "type": {
+                            "type": "string",
+                            "title": "Type",
+                            "description": "The message header type to create typed message headers.",
+                            "$comment": "group:advanced"
+                          },
+                          "value": {
+                          }
+                        },
+                        "additionalProperties": false,
+                        "anyOf": [
+                          {
+                            "oneOf": [
+                              {
+                                "type": "object",
+                                "properties": {
+                                  "value": {
+                                    "type": "string",
+                                    "title": "Value",
+                                    "description": "The message header value."
+                                  }
+                                }
+                              },
+                              {
+                                "type": "object",
+                                "properties": {
+                                  "resource": {
+                                    "type": "object",
+                                    "properties": {
+                                      "charset": {
+                                        "type": "string",
+                                        "title": "Charset",
+                                        "description": "Optional file resource charset used to read the file content.",
+                                        "$comment": "group:advanced"
+                                      },
+                                      "file": {
+                                        "type": "string",
+                                        "title": "File",
+                                        "description": "The file resource path."
+                                      }
+                                    },
+                                    "required": [
+                                      "file"
+                                    ],
+                                    "additionalProperties": false,
+                                    "title": "Resource",
+                                    "description": "The header data loaded from a file resource."
+                                  }
+                                }
+                              },
+                              {
+                                "type": "object",
+                                "properties": {
+                                  "data": {
+                                    "type": "string",
+                                    "title": "Data",
+                                    "description": "The message header value as inline data."
+                                  }
+                                }
+                              }
+                            ]
+                          }
+                        ],
+                        "title": "Headers",
+                        "description": "The message headers."
+                      }
+                    },
+                    "name": {
+                      "type": "string",
+                      "title": "Name",
+                      "description": "The message name. Named messages may be referenced in subsequent test steps."
+                    },
+                    "parameters": {
+                      "title": "Parameters",
+                      "description": "List of Http query parameters.",
+                      "$comment": "group:advanced",
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "name": {
+                            "type": "string",
+                            "title": "Name",
+                            "description": "Http query parameter name."
+                          },
+                          "value": {
+                            "type": "string",
+                            "title": "Value",
+                            "description": "Http query parameter value."
+                          }
+                        },
+                        "required": [
+                          "name",
+                          "value"
+                        ],
+                        "additionalProperties": false,
+                        "title": "Parameters",
+                        "description": "List of Http query parameters.",
+                        "$comment": "group:advanced"
+                      }
+                    },
+                    "path": {
+                      "type": "string",
+                      "title": "Path",
+                      "description": "Http request path."
+                    },
+                    "schema": {
+                      "type": "string",
+                      "title": "Schema",
+                      "description": "The reference to a schema in the bean registry that should be used for validation.",
+                      "$comment": "group:schema"
+                    },
+                    "schemaRepository": {
+                      "type": "string",
+                      "title": "SchemaRepository",
+                      "description": "The schema repository holding the schema.",
+                      "$comment": "group:schema"
+                    },
+                    "schemaValidation": {
+                      "type": "boolean",
+                      "title": "SchemaValidation",
+                      "description": "Enables the schema validation.",
+                      "$comment": "group:schema"
+                    },
+                    "type": {
+                      "type": "string",
+                      "title": "Type",
+                      "description": "The message type. Gives the validator a hint which validatory are capable of performing proper message validation.",
+                      "$comment": "group:advanced"
+                    },
+                    "version": {
+                      "type": "string",
+                      "title": "Version",
+                      "description": "Http version.",
+                      "$comment": "group:advanced"
+                    }
+                  },
+                  "additionalProperties": false,
+                  "title": "DELETE",
+                  "description": "Http DELETE request"
+                }
+              }
+            },
+            {
+              "type": "object",
+              "properties": {
+                "HEAD": {
+                  "type": "object",
+                  "properties": {
+                    "accept": {
+                      "type": "string",
+                      "title": "Accept",
+                      "description": "Http accept header.",
+                      "$comment": "group:advanced"
+                    },
+                    "body": {
+                      "type": "object",
+                      "properties": {
+                        "data": {
+                        },
+                        "resource": {
+                        },
+                        "script": {
+                        }
+                      },
+                      "additionalProperties": false,
+                      "anyOf": [
+                        {
+                          "oneOf": [
+                            {
+                              "type": "object",
+                              "properties": {
+                                "data": {
+                                  "type": "string",
+                                  "title": "Data",
+                                  "description": "The message body content as inline data."
+                                }
+                              }
+                            },
+                            {
+                              "type": "object",
+                              "properties": {
+                                "resource": {
+                                  "type": "object",
+                                  "properties": {
+                                    "charset": {
+                                      "type": "string",
+                                      "title": "Charset",
+                                      "$comment": "group:advanced"
+                                    },
+                                    "file": {
+                                      "type": "string",
+                                      "title": "File"
+                                    }
+                                  },
+                                  "additionalProperties": false,
+                                  "title": "Resource",
+                                  "description": "The message body loaded from a file resource."
+                                }
+                              }
+                            },
+                            {
+                              "type": "object",
+                              "properties": {
+                                "script": {
+                                  "type": "object",
+                                  "properties": {
+                                    "charset": {
+                                      "type": "string",
+                                      "title": "Charset",
+                                      "description": "The charset used to load the file resource.",
+                                      "$comment": "group:advanced"
+                                    },
+                                    "content": {
+                                      "type": "string",
+                                      "title": "Content",
+                                      "description": "The script content as inline data."
+                                    },
+                                    "file": {
+                                      "type": "string",
+                                      "title": "File",
+                                      "description": "The script content loaded as a file resource."
+                                    },
+                                    "type": {
+                                      "type": "string",
+                                      "title": "Type",
+                                      "description": "The script type.",
+                                      "default": "groovy"
+                                    }
+                                  },
+                                  "additionalProperties": false,
+                                  "title": "Script",
+                                  "description": "The message body set via script."
+                                }
+                              }
+                            }
+                          ]
+                        }
+                      ],
+                      "title": "Body",
+                      "description": "The message body."
+                    },
+                    "contentType": {
+                      "type": "string",
+                      "title": "ContentType",
+                      "description": "Http content type."
+                    },
+                    "dataDictionary": {
+                      "type": "string",
+                      "title": "DataDictionary",
+                      "description": "Sets a data dictionary that transforms message content before it is being processed.",
+                      "$comment": "group:dictionary"
+                    },
+                    "expression": {
+                      "title": "Expression",
+                      "description": "List of path expressions to evaluate on the message content before processing the message.",
+                      "$comment": "group:advanced",
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "path": {
+                            "type": "string",
+                            "title": "Path",
+                            "description": "The path expression to evaluate."
+                          },
+                          "value": {
+                            "type": "string",
+                            "title": "Value",
+                            "description": "The expected expression result value."
+                          }
+                        },
+                        "required": [
+                          "path",
+                          "value"
+                        ],
+                        "additionalProperties": false,
+                        "title": "Expression",
+                        "description": "List of path expressions to evaluate on the message content before processing the message.",
+                        "$comment": "group:advanced"
+                      }
+                    },
+                    "headerIgnoreCase": {
+                      "type": "string",
+                      "title": "HeaderIgnoreCase",
+                      "description": "When enabled the header case is not verified.",
+                      "$comment": "group:advanced"
+                    },
+                    "headers": {
+                      "title": "Headers",
+                      "description": "The message headers.",
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "data": {
+                          },
+                          "name": {
+                            "type": "string",
+                            "title": "Name",
+                            "description": "The message header name."
+                          },
+                          "resource": {
+                          },
+                          "type": {
+                            "type": "string",
+                            "title": "Type",
+                            "description": "The message header type to create typed message headers.",
+                            "$comment": "group:advanced"
+                          },
+                          "value": {
+                          }
+                        },
+                        "additionalProperties": false,
+                        "anyOf": [
+                          {
+                            "oneOf": [
+                              {
+                                "type": "object",
+                                "properties": {
+                                  "value": {
+                                    "type": "string",
+                                    "title": "Value",
+                                    "description": "The message header value."
+                                  }
+                                }
+                              },
+                              {
+                                "type": "object",
+                                "properties": {
+                                  "resource": {
+                                    "type": "object",
+                                    "properties": {
+                                      "charset": {
+                                        "type": "string",
+                                        "title": "Charset",
+                                        "description": "Optional file resource charset used to read the file content.",
+                                        "$comment": "group:advanced"
+                                      },
+                                      "file": {
+                                        "type": "string",
+                                        "title": "File",
+                                        "description": "The file resource path."
+                                      }
+                                    },
+                                    "required": [
+                                      "file"
+                                    ],
+                                    "additionalProperties": false,
+                                    "title": "Resource",
+                                    "description": "The header data loaded from a file resource."
+                                  }
+                                }
+                              },
+                              {
+                                "type": "object",
+                                "properties": {
+                                  "data": {
+                                    "type": "string",
+                                    "title": "Data",
+                                    "description": "The message header value as inline data."
+                                  }
+                                }
+                              }
+                            ]
+                          }
+                        ],
+                        "title": "Headers",
+                        "description": "The message headers."
+                      }
+                    },
+                    "name": {
+                      "type": "string",
+                      "title": "Name",
+                      "description": "The message name. Named messages may be referenced in subsequent test steps."
+                    },
+                    "parameters": {
+                      "title": "Parameters",
+                      "description": "List of Http query parameters.",
+                      "$comment": "group:advanced",
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "name": {
+                            "type": "string",
+                            "title": "Name",
+                            "description": "Http query parameter name."
+                          },
+                          "value": {
+                            "type": "string",
+                            "title": "Value",
+                            "description": "Http query parameter value."
+                          }
+                        },
+                        "required": [
+                          "name",
+                          "value"
+                        ],
+                        "additionalProperties": false,
+                        "title": "Parameters",
+                        "description": "List of Http query parameters.",
+                        "$comment": "group:advanced"
+                      }
+                    },
+                    "path": {
+                      "type": "string",
+                      "title": "Path",
+                      "description": "Http request path."
+                    },
+                    "schema": {
+                      "type": "string",
+                      "title": "Schema",
+                      "description": "The reference to a schema in the bean registry that should be used for validation.",
+                      "$comment": "group:schema"
+                    },
+                    "schemaRepository": {
+                      "type": "string",
+                      "title": "SchemaRepository",
+                      "description": "The schema repository holding the schema.",
+                      "$comment": "group:schema"
+                    },
+                    "schemaValidation": {
+                      "type": "boolean",
+                      "title": "SchemaValidation",
+                      "description": "Enables the schema validation.",
+                      "$comment": "group:schema"
+                    },
+                    "type": {
+                      "type": "string",
+                      "title": "Type",
+                      "description": "The message type. Gives the validator a hint which validatory are capable of performing proper message validation.",
+                      "$comment": "group:advanced"
+                    },
+                    "version": {
+                      "type": "string",
+                      "title": "Version",
+                      "description": "Http version.",
+                      "$comment": "group:advanced"
+                    }
+                  },
+                  "additionalProperties": false,
+                  "title": "HEAD",
+                  "description": "Http HEAD request"
+                }
+              }
+            },
+            {
+              "type": "object",
+              "properties": {
+                "OPTIONS": {
+                  "type": "object",
+                  "properties": {
+                    "accept": {
+                      "type": "string",
+                      "title": "Accept",
+                      "description": "Http accept header.",
+                      "$comment": "group:advanced"
+                    },
+                    "body": {
+                      "type": "object",
+                      "properties": {
+                        "data": {
+                        },
+                        "resource": {
+                        },
+                        "script": {
+                        }
+                      },
+                      "additionalProperties": false,
+                      "anyOf": [
+                        {
+                          "oneOf": [
+                            {
+                              "type": "object",
+                              "properties": {
+                                "data": {
+                                  "type": "string",
+                                  "title": "Data",
+                                  "description": "The message body content as inline data."
+                                }
+                              }
+                            },
+                            {
+                              "type": "object",
+                              "properties": {
+                                "resource": {
+                                  "type": "object",
+                                  "properties": {
+                                    "charset": {
+                                      "type": "string",
+                                      "title": "Charset",
+                                      "$comment": "group:advanced"
+                                    },
+                                    "file": {
+                                      "type": "string",
+                                      "title": "File"
+                                    }
+                                  },
+                                  "additionalProperties": false,
+                                  "title": "Resource",
+                                  "description": "The message body loaded from a file resource."
+                                }
+                              }
+                            },
+                            {
+                              "type": "object",
+                              "properties": {
+                                "script": {
+                                  "type": "object",
+                                  "properties": {
+                                    "charset": {
+                                      "type": "string",
+                                      "title": "Charset",
+                                      "description": "The charset used to load the file resource.",
+                                      "$comment": "group:advanced"
+                                    },
+                                    "content": {
+                                      "type": "string",
+                                      "title": "Content",
+                                      "description": "The script content as inline data."
+                                    },
+                                    "file": {
+                                      "type": "string",
+                                      "title": "File",
+                                      "description": "The script content loaded as a file resource."
+                                    },
+                                    "type": {
+                                      "type": "string",
+                                      "title": "Type",
+                                      "description": "The script type.",
+                                      "default": "groovy"
+                                    }
+                                  },
+                                  "additionalProperties": false,
+                                  "title": "Script",
+                                  "description": "The message body set via script."
+                                }
+                              }
+                            }
+                          ]
+                        }
+                      ],
+                      "title": "Body",
+                      "description": "The message body."
+                    },
+                    "contentType": {
+                      "type": "string",
+                      "title": "ContentType",
+                      "description": "Http content type."
+                    },
+                    "dataDictionary": {
+                      "type": "string",
+                      "title": "DataDictionary",
+                      "description": "Sets a data dictionary that transforms message content before it is being processed.",
+                      "$comment": "group:dictionary"
+                    },
+                    "expression": {
+                      "title": "Expression",
+                      "description": "List of path expressions to evaluate on the message content before processing the message.",
+                      "$comment": "group:advanced",
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "path": {
+                            "type": "string",
+                            "title": "Path",
+                            "description": "The path expression to evaluate."
+                          },
+                          "value": {
+                            "type": "string",
+                            "title": "Value",
+                            "description": "The expected expression result value."
+                          }
+                        },
+                        "required": [
+                          "path",
+                          "value"
+                        ],
+                        "additionalProperties": false,
+                        "title": "Expression",
+                        "description": "List of path expressions to evaluate on the message content before processing the message.",
+                        "$comment": "group:advanced"
+                      }
+                    },
+                    "headerIgnoreCase": {
+                      "type": "string",
+                      "title": "HeaderIgnoreCase",
+                      "description": "When enabled the header case is not verified.",
+                      "$comment": "group:advanced"
+                    },
+                    "headers": {
+                      "title": "Headers",
+                      "description": "The message headers.",
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "data": {
+                          },
+                          "name": {
+                            "type": "string",
+                            "title": "Name",
+                            "description": "The message header name."
+                          },
+                          "resource": {
+                          },
+                          "type": {
+                            "type": "string",
+                            "title": "Type",
+                            "description": "The message header type to create typed message headers.",
+                            "$comment": "group:advanced"
+                          },
+                          "value": {
+                          }
+                        },
+                        "additionalProperties": false,
+                        "anyOf": [
+                          {
+                            "oneOf": [
+                              {
+                                "type": "object",
+                                "properties": {
+                                  "value": {
+                                    "type": "string",
+                                    "title": "Value",
+                                    "description": "The message header value."
+                                  }
+                                }
+                              },
+                              {
+                                "type": "object",
+                                "properties": {
+                                  "resource": {
+                                    "type": "object",
+                                    "properties": {
+                                      "charset": {
+                                        "type": "string",
+                                        "title": "Charset",
+                                        "description": "Optional file resource charset used to read the file content.",
+                                        "$comment": "group:advanced"
+                                      },
+                                      "file": {
+                                        "type": "string",
+                                        "title": "File",
+                                        "description": "The file resource path."
+                                      }
+                                    },
+                                    "required": [
+                                      "file"
+                                    ],
+                                    "additionalProperties": false,
+                                    "title": "Resource",
+                                    "description": "The header data loaded from a file resource."
+                                  }
+                                }
+                              },
+                              {
+                                "type": "object",
+                                "properties": {
+                                  "data": {
+                                    "type": "string",
+                                    "title": "Data",
+                                    "description": "The message header value as inline data."
+                                  }
+                                }
+                              }
+                            ]
+                          }
+                        ],
+                        "title": "Headers",
+                        "description": "The message headers."
+                      }
+                    },
+                    "name": {
+                      "type": "string",
+                      "title": "Name",
+                      "description": "The message name. Named messages may be referenced in subsequent test steps."
+                    },
+                    "parameters": {
+                      "title": "Parameters",
+                      "description": "List of Http query parameters.",
+                      "$comment": "group:advanced",
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "name": {
+                            "type": "string",
+                            "title": "Name",
+                            "description": "Http query parameter name."
+                          },
+                          "value": {
+                            "type": "string",
+                            "title": "Value",
+                            "description": "Http query parameter value."
+                          }
+                        },
+                        "required": [
+                          "name",
+                          "value"
+                        ],
+                        "additionalProperties": false,
+                        "title": "Parameters",
+                        "description": "List of Http query parameters.",
+                        "$comment": "group:advanced"
+                      }
+                    },
+                    "path": {
+                      "type": "string",
+                      "title": "Path",
+                      "description": "Http request path."
+                    },
+                    "schema": {
+                      "type": "string",
+                      "title": "Schema",
+                      "description": "The reference to a schema in the bean registry that should be used for validation.",
+                      "$comment": "group:schema"
+                    },
+                    "schemaRepository": {
+                      "type": "string",
+                      "title": "SchemaRepository",
+                      "description": "The schema repository holding the schema.",
+                      "$comment": "group:schema"
+                    },
+                    "schemaValidation": {
+                      "type": "boolean",
+                      "title": "SchemaValidation",
+                      "description": "Enables the schema validation.",
+                      "$comment": "group:schema"
+                    },
+                    "type": {
+                      "type": "string",
+                      "title": "Type",
+                      "description": "The message type. Gives the validator a hint which validatory are capable of performing proper message validation.",
+                      "$comment": "group:advanced"
+                    },
+                    "version": {
+                      "type": "string",
+                      "title": "Version",
+                      "description": "Http version.",
+                      "$comment": "group:advanced"
+                    }
+                  },
+                  "additionalProperties": false,
+                  "title": "OPTIONS",
+                  "description": "Http OPTIONS request"
+                }
+              }
+            },
+            {
+              "type": "object",
+              "properties": {
+                "PATCH": {
+                  "type": "object",
+                  "properties": {
+                    "accept": {
+                      "type": "string",
+                      "title": "Accept",
+                      "description": "Http accept header.",
+                      "$comment": "group:advanced"
+                    },
+                    "body": {
+                      "type": "object",
+                      "properties": {
+                        "data": {
+                        },
+                        "resource": {
+                        },
+                        "script": {
+                        }
+                      },
+                      "additionalProperties": false,
+                      "anyOf": [
+                        {
+                          "oneOf": [
+                            {
+                              "type": "object",
+                              "properties": {
+                                "data": {
+                                  "type": "string",
+                                  "title": "Data",
+                                  "description": "The message body content as inline data."
+                                }
+                              }
+                            },
+                            {
+                              "type": "object",
+                              "properties": {
+                                "resource": {
+                                  "type": "object",
+                                  "properties": {
+                                    "charset": {
+                                      "type": "string",
+                                      "title": "Charset",
+                                      "$comment": "group:advanced"
+                                    },
+                                    "file": {
+                                      "type": "string",
+                                      "title": "File"
+                                    }
+                                  },
+                                  "additionalProperties": false,
+                                  "title": "Resource",
+                                  "description": "The message body loaded from a file resource."
+                                }
+                              }
+                            },
+                            {
+                              "type": "object",
+                              "properties": {
+                                "script": {
+                                  "type": "object",
+                                  "properties": {
+                                    "charset": {
+                                      "type": "string",
+                                      "title": "Charset",
+                                      "description": "The charset used to load the file resource.",
+                                      "$comment": "group:advanced"
+                                    },
+                                    "content": {
+                                      "type": "string",
+                                      "title": "Content",
+                                      "description": "The script content as inline data."
+                                    },
+                                    "file": {
+                                      "type": "string",
+                                      "title": "File",
+                                      "description": "The script content loaded as a file resource."
+                                    },
+                                    "type": {
+                                      "type": "string",
+                                      "title": "Type",
+                                      "description": "The script type.",
+                                      "default": "groovy"
+                                    }
+                                  },
+                                  "additionalProperties": false,
+                                  "title": "Script",
+                                  "description": "The message body set via script."
+                                }
+                              }
+                            }
+                          ]
+                        }
+                      ],
+                      "title": "Body",
+                      "description": "The message body."
+                    },
+                    "contentType": {
+                      "type": "string",
+                      "title": "ContentType",
+                      "description": "Http content type."
+                    },
+                    "dataDictionary": {
+                      "type": "string",
+                      "title": "DataDictionary",
+                      "description": "Sets a data dictionary that transforms message content before it is being processed.",
+                      "$comment": "group:dictionary"
+                    },
+                    "expression": {
+                      "title": "Expression",
+                      "description": "List of path expressions to evaluate on the message content before processing the message.",
+                      "$comment": "group:advanced",
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "path": {
+                            "type": "string",
+                            "title": "Path",
+                            "description": "The path expression to evaluate."
+                          },
+                          "value": {
+                            "type": "string",
+                            "title": "Value",
+                            "description": "The expected expression result value."
+                          }
+                        },
+                        "required": [
+                          "path",
+                          "value"
+                        ],
+                        "additionalProperties": false,
+                        "title": "Expression",
+                        "description": "List of path expressions to evaluate on the message content before processing the message.",
+                        "$comment": "group:advanced"
+                      }
+                    },
+                    "headerIgnoreCase": {
+                      "type": "string",
+                      "title": "HeaderIgnoreCase",
+                      "description": "When enabled the header case is not verified.",
+                      "$comment": "group:advanced"
+                    },
+                    "headers": {
+                      "title": "Headers",
+                      "description": "The message headers.",
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "data": {
+                          },
+                          "name": {
+                            "type": "string",
+                            "title": "Name",
+                            "description": "The message header name."
+                          },
+                          "resource": {
+                          },
+                          "type": {
+                            "type": "string",
+                            "title": "Type",
+                            "description": "The message header type to create typed message headers.",
+                            "$comment": "group:advanced"
+                          },
+                          "value": {
+                          }
+                        },
+                        "additionalProperties": false,
+                        "anyOf": [
+                          {
+                            "oneOf": [
+                              {
+                                "type": "object",
+                                "properties": {
+                                  "value": {
+                                    "type": "string",
+                                    "title": "Value",
+                                    "description": "The message header value."
+                                  }
+                                }
+                              },
+                              {
+                                "type": "object",
+                                "properties": {
+                                  "resource": {
+                                    "type": "object",
+                                    "properties": {
+                                      "charset": {
+                                        "type": "string",
+                                        "title": "Charset",
+                                        "description": "Optional file resource charset used to read the file content.",
+                                        "$comment": "group:advanced"
+                                      },
+                                      "file": {
+                                        "type": "string",
+                                        "title": "File",
+                                        "description": "The file resource path."
+                                      }
+                                    },
+                                    "required": [
+                                      "file"
+                                    ],
+                                    "additionalProperties": false,
+                                    "title": "Resource",
+                                    "description": "The header data loaded from a file resource."
+                                  }
+                                }
+                              },
+                              {
+                                "type": "object",
+                                "properties": {
+                                  "data": {
+                                    "type": "string",
+                                    "title": "Data",
+                                    "description": "The message header value as inline data."
+                                  }
+                                }
+                              }
+                            ]
+                          }
+                        ],
+                        "title": "Headers",
+                        "description": "The message headers."
+                      }
+                    },
+                    "name": {
+                      "type": "string",
+                      "title": "Name",
+                      "description": "The message name. Named messages may be referenced in subsequent test steps."
+                    },
+                    "parameters": {
+                      "title": "Parameters",
+                      "description": "List of Http query parameters.",
+                      "$comment": "group:advanced",
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "name": {
+                            "type": "string",
+                            "title": "Name",
+                            "description": "Http query parameter name."
+                          },
+                          "value": {
+                            "type": "string",
+                            "title": "Value",
+                            "description": "Http query parameter value."
+                          }
+                        },
+                        "required": [
+                          "name",
+                          "value"
+                        ],
+                        "additionalProperties": false,
+                        "title": "Parameters",
+                        "description": "List of Http query parameters.",
+                        "$comment": "group:advanced"
+                      }
+                    },
+                    "path": {
+                      "type": "string",
+                      "title": "Path",
+                      "description": "Http request path."
+                    },
+                    "schema": {
+                      "type": "string",
+                      "title": "Schema",
+                      "description": "The reference to a schema in the bean registry that should be used for validation.",
+                      "$comment": "group:schema"
+                    },
+                    "schemaRepository": {
+                      "type": "string",
+                      "title": "SchemaRepository",
+                      "description": "The schema repository holding the schema.",
+                      "$comment": "group:schema"
+                    },
+                    "schemaValidation": {
+                      "type": "boolean",
+                      "title": "SchemaValidation",
+                      "description": "Enables the schema validation.",
+                      "$comment": "group:schema"
+                    },
+                    "type": {
+                      "type": "string",
+                      "title": "Type",
+                      "description": "The message type. Gives the validator a hint which validatory are capable of performing proper message validation.",
+                      "$comment": "group:advanced"
+                    },
+                    "version": {
+                      "type": "string",
+                      "title": "Version",
+                      "description": "Http version.",
+                      "$comment": "group:advanced"
+                    }
+                  },
+                  "additionalProperties": false,
+                  "title": "PATCH",
+                  "description": "Http PATCH request"
+                }
+              }
+            },
+            {
+              "type": "object",
+              "properties": {
+                "TRACE": {
+                  "type": "object",
+                  "properties": {
+                    "accept": {
+                      "type": "string",
+                      "title": "Accept",
+                      "description": "Http accept header.",
+                      "$comment": "group:advanced"
+                    },
+                    "body": {
+                      "type": "object",
+                      "properties": {
+                        "data": {
+                        },
+                        "resource": {
+                        },
+                        "script": {
+                        }
+                      },
+                      "additionalProperties": false,
+                      "anyOf": [
+                        {
+                          "oneOf": [
+                            {
+                              "type": "object",
+                              "properties": {
+                                "data": {
+                                  "type": "string",
+                                  "title": "Data",
+                                  "description": "The message body content as inline data."
+                                }
+                              }
+                            },
+                            {
+                              "type": "object",
+                              "properties": {
+                                "resource": {
+                                  "type": "object",
+                                  "properties": {
+                                    "charset": {
+                                      "type": "string",
+                                      "title": "Charset",
+                                      "$comment": "group:advanced"
+                                    },
+                                    "file": {
+                                      "type": "string",
+                                      "title": "File"
+                                    }
+                                  },
+                                  "additionalProperties": false,
+                                  "title": "Resource",
+                                  "description": "The message body loaded from a file resource."
+                                }
+                              }
+                            },
+                            {
+                              "type": "object",
+                              "properties": {
+                                "script": {
+                                  "type": "object",
+                                  "properties": {
+                                    "charset": {
+                                      "type": "string",
+                                      "title": "Charset",
+                                      "description": "The charset used to load the file resource.",
+                                      "$comment": "group:advanced"
+                                    },
+                                    "content": {
+                                      "type": "string",
+                                      "title": "Content",
+                                      "description": "The script content as inline data."
+                                    },
+                                    "file": {
+                                      "type": "string",
+                                      "title": "File",
+                                      "description": "The script content loaded as a file resource."
+                                    },
+                                    "type": {
+                                      "type": "string",
+                                      "title": "Type",
+                                      "description": "The script type.",
+                                      "default": "groovy"
+                                    }
+                                  },
+                                  "additionalProperties": false,
+                                  "title": "Script",
+                                  "description": "The message body set via script."
+                                }
+                              }
+                            }
+                          ]
+                        }
+                      ],
+                      "title": "Body",
+                      "description": "The message body."
+                    },
+                    "contentType": {
+                      "type": "string",
+                      "title": "ContentType",
+                      "description": "Http content type."
+                    },
+                    "dataDictionary": {
+                      "type": "string",
+                      "title": "DataDictionary",
+                      "description": "Sets a data dictionary that transforms message content before it is being processed.",
+                      "$comment": "group:dictionary"
+                    },
+                    "expression": {
+                      "title": "Expression",
+                      "description": "List of path expressions to evaluate on the message content before processing the message.",
+                      "$comment": "group:advanced",
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "path": {
+                            "type": "string",
+                            "title": "Path",
+                            "description": "The path expression to evaluate."
+                          },
+                          "value": {
+                            "type": "string",
+                            "title": "Value",
+                            "description": "The expected expression result value."
+                          }
+                        },
+                        "required": [
+                          "path",
+                          "value"
+                        ],
+                        "additionalProperties": false,
+                        "title": "Expression",
+                        "description": "List of path expressions to evaluate on the message content before processing the message.",
+                        "$comment": "group:advanced"
+                      }
+                    },
+                    "headerIgnoreCase": {
+                      "type": "string",
+                      "title": "HeaderIgnoreCase",
+                      "description": "When enabled the header case is not verified.",
+                      "$comment": "group:advanced"
+                    },
+                    "headers": {
+                      "title": "Headers",
+                      "description": "The message headers.",
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "data": {
+                          },
+                          "name": {
+                            "type": "string",
+                            "title": "Name",
+                            "description": "The message header name."
+                          },
+                          "resource": {
+                          },
+                          "type": {
+                            "type": "string",
+                            "title": "Type",
+                            "description": "The message header type to create typed message headers.",
+                            "$comment": "group:advanced"
+                          },
+                          "value": {
+                          }
+                        },
+                        "additionalProperties": false,
+                        "anyOf": [
+                          {
+                            "oneOf": [
+                              {
+                                "type": "object",
+                                "properties": {
+                                  "value": {
+                                    "type": "string",
+                                    "title": "Value",
+                                    "description": "The message header value."
+                                  }
+                                }
+                              },
+                              {
+                                "type": "object",
+                                "properties": {
+                                  "resource": {
+                                    "type": "object",
+                                    "properties": {
+                                      "charset": {
+                                        "type": "string",
+                                        "title": "Charset",
+                                        "description": "Optional file resource charset used to read the file content.",
+                                        "$comment": "group:advanced"
+                                      },
+                                      "file": {
+                                        "type": "string",
+                                        "title": "File",
+                                        "description": "The file resource path."
+                                      }
+                                    },
+                                    "required": [
+                                      "file"
+                                    ],
+                                    "additionalProperties": false,
+                                    "title": "Resource",
+                                    "description": "The header data loaded from a file resource."
+                                  }
+                                }
+                              },
+                              {
+                                "type": "object",
+                                "properties": {
+                                  "data": {
+                                    "type": "string",
+                                    "title": "Data",
+                                    "description": "The message header value as inline data."
+                                  }
+                                }
+                              }
+                            ]
+                          }
+                        ],
+                        "title": "Headers",
+                        "description": "The message headers."
+                      }
+                    },
+                    "name": {
+                      "type": "string",
+                      "title": "Name",
+                      "description": "The message name. Named messages may be referenced in subsequent test steps."
+                    },
+                    "parameters": {
+                      "title": "Parameters",
+                      "description": "List of Http query parameters.",
+                      "$comment": "group:advanced",
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "name": {
+                            "type": "string",
+                            "title": "Name",
+                            "description": "Http query parameter name."
+                          },
+                          "value": {
+                            "type": "string",
+                            "title": "Value",
+                            "description": "Http query parameter value."
+                          }
+                        },
+                        "required": [
+                          "name",
+                          "value"
+                        ],
+                        "additionalProperties": false,
+                        "title": "Parameters",
+                        "description": "List of Http query parameters.",
+                        "$comment": "group:advanced"
+                      }
+                    },
+                    "path": {
+                      "type": "string",
+                      "title": "Path",
+                      "description": "Http request path."
+                    },
+                    "schema": {
+                      "type": "string",
+                      "title": "Schema",
+                      "description": "The reference to a schema in the bean registry that should be used for validation.",
+                      "$comment": "group:schema"
+                    },
+                    "schemaRepository": {
+                      "type": "string",
+                      "title": "SchemaRepository",
+                      "description": "The schema repository holding the schema.",
+                      "$comment": "group:schema"
+                    },
+                    "schemaValidation": {
+                      "type": "boolean",
+                      "title": "SchemaValidation",
+                      "description": "Enables the schema validation.",
+                      "$comment": "group:schema"
+                    },
+                    "type": {
+                      "type": "string",
+                      "title": "Type",
+                      "description": "The message type. Gives the validator a hint which validatory are capable of performing proper message validation.",
+                      "$comment": "group:advanced"
+                    },
+                    "version": {
+                      "type": "string",
+                      "title": "Version",
+                      "description": "Http version.",
+                      "$comment": "group:advanced"
+                    }
+                  },
+                  "additionalProperties": false,
+                  "title": "TRACE",
+                  "description": "Http TRACE request"
+                }
+              }
+            }
+          ]
+        }
+      ]
+    }
+  },
+  "http-sendResponse": {
+    "kind": "testAction",
+    "version": "4.10.1",
+    "name": "http-sendResponse",
+    "group": "http",
+    "module": "citrus-http",
+    "title": "SendResponse",
+    "description": "Send an Http response as a server.",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "extract": {
+          "type": "object",
+          "properties": {
+            "body": {
+              "title": "Body",
+              "description": "Extract elements from the message body into test variables.",
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "path": {
+                    "type": "string",
+                    "title": "Path",
+                    "description": "The path expression to evaluate."
+                  },
+                  "resultType": {
+                    "type": "string",
+                    "title": "ResultType",
+                    "description": "The expression result type. By default the path expression evaluate to String values.With this setting you can force another expression result type.",
+                    "$comment": "group:advanced"
+                  },
+                  "variable": {
+                    "type": "string",
+                    "title": "Variable",
+                    "description": "The test variable name."
+                  }
+                },
+                "required": [
+                  "variable"
+                ],
+                "additionalProperties": false,
+                "title": "Body",
+                "description": "Extract elements from the message body into test variables."
+              }
+            },
+            "header": {
+              "title": "Header",
+              "description": "Extract elements from the message header into test variables.",
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "title": "Name",
+                    "description": "The name of the message header."
+                  },
+                  "variable": {
+                    "type": "string",
+                    "title": "Variable",
+                    "description": "The test variable name."
+                  }
+                },
+                "required": [
+                  "name",
+                  "variable"
+                ],
+                "additionalProperties": false,
+                "title": "Header",
+                "description": "Extract elements from the message header into test variables."
+              }
+            }
+          },
+          "additionalProperties": false,
+          "title": "Extract",
+          "description": "Extract message content to test variables.",
+          "$comment": "group:advanced"
+        },
+        "response": {
+          "type": "object",
+          "properties": {
+            "body": {
+              "type": "object",
+              "properties": {
+                "data": {
+                },
+                "resource": {
+                },
+                "script": {
+                }
+              },
+              "additionalProperties": false,
+              "anyOf": [
+                {
+                  "oneOf": [
+                    {
+                      "type": "object",
+                      "properties": {
+                        "data": {
+                          "type": "string",
+                          "title": "Data",
+                          "description": "The message body content as inline data."
+                        }
+                      }
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "resource": {
+                          "type": "object",
+                          "properties": {
+                            "charset": {
+                              "type": "string",
+                              "title": "Charset",
+                              "$comment": "group:advanced"
+                            },
+                            "file": {
+                              "type": "string",
+                              "title": "File"
+                            }
+                          },
+                          "additionalProperties": false,
+                          "title": "Resource",
+                          "description": "The message body loaded from a file resource."
+                        }
+                      }
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "script": {
+                          "type": "object",
+                          "properties": {
+                            "charset": {
+                              "type": "string",
+                              "title": "Charset",
+                              "description": "The charset used to load the file resource.",
+                              "$comment": "group:advanced"
+                            },
+                            "content": {
+                              "type": "string",
+                              "title": "Content",
+                              "description": "The script content as inline data."
+                            },
+                            "file": {
+                              "type": "string",
+                              "title": "File",
+                              "description": "The script content loaded as a file resource."
+                            },
+                            "type": {
+                              "type": "string",
+                              "title": "Type",
+                              "description": "The script type.",
+                              "default": "groovy"
+                            }
+                          },
+                          "additionalProperties": false,
+                          "title": "Script",
+                          "description": "The message body set via script."
+                        }
+                      }
+                    }
+                  ]
+                }
+              ],
+              "title": "Body",
+              "description": "The message body."
+            },
+            "contentType": {
+              "type": "string",
+              "title": "ContentType",
+              "description": "Http content type."
+            },
+            "dataDictionary": {
+              "type": "string",
+              "title": "DataDictionary",
+              "description": "Sets a data dictionary that transforms message content before it is being processed.",
+              "$comment": "group:dictionary"
+            },
+            "expression": {
+              "title": "Expression",
+              "description": "List of path expressions to evaluate on the message content before processing the message.",
+              "$comment": "group:advanced",
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "path": {
+                    "type": "string",
+                    "title": "Path",
+                    "description": "The path expression to evaluate."
+                  },
+                  "value": {
+                    "type": "string",
+                    "title": "Value",
+                    "description": "The expected expression result value."
+                  }
+                },
+                "required": [
+                  "path",
+                  "value"
+                ],
+                "additionalProperties": false,
+                "title": "Expression",
+                "description": "List of path expressions to evaluate on the message content before processing the message.",
+                "$comment": "group:advanced"
+              }
+            },
+            "headerIgnoreCase": {
+              "type": "string",
+              "title": "HeaderIgnoreCase",
+              "description": "When enabled the header case is not verified.",
+              "$comment": "group:advanced"
+            },
+            "headers": {
+              "title": "Headers",
+              "description": "The message headers.",
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "data": {
+                  },
+                  "name": {
+                    "type": "string",
+                    "title": "Name",
+                    "description": "The message header name."
+                  },
+                  "resource": {
+                  },
+                  "type": {
+                    "type": "string",
+                    "title": "Type",
+                    "description": "The message header type to create typed message headers.",
+                    "$comment": "group:advanced"
+                  },
+                  "value": {
+                  }
+                },
+                "additionalProperties": false,
+                "anyOf": [
+                  {
+                    "oneOf": [
+                      {
+                        "type": "object",
+                        "properties": {
+                          "value": {
+                            "type": "string",
+                            "title": "Value",
+                            "description": "The message header value."
+                          }
+                        }
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "resource": {
+                            "type": "object",
+                            "properties": {
+                              "charset": {
+                                "type": "string",
+                                "title": "Charset",
+                                "description": "Optional file resource charset used to read the file content.",
+                                "$comment": "group:advanced"
+                              },
+                              "file": {
+                                "type": "string",
+                                "title": "File",
+                                "description": "The file resource path."
+                              }
+                            },
+                            "required": [
+                              "file"
+                            ],
+                            "additionalProperties": false,
+                            "title": "Resource",
+                            "description": "The header data loaded from a file resource."
+                          }
+                        }
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "data": {
+                            "type": "string",
+                            "title": "Data",
+                            "description": "The message header value as inline data."
+                          }
+                        }
+                      }
+                    ]
+                  }
+                ],
+                "title": "Headers",
+                "description": "The message headers."
+              }
+            },
+            "name": {
+              "type": "string",
+              "title": "Name",
+              "description": "The message name. Named messages may be referenced in subsequent test steps."
+            },
+            "reasonPhrase": {
+              "type": "string",
+              "title": "ReasonPhrase",
+              "description": "Http reason phrase.",
+              "$comment": "group:advanced"
+            },
+            "schema": {
+              "type": "string",
+              "title": "Schema",
+              "description": "The reference to a schema in the bean registry that should be used for validation.",
+              "$comment": "group:schema"
+            },
+            "schemaRepository": {
+              "type": "string",
+              "title": "SchemaRepository",
+              "description": "The schema repository holding the schema.",
+              "$comment": "group:schema"
+            },
+            "schemaValidation": {
+              "type": "boolean",
+              "title": "SchemaValidation",
+              "description": "Enables the schema validation.",
+              "$comment": "group:schema"
+            },
+            "status": {
+              "type": "string",
+              "title": "Status",
+              "description": "The Http status code."
+            },
+            "type": {
+              "type": "string",
+              "title": "Type",
+              "description": "The message type. Gives the validator a hint which validatory are capable of performing proper message validation.",
+              "$comment": "group:advanced"
+            },
+            "version": {
+              "type": "string",
+              "title": "Version",
+              "description": "Http version.",
+              "$comment": "group:advanced"
+            }
+          },
+          "additionalProperties": false,
+          "title": "Response",
+          "description": "Http response message."
+        }
+      },
+      "additionalProperties": false    }
+  },
+  "jbang": {
+    "kind": "testAction",
+    "version": "4.10.1",
+    "name": "jbang",
+    "module": "citrus-jbang-connector",
+    "title": "Jbang",
+    "description": "JBang test actions.",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "app": {
+          "type": "string",
+          "title": "App"
+        },
+        "args": {
+          "title": "Args",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string",
+                "title": "Name"
+              },
+              "value": {
+                "type": "string",
+                "title": "Value"
+              }
+            },
+            "required": [
+              "name",
+              "value"
+            ],
+            "additionalProperties": false,
+            "title": "Args"
+          }
+        },
+        "command": {
+          "type": "string",
+          "title": "Command"
+        },
+        "description": {
+          "type": "string",
+          "title": "Description",
+          "description": "Test action description printed when the action is executed.",
+          "$comment": "group:advanced"
+        },
+        "exitCode": {
+          "type": "string",
+          "title": "ExitCode"
+        },
+        "file": {
+          "type": "string",
+          "title": "File"
+        },
+        "output": {
+          "type": "string",
+          "title": "Output"
+        },
+        "printOutput": {
+          "type": "boolean",
+          "title": "PrintOutput"
+        },
+        "saveOutput": {
+          "type": "string",
+          "title": "SaveOutput"
+        },
+        "savePid": {
+          "type": "string",
+          "title": "SavePid"
+        },
+        "systemProperties": {
+          "title": "SystemProperties",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string",
+                "title": "Name"
+              },
+              "value": {
+                "type": "string",
+                "title": "Value"
+              }
+            },
+            "required": [
+              "name",
+              "value"
+            ],
+            "additionalProperties": false,
+            "title": "SystemProperties"
+          }
+        }
+      },
+      "additionalProperties": false    }
+  },
+  "knative": {
+    "kind": "testActionGroup",
+    "version": "4.10.1",
+    "name": "knative",
+    "module": "citrus-knative",
+    "title": "Knative",
+    "description": "Knative test actions.",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "actor": {
+          "type": "string",
+          "title": "Actor",
+          "$comment": "group:advanced"
+        },
+        "autoRemove": {
+          "type": "boolean",
+          "title": "AutoRemove"
+        },
+        "client": {
+          "type": "string",
+          "title": "Client"
+        },
+        "clusterType": {
+          "type": "string",
+          "enum": [
+            "LOCAL",
+            "KUBERNETES",
+            "OPENSHIFT"
+          ],
+          "title": "ClusterType"
+        },
+        "description": {
+          "type": "string",
+          "title": "Description",
+          "description": "Test action description printed when the action is executed.",
+          "$comment": "group:advanced"
+        },
+        "kubernetesClient": {
+          "type": "string",
+          "title": "KubernetesClient"
+        },
+        "namespace": {
+          "type": "string",
+          "title": "Namespace"
+        }
+      },
+      "additionalProperties": false    }
+  },
+  "knative-createBroker": {
+    "kind": "testAction",
+    "version": "4.10.1",
+    "name": "knative-createBroker",
+    "group": "knative",
+    "module": "citrus-knative",
+    "title": "CreateBroker",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "title": "Name"
+        }
+      },
+      "additionalProperties": false    }
+  },
+  "knative-createChannel": {
+    "kind": "testAction",
+    "version": "4.10.1",
+    "name": "knative-createChannel",
+    "group": "knative",
+    "module": "citrus-knative",
+    "title": "CreateChannel",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "title": "Name"
+        }
+      },
+      "additionalProperties": false    }
+  },
+  "knative-createSubscription": {
+    "kind": "testAction",
+    "version": "4.10.1",
+    "name": "knative-createSubscription",
+    "group": "knative",
+    "module": "citrus-knative",
+    "title": "CreateSubscription",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "channel": {
+          "type": "string",
+          "title": "Channel"
+        },
+        "name": {
+          "type": "string",
+          "title": "Name"
+        },
+        "service": {
+          "type": "string",
+          "title": "Service"
+        }
+      },
+      "additionalProperties": false    }
+  },
+  "knative-createTrigger": {
+    "kind": "testAction",
+    "version": "4.10.1",
+    "name": "knative-createTrigger",
+    "group": "knative",
+    "module": "citrus-knative",
+    "title": "CreateTrigger",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "broker": {
+          "type": "string",
+          "title": "Broker"
+        },
+        "channel": {
+          "type": "string",
+          "title": "Channel"
+        },
+        "filter": {
+          "type": "object",
+          "properties": {
+            "attributes": {
+              "title": "Attributes",
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "title": "Name"
+                  },
+                  "value": {
+                    "type": "string",
+                    "title": "Value"
+                  }
+                },
+                "additionalProperties": false,
+                "title": "Attributes"
+              }
+            }
+          },
+          "additionalProperties": false,
+          "title": "Filter"
+        },
+        "name": {
+          "type": "string",
+          "title": "Name"
+        },
+        "service": {
+          "type": "string",
+          "title": "Service"
+        }
+      },
+      "additionalProperties": false    }
+  },
+  "knative-deleteBroker": {
+    "kind": "testAction",
+    "version": "4.10.1",
+    "name": "knative-deleteBroker",
+    "group": "knative",
+    "module": "citrus-knative",
+    "title": "DeleteBroker",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "title": "Name"
+        }
+      },
+      "additionalProperties": false    }
+  },
+  "knative-deleteChannel": {
+    "kind": "testAction",
+    "version": "4.10.1",
+    "name": "knative-deleteChannel",
+    "group": "knative",
+    "module": "citrus-knative",
+    "title": "DeleteChannel",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "title": "Name"
+        }
+      },
+      "additionalProperties": false    }
+  },
+  "knative-deleteResource": {
+    "kind": "testAction",
+    "version": "4.10.1",
+    "name": "knative-deleteResource",
+    "group": "knative",
+    "module": "citrus-knative",
+    "title": "DeleteResource",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "component": {
+          "type": "string",
+          "title": "Component"
+        },
+        "kind": {
+          "type": "string",
+          "title": "Kind"
+        },
+        "name": {
+          "type": "string",
+          "title": "Name"
+        }
+      },
+      "additionalProperties": false    }
+  },
+  "knative-deleteSubscription": {
+    "kind": "testAction",
+    "version": "4.10.1",
+    "name": "knative-deleteSubscription",
+    "group": "knative",
+    "module": "citrus-knative",
+    "title": "DeleteSubscription",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "title": "Name"
+        }
+      },
+      "additionalProperties": false    }
+  },
+  "knative-deleteTrigger": {
+    "kind": "testAction",
+    "version": "4.10.1",
+    "name": "knative-deleteTrigger",
+    "group": "knative",
+    "module": "citrus-knative",
+    "title": "DeleteTrigger",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "title": "Name"
+        }
+      },
+      "additionalProperties": false    }
+  },
+  "knative-receiveEvent": {
+    "kind": "testAction",
+    "version": "4.10.1",
+    "name": "knative-receiveEvent",
+    "group": "knative",
+    "module": "citrus-knative",
+    "title": "ReceiveEvent",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "event": {
+          "type": "object",
+          "properties": {
+            "attributes": {
+              "title": "Attributes",
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "title": "Name"
+                  },
+                  "value": {
+                    "type": "string",
+                    "title": "Value"
+                  }
+                },
+                "additionalProperties": false,
+                "title": "Attributes"
+              }
+            },
+            "data": {
+              "type": "string",
+              "title": "Data",
+              "description": "The event message body as inline data."
+            }
+          },
+          "additionalProperties": false,
+          "title": "Event"
+        },
+        "port": {
+          "type": "integer",
+          "title": "Port"
+        },
+        "service": {
+          "type": "string",
+          "title": "Service"
+        },
+        "timeout": {
+          "type": "integer",
+          "title": "Timeout"
+        }
+      },
+      "additionalProperties": false    }
+  },
+  "knative-sendEvent": {
+    "kind": "testAction",
+    "version": "4.10.1",
+    "name": "knative-sendEvent",
+    "group": "knative",
+    "module": "citrus-knative",
+    "title": "SendEvent",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "broker": {
+          "type": "string",
+          "title": "Broker"
+        },
+        "event": {
+          "type": "object",
+          "properties": {
+            "attributes": {
+              "title": "Attributes",
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "title": "Name"
+                  },
+                  "value": {
+                    "type": "string",
+                    "title": "Value"
+                  }
+                },
+                "additionalProperties": false,
+                "title": "Attributes"
+              }
+            },
+            "data": {
+              "type": "string",
+              "title": "Data",
+              "description": "The event message body as inline data."
+            }
+          },
+          "additionalProperties": false,
+          "title": "Event"
+        },
+        "fork": {
+          "type": "boolean",
+          "title": "Fork"
+        },
+        "timeout": {
+          "type": "integer",
+          "title": "Timeout"
+        }
+      },
+      "additionalProperties": false    }
+  },
+  "knative-verifyBroker": {
+    "kind": "testAction",
+    "version": "4.10.1",
+    "name": "knative-verifyBroker",
+    "group": "knative",
+    "module": "citrus-knative",
+    "title": "VerifyBroker",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "title": "Name"
+        }
+      },
+      "additionalProperties": false    }
+  },
+  "kubernetes": {
+    "kind": "testActionGroup",
+    "version": "4.10.1",
+    "name": "kubernetes",
+    "module": "citrus-kubernetes",
+    "title": "Kubernetes",
+    "description": "Kubernetes test actions.",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "actor": {
+          "type": "string",
+          "title": "Actor",
+          "$comment": "group:advanced"
+        },
+        "autoRemove": {
+          "type": "boolean",
+          "title": "AutoRemove"
+        },
+        "client": {
+          "type": "string",
+          "title": "Client"
+        },
+        "description": {
+          "type": "string",
+          "title": "Description",
+          "description": "Test action description printed when the action is executed.",
+          "$comment": "group:advanced"
+        },
+        "namespace": {
+          "type": "string",
+          "title": "Namespace"
+        }
+      },
+      "additionalProperties": false    }
+  },
+  "kubernetes-agent": {
+    "kind": "testAction",
+    "version": "4.10.1",
+    "name": "kubernetes-agent",
+    "group": "kubernetes",
+    "module": "citrus-kubernetes",
+    "title": "Agent",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "connect": {
+          "type": "object",
+          "properties": {
+            "client": {
+              "type": "string",
+              "title": "Client",
+              "description": "Creates and exposes a client that connects to this agent. The client can be referenced by this name."
+            },
+            "image": {
+              "type": "string",
+              "title": "Image"
+            },
+            "localPort": {
+              "type": "string",
+              "title": "LocalPort",
+              "description": "Local port on the host machine. Creates a local port forward to the Kubernetes agent service."
+            },
+            "name": {
+              "type": "string",
+              "title": "Name"
+            },
+            "port": {
+              "type": "string",
+              "title": "Port",
+              "description": "The exposed agent service port used to connect to."
+            },
+            "registry": {
+              "type": "string",
+              "title": "Registry"
+            },
+            "testJar": {
+              "type": "string",
+              "title": "TestJar"
+            },
+            "timeout": {
+              "type": "string",
+              "title": "Timeout"
+            },
+            "waitForRunningState": {
+              "type": "boolean",
+              "title": "WaitForRunningState"
+            }
+          },
+          "additionalProperties": false,
+          "title": "Connect"
+        },
+        "disconnect": {
+          "type": "object",
+          "properties": {
+            "name": {
+              "type": "string",
+              "title": "Name"
+            }
+          },
+          "additionalProperties": false,
+          "title": "Disconnect"
+        }
+      },
+      "additionalProperties": false    }
+  },
+  "kubernetes-connect": {
+    "kind": "testAction",
+    "version": "4.10.1",
+    "name": "kubernetes-connect",
+    "group": "kubernetes",
+    "module": "citrus-kubernetes",
+    "title": "Connect",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "service": {
+          "type": "object",
+          "properties": {
+            "client": {
+              "type": "string",
+              "title": "Client",
+              "description": "Creates and exposes a client that connects to this service. The client can be referenced by this name."
+            },
+            "localPort": {
+              "type": "string",
+              "title": "LocalPort",
+              "description": "Local port on the host machine. Creates a local port forward to the Kubernetes service."
+            },
+            "name": {
+              "type": "string",
+              "title": "Name",
+              "description": "The Kubernetes service name to connect to"
+            },
+            "port": {
+              "type": "string",
+              "title": "Port",
+              "description": "The exposed service port used to connect to."
+            }
+          },
+          "additionalProperties": false,
+          "title": "Service",
+          "description": "Connects to this Kubernetes service."
+        }
+      },
+      "additionalProperties": false    }
+  },
+  "kubernetes-connectService": {
+    "kind": "testAction",
+    "version": "4.10.1",
+    "name": "kubernetes-connectService",
+    "group": "kubernetes",
+    "module": "citrus-kubernetes",
+    "title": "ConnectService",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "client": {
+          "type": "string",
+          "title": "Client",
+          "description": "Creates and exposes a client that connects to this service. The client can be referenced by this name."
+        },
+        "localPort": {
+          "type": "string",
+          "title": "LocalPort",
+          "description": "Local port on the host machine. Creates a local port forward to the Kubernetes service."
+        },
+        "name": {
+          "type": "string",
+          "title": "ServiceName",
+          "description": "The Kubernetes service name to connect to"
+        },
+        "port": {
+          "type": "string",
+          "title": "Port",
+          "description": "The exposed service port used to connect to."
+        }
+      },
+      "additionalProperties": false    }
+  },
+  "kubernetes-createAnnotations": {
+    "kind": "testAction",
+    "version": "4.10.1",
+    "name": "kubernetes-createAnnotations",
+    "group": "kubernetes",
+    "module": "citrus-kubernetes",
+    "title": "CreateAnnotations",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "annotations": {
+          "title": "Annotations",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string",
+                "title": "Name"
+              },
+              "value": {
+                "type": "string",
+                "title": "Value"
+              }
+            },
+            "additionalProperties": false,
+            "title": "Annotations"
+          }
+        },
+        "resource": {
+          "type": "string",
+          "title": "Resource"
+        },
+        "type": {
+          "type": "string",
+          "title": "Type"
+        }
+      },
+      "additionalProperties": false    }
+  },
+  "kubernetes-createConfigMap": {
+    "kind": "testAction",
+    "version": "4.10.1",
+    "name": "kubernetes-createConfigMap",
+    "group": "kubernetes",
+    "module": "citrus-kubernetes",
+    "title": "CreateConfigMap",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "file": {
+          "type": "string",
+          "title": "File"
+        },
+        "name": {
+          "type": "string",
+          "title": "Name"
+        },
+        "properties": {
+          "title": "Properties",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string",
+                "title": "Name"
+              },
+              "value": {
+                "type": "string",
+                "title": "Value"
+              }
+            },
+            "additionalProperties": false,
+            "title": "Properties"
+          }
+        }
+      },
+      "additionalProperties": false    }
+  },
+  "kubernetes-createCustomResource": {
+    "kind": "testAction",
+    "version": "4.10.1",
+    "name": "kubernetes-createCustomResource",
+    "group": "kubernetes",
+    "module": "citrus-kubernetes",
+    "title": "CreateCustomResource",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "title": "ApiVersion"
+        },
+        "data": {
+        },
+        "file": {
+        },
+        "group": {
+          "type": "string",
+          "title": "Group"
+        },
+        "kind": {
+          "type": "string",
+          "title": "Kind"
+        },
+        "type": {
+          "type": "string",
+          "title": "Type"
+        },
+        "version": {
+          "type": "string",
+          "title": "Version"
+        }
+      },
+      "additionalProperties": false,
+      "anyOf": [
+        {
+          "oneOf": [
+            {
+              "type": "object",
+              "properties": {
+                "data": {
+                  "type": "string",
+                  "title": "Data",
+                  "description": "The custom resource specification as inline data."
+                }
+              }
+            },
+            {
+              "type": "object",
+              "properties": {
+                "file": {
+                  "type": "string",
+                  "title": "File",
+                  "description": "The custom resource specification loaded from a file resource."
+                }
+              }
+            }
+          ]
+        }
+      ]
+    }
+  },
+  "kubernetes-createLabels": {
+    "kind": "testAction",
+    "version": "4.10.1",
+    "name": "kubernetes-createLabels",
+    "group": "kubernetes",
+    "module": "citrus-kubernetes",
+    "title": "CreateLabels",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "labels": {
+          "title": "Labels",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string",
+                "title": "Name"
+              },
+              "value": {
+                "type": "string",
+                "title": "Value"
+              }
+            },
+            "additionalProperties": false,
+            "title": "Labels"
+          }
+        },
+        "resource": {
+          "type": "string",
+          "title": "Resource"
+        },
+        "type": {
+          "type": "string",
+          "title": "Type"
+        }
+      },
+      "additionalProperties": false    }
+  },
+  "kubernetes-createResource": {
+    "kind": "testAction",
+    "version": "4.10.1",
+    "name": "kubernetes-createResource",
+    "group": "kubernetes",
+    "module": "citrus-kubernetes",
+    "title": "CreateResource",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "data": {
+        },
+        "file": {
+        }
+      },
+      "additionalProperties": false,
+      "anyOf": [
+        {
+          "oneOf": [
+            {
+              "type": "object",
+              "properties": {
+                "data": {
+                  "type": "string",
+                  "title": "Data",
+                  "description": "The custom resource specification as inline data."
+                }
+              }
+            },
+            {
+              "type": "object",
+              "properties": {
+                "file": {
+                  "type": "string",
+                  "title": "File",
+                  "description": "The custom resource specification loaded from a file resource."
+                }
+              }
+            }
+          ]
+        }
+      ]
+    }
+  },
+  "kubernetes-createSecret": {
+    "kind": "testAction",
+    "version": "4.10.1",
+    "name": "kubernetes-createSecret",
+    "group": "kubernetes",
+    "module": "citrus-kubernetes",
+    "title": "CreateSecret",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "file": {
+          "type": "string",
+          "title": "File"
+        },
+        "name": {
+          "type": "string",
+          "title": "Name"
+        },
+        "properties": {
+          "title": "Properties",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string",
+                "title": "Name"
+              },
+              "value": {
+                "type": "string",
+                "title": "Value"
+              }
+            },
+            "additionalProperties": false,
+            "title": "Properties"
+          }
+        }
+      },
+      "additionalProperties": false    }
+  },
+  "kubernetes-createService": {
+    "kind": "testAction",
+    "version": "4.10.1",
+    "name": "kubernetes-createService",
+    "group": "kubernetes",
+    "module": "citrus-kubernetes",
+    "title": "CreateService",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "autoCreateServerBinding": {
+          "type": "boolean",
+          "title": "AutoCreateServerBinding"
+        },
+        "name": {
+          "type": "string",
+          "title": "Name"
+        },
+        "ports": {
+          "title": "Ports",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "port": {
+                "type": "string",
+                "title": "Port"
+              },
+              "targetPort": {
+                "type": "string",
+                "title": "TargetPort"
+              }
+            },
+            "additionalProperties": false,
+            "title": "Ports"
+          }
+        },
+        "protocol": {
+          "type": "string",
+          "title": "Protocol"
+        },
+        "selector": {
+          "type": "object",
+          "properties": {
+            "labels": {
+              "title": "Labels",
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "title": "Name"
+                  },
+                  "value": {
+                    "type": "string",
+                    "title": "Value"
+                  }
+                },
+                "additionalProperties": false,
+                "title": "Labels"
+              }
+            }
+          },
+          "additionalProperties": false,
+          "title": "Selector"
+        },
+        "server": {
+          "type": "string",
+          "title": "Server",
+          "description": "Uses an endpoint URI or references an endpoint name."
+        }
+      },
+      "additionalProperties": false    }
+  },
+  "kubernetes-deleteConfigMap": {
+    "kind": "testAction",
+    "version": "4.10.1",
+    "name": "kubernetes-deleteConfigMap",
+    "group": "kubernetes",
+    "module": "citrus-kubernetes",
+    "title": "DeleteConfigMap",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "title": "Name"
+        }
+      },
+      "additionalProperties": false    }
+  },
+  "kubernetes-deleteCustomResource": {
+    "kind": "testAction",
+    "version": "4.10.1",
+    "name": "kubernetes-deleteCustomResource",
+    "group": "kubernetes",
+    "module": "citrus-kubernetes",
+    "title": "DeleteCustomResource",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "title": "ApiVersion"
+        },
+        "group": {
+          "type": "string",
+          "title": "Group"
+        },
+        "kind": {
+          "type": "string",
+          "title": "Kind"
+        },
+        "name": {
+          "type": "string",
+          "title": "Name"
+        },
+        "type": {
+          "type": "string",
+          "title": "Type"
+        },
+        "version": {
+          "type": "string",
+          "title": "Version"
+        }
+      },
+      "additionalProperties": false    }
+  },
+  "kubernetes-deleteResource": {
+    "kind": "testAction",
+    "version": "4.10.1",
+    "name": "kubernetes-deleteResource",
+    "group": "kubernetes",
+    "module": "citrus-kubernetes",
+    "title": "DeleteResource",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "data": {
+        },
+        "file": {
+        }
+      },
+      "additionalProperties": false,
+      "anyOf": [
+        {
+          "oneOf": [
+            {
+              "type": "object",
+              "properties": {
+                "data": {
+                  "type": "string",
+                  "title": "Data",
+                  "description": "The custom resource specification as inline data."
+                }
+              }
+            },
+            {
+              "type": "object",
+              "properties": {
+                "file": {
+                  "type": "string",
+                  "title": "File",
+                  "description": "The custom resource specification loaded from a file resource."
+                }
+              }
+            }
+          ]
+        }
+      ]
+    }
+  },
+  "kubernetes-deleteSecret": {
+    "kind": "testAction",
+    "version": "4.10.1",
+    "name": "kubernetes-deleteSecret",
+    "group": "kubernetes",
+    "module": "citrus-kubernetes",
+    "title": "DeleteSecret",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "title": "Name"
+        }
+      },
+      "additionalProperties": false    }
+  },
+  "kubernetes-deleteService": {
+    "kind": "testAction",
+    "version": "4.10.1",
+    "name": "kubernetes-deleteService",
+    "group": "kubernetes",
+    "module": "citrus-kubernetes",
+    "title": "DeleteService",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "title": "Name"
+        }
+      },
+      "additionalProperties": false    }
+  },
+  "kubernetes-disconnect": {
+    "kind": "testAction",
+    "version": "4.10.1",
+    "name": "kubernetes-disconnect",
+    "group": "kubernetes",
+    "module": "citrus-kubernetes",
+    "title": "Disconnect",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "service": {
+          "type": "object",
+          "properties": {
+            "name": {
+              "type": "string",
+              "title": "Name"
+            }
+          },
+          "additionalProperties": false,
+          "title": "Service"
+        }
+      },
+      "additionalProperties": false    }
+  },
+  "kubernetes-disconnectService": {
+    "kind": "testAction",
+    "version": "4.10.1",
+    "name": "kubernetes-disconnectService",
+    "group": "kubernetes",
+    "module": "citrus-kubernetes",
+    "title": "DisconnectService",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "client": {
+          "type": "string",
+          "title": "Client"
+        },
+        "name": {
+          "type": "string",
+          "title": "Name"
+        }
+      },
+      "additionalProperties": false    }
+  },
+  "kubernetes-verifyCustomResource": {
+    "kind": "testAction",
+    "version": "4.10.1",
+    "name": "kubernetes-verifyCustomResource",
+    "group": "kubernetes",
+    "module": "citrus-kubernetes",
+    "title": "VerifyCustomResource",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "title": "ApiVersion"
+        },
+        "condition": {
+          "type": "string",
+          "title": "Condition"
+        },
+        "delayBetweenAttempts": {
+          "type": "integer",
+          "title": "DelayBetweenAttempts"
+        },
+        "group": {
+          "type": "string",
+          "title": "Group"
+        },
+        "kind": {
+          "type": "string",
+          "title": "Kind"
+        },
+        "label": {
+          "type": "string",
+          "title": "Label"
+        },
+        "maxAttempts": {
+          "type": "integer",
+          "title": "MaxAttempts"
+        },
+        "name": {
+          "type": "string",
+          "title": "Name"
+        },
+        "type": {
+          "type": "string",
+          "title": "Type"
+        },
+        "version": {
+          "type": "string",
+          "title": "Version"
+        }
+      },
+      "additionalProperties": false    }
+  },
+  "kubernetes-verifyPod": {
+    "kind": "testAction",
+    "version": "4.10.1",
+    "name": "kubernetes-verifyPod",
+    "group": "kubernetes",
+    "module": "citrus-kubernetes",
+    "title": "VerifyPod",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "delayBetweenAttempts": {
+          "type": "integer",
+          "title": "DelayBetweenAttempts"
+        },
+        "label": {
+          "type": "string",
+          "title": "Label"
+        },
+        "labels": {
+          "title": "Labels",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string",
+                "title": "Name"
+              },
+              "value": {
+                "type": "string",
+                "title": "Value"
+              }
+            },
+            "additionalProperties": false,
+            "title": "Labels"
+          }
+        },
+        "logMessage": {
+          "type": "string",
+          "title": "LogMessage"
+        },
+        "maxAttempts": {
+          "type": "integer",
+          "title": "MaxAttempts"
+        },
+        "name": {
+          "type": "string",
+          "title": "Name"
+        },
+        "phase": {
+          "type": "string",
+          "title": "Phase"
+        },
+        "printLogs": {
+          "type": "boolean",
+          "title": "PrintLogs"
+        }
+      },
+      "additionalProperties": false    }
+  },
+  "kubernetes-watchPodLogs": {
+    "kind": "testAction",
+    "version": "4.10.1",
+    "name": "kubernetes-watchPodLogs",
+    "group": "kubernetes",
+    "module": "citrus-kubernetes",
+    "title": "WatchPodLogs",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "label": {
+          "type": "string",
+          "title": "Label"
+        },
+        "labels": {
+          "title": "Labels",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string",
+                "title": "Name"
+              },
+              "value": {
+                "type": "string",
+                "title": "Value"
+              }
+            },
+            "additionalProperties": false,
+            "title": "Labels"
+          }
+        },
+        "name": {
+          "type": "string",
+          "title": "Name"
+        },
+        "timeout": {
+          "type": "string",
+          "title": "Timeout"
+        }
+      },
+      "additionalProperties": false    }
+  },
+  "load": {
+    "kind": "testAction",
+    "version": "4.10.1",
+    "name": "load",
+    "title": "Load",
+    "description": "Load properties test action.",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "properties": {
+          "type": "object",
+          "properties": {
+            "file": {
+              "type": "string",
+              "title": "File",
+              "description": "Properties file resource."
+            }
+          },
+          "required": [
+            "file"
+          ],
+          "additionalProperties": false,
+          "title": "Properties",
+          "description": "The properties source."
+        }
+      },
+      "required": [
+        "properties"
+      ],
+      "additionalProperties": false    }
+  },
+  "openapi": {
+    "kind": "testActionGroup",
+    "version": "4.10.1",
+    "name": "openapi",
+    "module": "citrus-openapi",
+    "title": "Openapi",
+    "description": "OpenAPI related test actions.",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "actor": {
+          "type": "string",
+          "title": "Actor",
+          "$comment": "group:advanced"
+        },
+        "client": {
+          "type": "string",
+          "title": "Client",
+          "description": "Sets the Http client used to send requests. Uses an endpoint URI or references an endpoint name."
+        },
+        "description": {
+          "type": "string",
+          "title": "Description",
+          "description": "Test action description printed when the action is executed.",
+          "$comment": "group:advanced"
+        },
+        "server": {
+          "type": "string",
+          "title": "Server",
+          "description": "Sets the Http server that provides the Http API. Uses an endpoint URI or references an endpoint name."
+        },
+        "specification": {
+          "type": "string",
+          "title": "Specification",
+          "description": "The OpenAPI specification source. Can be a local file resource or an Http endpoint URI."
+        }
+      },
+      "required": [
+        "specification"
+      ],
+      "additionalProperties": false    }
+  },
+  "openapi-receiveRequest": {
+    "kind": "testAction",
+    "version": "4.10.1",
+    "name": "openapi-receiveRequest",
+    "group": "openapi",
+    "module": "citrus-openapi",
+    "title": "ReceiveRequest",
+    "description": "Receives a client request as a server.",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "extract": {
+          "type": "object",
+          "properties": {
+            "body": {
+              "title": "Body",
+              "description": "Extract elements from the message body into test variables.",
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "path": {
+                    "type": "string",
+                    "title": "Path",
+                    "description": "The path expression to evaluate."
+                  },
+                  "resultType": {
+                    "type": "string",
+                    "title": "ResultType",
+                    "description": "The expression result type. By default the path expression evaluate to String values.With this setting you can force another expression result type.",
+                    "$comment": "group:advanced"
+                  },
+                  "variable": {
+                    "type": "string",
+                    "title": "Variable",
+                    "description": "The test variable name."
+                  }
+                },
+                "required": [
+                  "variable"
+                ],
+                "additionalProperties": false,
+                "title": "Body",
+                "description": "Extract elements from the message body into test variables."
+              }
+            },
+            "header": {
+              "title": "Header",
+              "description": "Extract elements from the message header into test variables.",
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "title": "Name",
+                    "description": "The name of the message header."
+                  },
+                  "variable": {
+                    "type": "string",
+                    "title": "Variable",
+                    "description": "The test variable name."
+                  }
+                },
+                "required": [
+                  "name",
+                  "variable"
+                ],
+                "additionalProperties": false,
+                "title": "Header",
+                "description": "Extract elements from the message header into test variables."
+              }
+            }
+          },
+          "additionalProperties": false,
+          "title": "Extract",
+          "description": "Extract message content to test variables.",
+          "$comment": "group:advanced"
+        },
+        "headerValidator": {
+          "type": "string",
+          "title": "HeaderValidator",
+          "description": "Explicit message header validator.",
+          "$comment": "group:advanced"
+        },
+        "headerValidators": {
+          "type": "string",
+          "title": "HeaderValidators",
+          "description": "List of message header validators used to validate the message.",
+          "$comment": "group:advanced"
+        },
+        "operation": {
+          "type": "string",
+          "title": "Operation",
+          "description": "The expected API operation."
+        },
+        "schemaValidation": {
+          "type": "boolean",
+          "title": "SchemaValidation",
+          "description": "Enables the schema validation.",
+          "default": "false"
+        },
+        "select": {
+          "type": "string",
+          "title": "Select",
+          "description": "Message selector expression to selectively consume messages.",
+          "$comment": "group:advanced"
+        },
+        "timeout": {
+          "type": "integer",
+          "title": "Timeout",
+          "description": "The timeout while waiting for incoming Http requests."
+        },
+        "validates": {
+          "title": "Validates",
+          "description": "Additional message validation expressions.",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "jsonPath": {
+                "title": "JsonPath",
+                "description": "JsonPath validation expression.",
+                "$comment": "group:jsonPath",
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "expression": {
+                      "type": "string",
+                      "title": "Expression",
+                      "description": "The Json path expression to evaluate."
+                    },
+                    "value": {
+                      "type": "string",
+                      "title": "Value",
+                      "description": "The expected result."
+                    }
+                  },
+                  "required": [
+                    "expression",
+                    "value"
+                  ],
+                  "additionalProperties": false,
+                  "title": "JsonPath",
+                  "description": "JsonPath validation expression.",
+                  "$comment": "group:jsonPath"
+                }
+              },
+              "namespace": {
+                "title": "Namespace",
+                "description": "List of expected namespaces.",
+                "$comment": "group:xml",
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "prefix": {
+                      "type": "string",
+                      "title": "Prefix",
+                      "description": "The expected namespace prefix."
+                    },
+                    "value": {
+                      "type": "string",
+                      "title": "Value",
+                      "description": "The expected namespace value."
+                    }
+                  },
+                  "required": [
+                    "prefix",
+                    "value"
+                  ],
+                  "additionalProperties": false,
+                  "title": "Namespace",
+                  "description": "List of expected namespaces.",
+                  "$comment": "group:xml"
+                }
+              },
+              "path": {
+                "type": "string",
+                "title": "Path",
+                "description": "Message validation expression."
+              },
+              "resultType": {
+                "type": "string",
+                "title": "ResultType",
+                "description": "Expected expression result type.",
+                "$comment": "group:advanced"
+              },
+              "script": {
+                "type": "object",
+                "properties": {
+                  "charset": {
+                    "type": "string",
+                    "title": "Charset",
+                    "description": "The charset used to load the file resource.",
+                    "$comment": "group:advanced"
+                  },
+                  "content": {
+                    "type": "string",
+                    "title": "Content",
+                    "description": "The script content as inline data."
+                  },
+                  "file": {
+                    "type": "string",
+                    "title": "File",
+                    "description": "The script content loaded as a file resource."
+                  },
+                  "type": {
+                    "type": "string",
+                    "title": "Type",
+                    "description": "The script type.",
+                    "default": "groovy"
+                  }
+                },
+                "additionalProperties": false,
+                "title": "Script",
+                "description": "Script that builds the expected validate value.",
+                "$comment": "group:script"
+              },
+              "value": {
+                "type": "string",
+                "title": "Value",
+                "description": "Expected message validation expression value."
+              },
+              "xpath": {
+                "title": "Xpath",
+                "description": "Xpath validation expression.",
+                "$comment": "group:xml",
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "expression": {
+                      "type": "string",
+                      "title": "Expression",
+                      "description": "The Xpath expression to evaluate."
+                    },
+                    "resultType": {
+                      "type": "string",
+                      "title": "ResultType",
+                      "description": "The expected result type.",
+                      "$comment": "group:advanced"
+                    },
+                    "value": {
+                      "type": "string",
+                      "title": "Value",
+                      "description": "The expected result."
+                    }
+                  },
+                  "required": [
+                    "expression",
+                    "value"
+                  ],
+                  "additionalProperties": false,
+                  "title": "Xpath",
+                  "description": "Xpath validation expression.",
+                  "$comment": "group:xml"
+                }
+              }
+            },
+            "additionalProperties": false,
+            "title": "Validates",
+            "description": "Additional message validation expressions."
+          }
+        },
+        "validator": {
+          "type": "string",
+          "title": "Validator",
+          "description": "Explicit message validator.",
+          "$comment": "group:advanced"
+        },
+        "validators": {
+          "type": "string",
+          "title": "Validators",
+          "description": "List of message validators used to validate the message.",
+          "$comment": "group:advanced"
+        }
+      },
+      "required": [
+        "operation"
+      ],
+      "additionalProperties": false    }
+  },
+  "openapi-receiveResponse": {
+    "kind": "testAction",
+    "version": "4.10.1",
+    "name": "openapi-receiveResponse",
+    "group": "openapi",
+    "module": "citrus-openapi",
+    "title": "ReceiveResponse",
+    "description": "Receives a response as a client.",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "extract": {
+          "type": "object",
+          "properties": {
+            "body": {
+              "title": "Body",
+              "description": "Extract elements from the message body into test variables.",
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "path": {
+                    "type": "string",
+                    "title": "Path",
+                    "description": "The path expression to evaluate."
+                  },
+                  "resultType": {
+                    "type": "string",
+                    "title": "ResultType",
+                    "description": "The expression result type. By default the path expression evaluate to String values.With this setting you can force another expression result type.",
+                    "$comment": "group:advanced"
+                  },
+                  "variable": {
+                    "type": "string",
+                    "title": "Variable",
+                    "description": "The test variable name."
+                  }
+                },
+                "required": [
+                  "variable"
+                ],
+                "additionalProperties": false,
+                "title": "Body",
+                "description": "Extract elements from the message body into test variables."
+              }
+            },
+            "header": {
+              "title": "Header",
+              "description": "Extract elements from the message header into test variables.",
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "title": "Name",
+                    "description": "The name of the message header."
+                  },
+                  "variable": {
+                    "type": "string",
+                    "title": "Variable",
+                    "description": "The test variable name."
+                  }
+                },
+                "required": [
+                  "name",
+                  "variable"
+                ],
+                "additionalProperties": false,
+                "title": "Header",
+                "description": "Extract elements from the message header into test variables."
+              }
+            }
+          },
+          "additionalProperties": false,
+          "title": "Extract",
+          "description": "Extract message content to test variables.",
+          "$comment": "group:advanced"
+        },
+        "headerValidator": {
+          "type": "string",
+          "title": "HeaderValidator",
+          "description": "Explicit message header validator.",
+          "$comment": "group:advanced"
+        },
+        "headerValidators": {
+          "type": "string",
+          "title": "HeaderValidators",
+          "description": "List of message header validators used to validate the message.",
+          "$comment": "group:advanced"
+        },
+        "operation": {
+          "type": "string",
+          "title": "Operation",
+          "description": "The OpenAPI operation that defines the expected response."
+        },
+        "schemaValidation": {
+          "type": "boolean",
+          "title": "SchemaValidation",
+          "description": "Enables the schema validation.",
+          "default": "false"
+        },
+        "select": {
+          "type": "string",
+          "title": "Select",
+          "description": "Message selector expression to selectively consume messages.",
+          "$comment": "group:advanced"
+        },
+        "selector": {
+          "type": "object",
+          "properties": {
+            "element": {
+              "title": "Element",
+              "description": "List of elements to build the selector expression.",
+              "$comment": "group:advanced",
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "title": "Name",
+                    "description": "Select element key name."
+                  },
+                  "value": {
+                    "type": "string",
+                    "title": "Value",
+                    "description": "Select expression value."
+                  }
+                },
+                "required": [
+                  "name",
+                  "value"
+                ],
+                "additionalProperties": false,
+                "title": "Element",
+                "description": "List of elements to build the selector expression.",
+                "$comment": "group:advanced"
+              }
+            },
+            "value": {
+              "type": "string",
+              "title": "Value",
+              "description": "Selector expression value."
+            }
+          },
+          "additionalProperties": false,
+          "title": "Selector",
+          "description": "Message selector to selectively consume messages.",
+          "$comment": "group:advanced"
+        },
+        "status": {
+          "type": "string",
+          "title": "Status",
+          "description": "Expected response status."
+        },
+        "timeout": {
+          "type": "integer",
+          "title": "Timeout",
+          "description": "Timeout in milliseconds while waiting for the server response."
+        },
+        "validator": {
+          "type": "string",
+          "title": "Validator",
+          "description": "Explicit message validator.",
+          "$comment": "group:advanced"
+        },
+        "validators": {
+          "type": "string",
+          "title": "Validators",
+          "description": "List of message validators used to validate the message.",
+          "$comment": "group:advanced"
+        }
+      },
+      "required": [
+        "operation"
+      ],
+      "additionalProperties": false    }
+  },
+  "openapi-sendRequest": {
+    "kind": "testAction",
+    "version": "4.10.1",
+    "name": "openapi-sendRequest",
+    "group": "openapi",
+    "module": "citrus-openapi",
+    "title": "SendRequest",
+    "description": "Send a request as a client.",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "autoFill": {
+          "type": "string",
+          "enum": [
+            "NONE",
+            "REQUIRED",
+            "ALL"
+          ],
+          "title": "AutoFill",
+          "description": "Define which of the request fields are automatically filled with generated test data."
+        },
+        "extract": {
+          "type": "object",
+          "properties": {
+            "body": {
+              "title": "Body",
+              "description": "Extract elements from the message body into test variables.",
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "path": {
+                    "type": "string",
+                    "title": "Path",
+                    "description": "The path expression to evaluate."
+                  },
+                  "resultType": {
+                    "type": "string",
+                    "title": "ResultType",
+                    "description": "The expression result type. By default the path expression evaluate to String values.With this setting you can force another expression result type.",
+                    "$comment": "group:advanced"
+                  },
+                  "variable": {
+                    "type": "string",
+                    "title": "Variable",
+                    "description": "The test variable name."
+                  }
+                },
+                "required": [
+                  "variable"
+                ],
+                "additionalProperties": false,
+                "title": "Body",
+                "description": "Extract elements from the message body into test variables."
+              }
+            },
+            "header": {
+              "title": "Header",
+              "description": "Extract elements from the message header into test variables.",
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "title": "Name",
+                    "description": "The name of the message header."
+                  },
+                  "variable": {
+                    "type": "string",
+                    "title": "Variable",
+                    "description": "The test variable name."
+                  }
+                },
+                "required": [
+                  "name",
+                  "variable"
+                ],
+                "additionalProperties": false,
+                "title": "Header",
+                "description": "Extract elements from the message header into test variables."
+              }
+            }
+          },
+          "additionalProperties": false,
+          "title": "Extract",
+          "description": "Extract message content to test variables before the request is sent.",
+          "$comment": "group:advanced"
+        },
+        "fork": {
+          "type": "boolean",
+          "title": "Fork",
+          "description": "When enabled send operation does not block while waiting for the response.",
+          "$comment": "group:advanced"
+        },
+        "operation": {
+          "type": "string",
+          "title": "Operation",
+          "description": "The API operation to call."
+        },
+        "schemaValidation": {
+          "type": "boolean",
+          "title": "SchemaValidation",
+          "description": "Enables the schema validation.",
+          "default": "false",
+          "$comment": "group:advanced"
+        },
+        "uri": {
+          "type": "string",
+          "title": "Uri",
+          "description": "Http endpoint URI overwrite.",
+          "$comment": "group:advanced"
+        }
+      },
+      "required": [
+        "operation"
+      ],
+      "additionalProperties": false    }
+  },
+  "openapi-sendResponse": {
+    "kind": "testAction",
+    "version": "4.10.1",
+    "name": "openapi-sendResponse",
+    "group": "openapi",
+    "module": "citrus-openapi",
+    "title": "SendResponse",
+    "description": "Sends a response as a server.",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "autoFill": {
+          "type": "string",
+          "enum": [
+            "NONE",
+            "REQUIRED",
+            "ALL"
+          ],
+          "title": "AutoFill",
+          "description": "Define which response fields are set with generated values."
+        },
+        "extract": {
+          "type": "object",
+          "properties": {
+            "body": {
+              "title": "Body",
+              "description": "Extract elements from the message body into test variables.",
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "path": {
+                    "type": "string",
+                    "title": "Path",
+                    "description": "The path expression to evaluate."
+                  },
+                  "resultType": {
+                    "type": "string",
+                    "title": "ResultType",
+                    "description": "The expression result type. By default the path expression evaluate to String values.With this setting you can force another expression result type.",
+                    "$comment": "group:advanced"
+                  },
+                  "variable": {
+                    "type": "string",
+                    "title": "Variable",
+                    "description": "The test variable name."
+                  }
+                },
+                "required": [
+                  "variable"
+                ],
+                "additionalProperties": false,
+                "title": "Body",
+                "description": "Extract elements from the message body into test variables."
+              }
+            },
+            "header": {
+              "title": "Header",
+              "description": "Extract elements from the message header into test variables.",
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "title": "Name",
+                    "description": "The name of the message header."
+                  },
+                  "variable": {
+                    "type": "string",
+                    "title": "Variable",
+                    "description": "The test variable name."
+                  }
+                },
+                "required": [
+                  "name",
+                  "variable"
+                ],
+                "additionalProperties": false,
+                "title": "Header",
+                "description": "Extract elements from the message header into test variables."
+              }
+            }
+          },
+          "additionalProperties": false,
+          "title": "Extract",
+          "description": "Extract message content to test variables.",
+          "$comment": "group:advanced"
+        },
+        "operation": {
+          "type": "string",
+          "title": "Operation",
+          "description": "The OpenAPI operation that generates the response."
+        },
+        "schemaValidation": {
+          "type": "boolean",
+          "title": "SchemaValidation",
+          "description": "Enables the schema validation.",
+          "default": "false",
+          "$comment": "group:advanced"
+        },
+        "status": {
+          "type": "string",
+          "title": "Status",
+          "description": "The response to generate."
+        }
+      },
+      "required": [
+        "operation"
+      ],
+      "additionalProperties": false    }
+  },
+  "plsql": {
+    "kind": "testAction",
+    "version": "4.10.1",
+    "name": "plsql",
+    "module": "citrus-sql",
+    "title": "Plsql",
+    "description": "PLSQL test actions.",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "dataSource": {
+          "type": "string",
+          "title": "DataSource"
+        },
+        "description": {
+          "type": "string",
+          "title": "Description",
+          "description": "Test action description printed when the action is executed.",
+          "$comment": "group:advanced"
+        },
+        "ignoreErrors": {
+          "type": "boolean",
+          "title": "IgnoreErrors"
+        },
+        "statements": {
+          "title": "Statements",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "file": {
+                "type": "string",
+                "title": "File"
+              },
+              "script": {
+                "type": "string",
+                "title": "Script"
+              },
+              "statement": {
+                "type": "string",
+                "title": "Statement"
+              }
+            },
+            "additionalProperties": false,
+            "title": "Statements"
+          }
+        },
+        "transaction": {
+          "type": "object",
+          "properties": {
+            "isolationLevel": {
+              "type": "string",
+              "title": "IsolationLevel"
+            },
+            "manager": {
+              "type": "string",
+              "title": "Manager"
+            },
+            "timeout": {
+              "type": "string",
+              "title": "Timeout"
+            }
+          },
+          "additionalProperties": false,
+          "title": "Transaction"
+        }
+      },
+      "required": [
+        "statements"
+      ],
+      "additionalProperties": false    }
+  },
+  "print": {
+    "kind": "testAction",
+    "version": "4.10.1",
+    "name": "print",
+    "title": "Print",
+    "description": "Print test action.",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "description": {
+          "type": "string",
+          "title": "Description",
+          "description": "Test action description printed when the action is executed.",
+          "$comment": "group:advanced"
+        },
+        "message": {
+          "type": "string",
+          "title": "Message",
+          "description": "The message to print."
+        }
+      },
+      "required": [
+        "message"
+      ],
+      "additionalProperties": false    }
+  },
+  "purge": {
+    "kind": "testAction",
+    "version": "4.10.1",
+    "name": "purge",
+    "title": "Purge",
+    "description": "Purge test action.",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "endpoint": {
+          "type": "string",
+          "title": "Endpoint",
+          "description": "The name of the endpoint to purge. Uses an endpoint URI or references an endpoint name."
+        },
+        "endpoints": {
+          "title": "Endpoints",
+          "description": "List of endpoints to purge.",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string",
+                "title": "Name",
+                "description": "The name of the endpoint. Uses an endpoint URI or references an endpoint name."
+              },
+              "ref": {
+                "type": "string",
+                "title": "Ref",
+                "description": "Reference to the endpoint in the bean registry. Uses an endpoint URI or references an endpoint name."
+              }
+            },
+            "additionalProperties": false,
+            "title": "Endpoints",
+            "description": "List of endpoints to purge."
+          }
+        },
+        "select": {
+          "type": "string",
+          "title": "Select",
+          "description": "Message selector to purge only matching messages.",
+          "$comment": "group:advanced"
+        },
+        "selector": {
+          "type": "object",
+          "properties": {
+            "elements": {
+              "title": "Elements",
+              "description": "Select on given elements.",
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "title": "Name",
+                    "description": "Key of the selector expression."
+                  },
+                  "value": {
+                    "type": "string",
+                    "title": "Value",
+                    "description": "Select value of the selector expression."
+                  }
+                },
+                "required": [
+                  "name",
+                  "value"
+                ],
+                "additionalProperties": false,
+                "title": "Elements",
+                "description": "Select on given elements."
+              }
+            },
+            "value": {
+              "type": "string",
+              "title": "Value",
+              "description": "Selector expression value."
+            }
+          },
+          "additionalProperties": false,
+          "title": "Selector",
+          "description": "Message selector to find matching messages that should be purged.",
+          "$comment": "group:advanced"
+        },
+        "sleep": {
+          "type": "integer",
+          "title": "Sleep",
+          "description": "Wait this time between reading attempts.",
+          "$comment": "group:advanced"
+        },
+        "timeout": {
+          "type": "integer",
+          "title": "Timeout",
+          "description": "Timeout when reading messages from the endpoint."
+        }
+      },
+      "additionalProperties": false    }
+  },
+  "purgeQueues": {
+    "kind": "testAction",
+    "version": "4.10.1",
+    "name": "purgeQueues",
+    "module": "citrus-jms",
+    "title": "PurgeQueues",
+    "description": "Purge JMS queue test action.",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "actor": {
+          "type": "string",
+          "title": "Actor",
+          "$comment": "group:advanced"
+        },
+        "connectionFactory": {
+          "type": "string",
+          "title": "ConnectionFactory",
+          "description": "The JMS connection factory."
+        },
+        "description": {
+          "type": "string",
+          "title": "Description",
+          "description": "Test action description printed when the action is executed.",
+          "$comment": "group:advanced"
+        },
+        "queue": {
+          "type": "string",
+          "title": "Queue",
+          "description": "The JMS queue to purge."
+        },
+        "queues": {
+          "title": "Queues",
+          "description": "List of JMS queues to purge.",
+          "type": "array",
+          "items": {
+            "type": "string",
+            "title": "Queues",
+            "description": "List of JMS queues to purge."
+          }
+        },
+        "sleep": {
+          "type": "integer",
+          "title": "Sleep",
+          "description": "Time to wait between message consume attempts.",
+          "$comment": "group:advanced"
+        },
+        "timeout": {
+          "type": "integer",
+          "title": "Timeout",
+          "description": "Request timeout while consuming messages from the queue."
+        }
+      },
+      "required": [
+        "connectionFactory"
+      ],
+      "additionalProperties": false    }
+  },
+  "receive": {
+    "kind": "testAction",
+    "version": "4.10.1",
+    "name": "receive",
+    "title": "Receive",
+    "description": "Receive message test action.",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "actor": {
+          "type": "string",
+          "title": "Actor",
+          "$comment": "group:advanced"
+        },
+        "description": {
+          "type": "string",
+          "title": "Description",
+          "description": "Test action description printed when the action is executed.",
+          "$comment": "group:advanced"
+        },
+        "endpoint": {
+          "type": "string",
+          "title": "Endpoint",
+          "description": "The message endpoint name or URI used to receive the message. Uses an endpoint URI or references an endpoint name."
+        },
+        "extract": {
+          "type": "object",
+          "properties": {
+            "body": {
+              "title": "Body",
+              "description": "Extract elements from the message body into test variables.",
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "path": {
+                    "type": "string",
+                    "title": "Path",
+                    "description": "The path expression to evaluate."
+                  },
+                  "resultType": {
+                    "type": "string",
+                    "title": "ResultType",
+                    "description": "The expression result type. By default the path expression evaluate to String values.With this setting you can force another expression result type.",
+                    "$comment": "group:advanced"
+                  },
+                  "variable": {
+                    "type": "string",
+                    "title": "Variable",
+                    "description": "The test variable name."
+                  }
+                },
+                "required": [
+                  "variable"
+                ],
+                "additionalProperties": false,
+                "title": "Body",
+                "description": "Extract elements from the message body into test variables."
+              }
+            },
+            "header": {
+              "title": "Header",
+              "description": "Extract elements from the message header into test variables.",
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "title": "Name",
+                    "description": "The name of the message header."
+                  },
+                  "variable": {
+                    "type": "string",
+                    "title": "Variable",
+                    "description": "The test variable name."
+                  }
+                },
+                "required": [
+                  "name",
+                  "variable"
+                ],
+                "additionalProperties": false,
+                "title": "Header",
+                "description": "Extract elements from the message header into test variables."
+              }
+            }
+          },
+          "additionalProperties": false,
+          "title": "Extract",
+          "description": "Extract message content to test variables after the message validation.",
+          "$comment": "group:extract"
+        },
+        "headerValidator": {
+          "type": "string",
+          "title": "HeaderValidator",
+          "description": "Explicit message header validator.",
+          "$comment": "group:validator"
+        },
+        "headerValidators": {
+          "type": "string",
+          "title": "HeaderValidators",
+          "description": "List of message header validators used to validate the message.",
+          "$comment": "group:validator"
+        },
+        "ignore": {
+          "title": "Ignore",
+          "description": "List of expressions to identify message elements that should be ignored during validation.",
+          "$comment": "group:ignore",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "path": {
+                "type": "string",
+                "title": "Path",
+                "description": "Path expression identifies the message element to ignore."
+              }
+            },
+            "required": [
+              "path"
+            ],
+            "additionalProperties": false,
+            "title": "Ignore",
+            "description": "List of expressions to identify message elements that should be ignored during validation.",
+            "$comment": "group:ignore"
+          }
+        },
+        "message": {
+          "type": "object",
+          "properties": {
+            "body": {
+              "type": "object",
+              "properties": {
+                "data": {
+                },
+                "resource": {
+                },
+                "script": {
+                }
+              },
+              "additionalProperties": false,
+              "anyOf": [
+                {
+                  "oneOf": [
+                    {
+                      "type": "object",
+                      "properties": {
+                        "data": {
+                          "type": "string",
+                          "title": "Data",
+                          "description": "The message body content as inline data."
+                        }
+                      }
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "resource": {
+                          "type": "object",
+                          "properties": {
+                            "charset": {
+                              "type": "string",
+                              "title": "Charset",
+                              "$comment": "group:advanced"
+                            },
+                            "file": {
+                              "type": "string",
+                              "title": "File"
+                            }
+                          },
+                          "additionalProperties": false,
+                          "title": "Resource",
+                          "description": "The message body loaded from a file resource."
+                        }
+                      }
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "script": {
+                          "type": "object",
+                          "properties": {
+                            "charset": {
+                              "type": "string",
+                              "title": "Charset",
+                              "description": "The charset used to load the file resource.",
+                              "$comment": "group:advanced"
+                            },
+                            "content": {
+                              "type": "string",
+                              "title": "Content",
+                              "description": "The script content as inline data."
+                            },
+                            "file": {
+                              "type": "string",
+                              "title": "File",
+                              "description": "The script content loaded as a file resource."
+                            },
+                            "type": {
+                              "type": "string",
+                              "title": "Type",
+                              "description": "The script type.",
+                              "default": "groovy"
+                            }
+                          },
+                          "additionalProperties": false,
+                          "title": "Script",
+                          "description": "The message body set via script."
+                        }
+                      }
+                    }
+                  ]
+                }
+              ],
+              "title": "Body",
+              "description": "The message body."
+            },
+            "dataDictionary": {
+              "type": "string",
+              "title": "DataDictionary",
+              "description": "Sets a data dictionary that transforms message content before it is being processed.",
+              "$comment": "group:dictionary"
+            },
+            "expression": {
+              "title": "Expression",
+              "description": "List of path expressions to evaluate on the message content before processing the message.",
+              "$comment": "group:advanced",
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "path": {
+                    "type": "string",
+                    "title": "Path",
+                    "description": "The path expression to evaluate."
+                  },
+                  "value": {
+                    "type": "string",
+                    "title": "Value",
+                    "description": "The expected expression result value."
+                  }
+                },
+                "required": [
+                  "path",
+                  "value"
+                ],
+                "additionalProperties": false,
+                "title": "Expression",
+                "description": "List of path expressions to evaluate on the message content before processing the message.",
+                "$comment": "group:advanced"
+              }
+            },
+            "headerIgnoreCase": {
+              "type": "string",
+              "title": "HeaderIgnoreCase",
+              "description": "When enabled the header case is not verified.",
+              "$comment": "group:advanced"
+            },
+            "headers": {
+              "title": "Headers",
+              "description": "The message headers.",
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "data": {
+                  },
+                  "name": {
+                    "type": "string",
+                    "title": "Name",
+                    "description": "The message header name."
+                  },
+                  "resource": {
+                  },
+                  "type": {
+                    "type": "string",
+                    "title": "Type",
+                    "description": "The message header type to create typed message headers.",
+                    "$comment": "group:advanced"
+                  },
+                  "value": {
+                  }
+                },
+                "additionalProperties": false,
+                "anyOf": [
+                  {
+                    "oneOf": [
+                      {
+                        "type": "object",
+                        "properties": {
+                          "value": {
+                            "type": "string",
+                            "title": "Value",
+                            "description": "The message header value."
+                          }
+                        }
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "resource": {
+                            "type": "object",
+                            "properties": {
+                              "charset": {
+                                "type": "string",
+                                "title": "Charset",
+                                "description": "Optional file resource charset used to read the file content.",
+                                "$comment": "group:advanced"
+                              },
+                              "file": {
+                                "type": "string",
+                                "title": "File",
+                                "description": "The file resource path."
+                              }
+                            },
+                            "required": [
+                              "file"
+                            ],
+                            "additionalProperties": false,
+                            "title": "Resource",
+                            "description": "The header data loaded from a file resource."
+                          }
+                        }
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "data": {
+                            "type": "string",
+                            "title": "Data",
+                            "description": "The message header value as inline data."
+                          }
+                        }
+                      }
+                    ]
+                  }
+                ],
+                "title": "Headers",
+                "description": "The message headers."
+              }
+            },
+            "name": {
+              "type": "string",
+              "title": "Name",
+              "description": "The message name. Named messages may be referenced in subsequent test steps."
+            },
+            "schema": {
+              "type": "string",
+              "title": "Schema",
+              "description": "The reference to a schema in the bean registry that should be used for validation.",
+              "$comment": "group:schema"
+            },
+            "schemaRepository": {
+              "type": "string",
+              "title": "SchemaRepository",
+              "description": "The schema repository holding the schema.",
+              "$comment": "group:schema"
+            },
+            "schemaValidation": {
+              "type": "boolean",
+              "title": "SchemaValidation",
+              "description": "Enables the schema validation.",
+              "$comment": "group:schema"
+            },
+            "type": {
+              "type": "string",
+              "title": "Type",
+              "description": "The message type. Gives the validator a hint which validatory are capable of performing proper message validation.",
+              "$comment": "group:advanced"
+            }
+          },
+          "additionalProperties": false,
+          "title": "Message",
+          "description": "The expected message used to validate."
+        },
+        "namespace": {
+          "title": "Namespace",
+          "description": "Optional XML namespace to validate.",
+          "$comment": "group:xml",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "prefix": {
+                "type": "string",
+                "title": "Prefix",
+                "description": "Expected namespace prefix."
+              },
+              "value": {
+                "type": "string",
+                "title": "Value",
+                "description": "Expected namespace value."
+              }
+            },
+            "required": [
+              "prefix",
+              "value"
+            ],
+            "additionalProperties": false,
+            "title": "Namespace",
+            "description": "Optional XML namespace to validate.",
+            "$comment": "group:xml"
+          }
+        },
+        "select": {
+          "type": "string",
+          "title": "Select",
+          "description": "Message select expression to selectively receive a message.",
+          "$comment": "group:selector"
+        },
+        "selector": {
+          "type": "object",
+          "properties": {
+            "element": {
+              "title": "Element",
+              "description": "List of elements to build the selector expression.",
+              "$comment": "group:advanced",
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "title": "Name",
+                    "description": "Select element key name."
+                  },
+                  "value": {
+                    "type": "string",
+                    "title": "Value",
+                    "description": "Select expression value."
+                  }
+                },
+                "required": [
+                  "name",
+                  "value"
+                ],
+                "additionalProperties": false,
+                "title": "Element",
+                "description": "List of elements to build the selector expression.",
+                "$comment": "group:advanced"
+              }
+            },
+            "value": {
+              "type": "string",
+              "title": "Value",
+              "description": "Selector expression value."
+            }
+          },
+          "additionalProperties": false,
+          "title": "Selector",
+          "description": "Message selector used to selectively receive a message.",
+          "$comment": "group:selector"
+        },
+        "timeout": {
+          "type": "integer",
+          "title": "Timeout",
+          "description": "Receive timeout."
+        },
+        "validate": {
+          "title": "Validate",
+          "description": "Validation expressions evaluated on the message.",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "jsonPath": {
+                "title": "JsonPath",
+                "description": "JsonPath validation expression.",
+                "$comment": "group:jsonPath",
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "expression": {
+                      "type": "string",
+                      "title": "Expression",
+                      "description": "The Json path expression to evaluate."
+                    },
+                    "value": {
+                      "type": "string",
+                      "title": "Value",
+                      "description": "The expected result."
+                    }
+                  },
+                  "required": [
+                    "expression",
+                    "value"
+                  ],
+                  "additionalProperties": false,
+                  "title": "JsonPath",
+                  "description": "JsonPath validation expression.",
+                  "$comment": "group:jsonPath"
+                }
+              },
+              "namespace": {
+                "title": "Namespace",
+                "description": "List of expected namespaces.",
+                "$comment": "group:xml",
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "prefix": {
+                      "type": "string",
+                      "title": "Prefix",
+                      "description": "The expected namespace prefix."
+                    },
+                    "value": {
+                      "type": "string",
+                      "title": "Value",
+                      "description": "The expected namespace value."
+                    }
+                  },
+                  "required": [
+                    "prefix",
+                    "value"
+                  ],
+                  "additionalProperties": false,
+                  "title": "Namespace",
+                  "description": "List of expected namespaces.",
+                  "$comment": "group:xml"
+                }
+              },
+              "path": {
+                "type": "string",
+                "title": "Path",
+                "description": "Message validation expression."
+              },
+              "resultType": {
+                "type": "string",
+                "title": "ResultType",
+                "description": "Expected expression result type.",
+                "$comment": "group:advanced"
+              },
+              "script": {
+                "type": "object",
+                "properties": {
+                  "charset": {
+                    "type": "string",
+                    "title": "Charset",
+                    "description": "The charset used to load the file resource.",
+                    "$comment": "group:advanced"
+                  },
+                  "content": {
+                    "type": "string",
+                    "title": "Content",
+                    "description": "The script content as inline data."
+                  },
+                  "file": {
+                    "type": "string",
+                    "title": "File",
+                    "description": "The script content loaded as a file resource."
+                  },
+                  "type": {
+                    "type": "string",
+                    "title": "Type",
+                    "description": "The script type.",
+                    "default": "groovy"
+                  }
+                },
+                "additionalProperties": false,
+                "title": "Script",
+                "description": "Script that builds the expected validate value.",
+                "$comment": "group:script"
+              },
+              "value": {
+                "type": "string",
+                "title": "Value",
+                "description": "Expected message validation expression value."
+              },
+              "xpath": {
+                "title": "Xpath",
+                "description": "Xpath validation expression.",
+                "$comment": "group:xml",
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "expression": {
+                      "type": "string",
+                      "title": "Expression",
+                      "description": "The Xpath expression to evaluate."
+                    },
+                    "resultType": {
+                      "type": "string",
+                      "title": "ResultType",
+                      "description": "The expected result type.",
+                      "$comment": "group:advanced"
+                    },
+                    "value": {
+                      "type": "string",
+                      "title": "Value",
+                      "description": "The expected result."
+                    }
+                  },
+                  "required": [
+                    "expression",
+                    "value"
+                  ],
+                  "additionalProperties": false,
+                  "title": "Xpath",
+                  "description": "Xpath validation expression.",
+                  "$comment": "group:xml"
+                }
+              }
+            },
+            "additionalProperties": false,
+            "title": "Validate",
+            "description": "Validation expressions evaluated on the message."
+          }
+        },
+        "validator": {
+          "type": "string",
+          "title": "Validator",
+          "description": "Explicit message validator.",
+          "$comment": "group:validator"
+        },
+        "validators": {
+          "type": "string",
+          "title": "Validators",
+          "description": "List of message validators used to validate the message.",
+          "$comment": "group:validator"
+        }
+      },
+      "required": [
+        "endpoint",
+        "message"
+      ],
+      "additionalProperties": false    }
+  },
+  "selenium": {
+    "kind": "testActionGroup",
+    "version": "4.10.1",
+    "name": "selenium",
+    "module": "citrus-selenium",
+    "title": "Selenium",
+    "description": "Selenium test actions.",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "actor": {
+          "type": "string",
+          "title": "Actor",
+          "$comment": "group:advanced"
+        },
+        "browser": {
+          "type": "string",
+          "title": "Browser",
+          "description": "Sets the Selenium browser.Uses an endpoint URI or references an endpoint name."
+        },
+        "description": {
+          "type": "string",
+          "title": "Description",
+          "description": "Test action description printed when the action is executed.",
+          "$comment": "group:advanced"
+        }
+      },
+      "additionalProperties": false    }
+  },
+  "selenium-alert": {
+    "kind": "testAction",
+    "version": "4.10.1",
+    "name": "selenium-alert",
+    "group": "selenium",
+    "module": "citrus-selenium",
+    "title": "Alert",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "accept": {
+          "type": "boolean",
+          "title": "Accept"
+        },
+        "dismiss": {
+          "type": "boolean",
+          "title": "Dismiss"
+        },
+        "text": {
+          "type": "string",
+          "title": "Text"
+        }
+      },
+      "additionalProperties": false    }
+  },
+  "selenium-checkInput": {
+    "kind": "testAction",
+    "version": "4.10.1",
+    "name": "selenium-checkInput",
+    "group": "selenium",
+    "module": "citrus-selenium",
+    "title": "CheckInput",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "checked": {
+          "type": "boolean",
+          "title": "Checked"
+        },
+        "element": {
+          "type": "object",
+          "properties": {
+            "className": {
+              "type": "string",
+              "title": "ClassName"
+            },
+            "cssSelector": {
+              "type": "string",
+              "title": "CssSelector"
+            },
+            "id": {
+              "type": "string",
+              "title": "Id"
+            },
+            "linkText": {
+              "type": "string",
+              "title": "LinkText"
+            },
+            "name": {
+              "type": "string",
+              "title": "Name"
+            },
+            "partialLinkText": {
+              "type": "string",
+              "title": "PartialLinkText"
+            },
+            "property": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "title": "Name"
+                },
+                "value": {
+                  "type": "string",
+                  "title": "Value"
+                }
+              },
+              "additionalProperties": false,
+              "title": "Property"
+            },
+            "tagName": {
+              "type": "string",
+              "title": "TagName"
+            },
+            "xpath": {
+              "type": "string",
+              "title": "Xpath"
+            }
+          },
+          "additionalProperties": false,
+          "title": "Element"
+        }
+      },
+      "additionalProperties": false    }
+  },
+  "selenium-clearCache": {
+    "kind": "testAction",
+    "version": "4.10.1",
+    "name": "selenium-clearCache",
+    "group": "selenium",
+    "module": "citrus-selenium",
+    "title": "ClearCache",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "additionalProperties": false    }
+  },
+  "selenium-click": {
+    "kind": "testAction",
+    "version": "4.10.1",
+    "name": "selenium-click",
+    "group": "selenium",
+    "module": "citrus-selenium",
+    "title": "Click",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "element": {
+          "type": "object",
+          "properties": {
+            "className": {
+              "type": "string",
+              "title": "ClassName"
+            },
+            "cssSelector": {
+              "type": "string",
+              "title": "CssSelector"
+            },
+            "id": {
+              "type": "string",
+              "title": "Id"
+            },
+            "linkText": {
+              "type": "string",
+              "title": "LinkText"
+            },
+            "name": {
+              "type": "string",
+              "title": "Name"
+            },
+            "partialLinkText": {
+              "type": "string",
+              "title": "PartialLinkText"
+            },
+            "property": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "title": "Name"
+                },
+                "value": {
+                  "type": "string",
+                  "title": "Value"
+                }
+              },
+              "additionalProperties": false,
+              "title": "Property"
+            },
+            "tagName": {
+              "type": "string",
+              "title": "TagName"
+            },
+            "xpath": {
+              "type": "string",
+              "title": "Xpath"
+            }
+          },
+          "additionalProperties": false,
+          "title": "Element"
+        }
+      },
+      "additionalProperties": false    }
+  },
+  "selenium-closeWindow": {
+    "kind": "testAction",
+    "version": "4.10.1",
+    "name": "selenium-closeWindow",
+    "group": "selenium",
+    "module": "citrus-selenium",
+    "title": "CloseWindow",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "title": "Name"
+        },
+        "window": {
+          "type": "string",
+          "title": "Window"
+        }
+      },
+      "additionalProperties": false    }
+  },
+  "selenium-dropdownSelect": {
+    "kind": "testAction",
+    "version": "4.10.1",
+    "name": "selenium-dropdownSelect",
+    "group": "selenium",
+    "module": "citrus-selenium",
+    "title": "DropdownSelect",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "element": {
+          "type": "object",
+          "properties": {
+            "className": {
+              "type": "string",
+              "title": "ClassName"
+            },
+            "cssSelector": {
+              "type": "string",
+              "title": "CssSelector"
+            },
+            "id": {
+              "type": "string",
+              "title": "Id"
+            },
+            "linkText": {
+              "type": "string",
+              "title": "LinkText"
+            },
+            "name": {
+              "type": "string",
+              "title": "Name"
+            },
+            "partialLinkText": {
+              "type": "string",
+              "title": "PartialLinkText"
+            },
+            "property": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "title": "Name"
+                },
+                "value": {
+                  "type": "string",
+                  "title": "Value"
+                }
+              },
+              "additionalProperties": false,
+              "title": "Property"
+            },
+            "tagName": {
+              "type": "string",
+              "title": "TagName"
+            },
+            "xpath": {
+              "type": "string",
+              "title": "Xpath"
+            }
+          },
+          "additionalProperties": false,
+          "title": "Element"
+        },
+        "option": {
+          "type": "string",
+          "title": "Option"
+        },
+        "options": {
+          "title": "Options",
+          "type": "array",
+          "items": {
+            "type": "string",
+            "title": "Options"
+          }
+        }
+      },
+      "additionalProperties": false    }
+  },
+  "selenium-fillForm": {
+    "kind": "testAction",
+    "version": "4.10.1",
+    "name": "selenium-fillForm",
+    "group": "selenium",
+    "module": "citrus-selenium",
+    "title": "FillForm",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "fields": {
+          "title": "Fields",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "string",
+                "title": "Id"
+              },
+              "value": {
+                "type": "string",
+                "title": "Value"
+              }
+            },
+            "additionalProperties": false,
+            "title": "Fields"
+          }
+        },
+        "json": {
+          "type": "string",
+          "title": "Json"
+        },
+        "submit": {
+          "type": "string",
+          "title": "Submit"
+        }
+      },
+      "additionalProperties": false    }
+  },
+  "selenium-find": {
+    "kind": "testAction",
+    "version": "4.10.1",
+    "name": "selenium-find",
+    "group": "selenium",
+    "module": "citrus-selenium",
+    "title": "Find",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "element": {
+          "type": "object",
+          "properties": {
+            "className": {
+              "type": "string",
+              "title": "ClassName"
+            },
+            "cssSelector": {
+              "type": "string",
+              "title": "CssSelector"
+            },
+            "id": {
+              "type": "string",
+              "title": "Id"
+            },
+            "linkText": {
+              "type": "string",
+              "title": "LinkText"
+            },
+            "name": {
+              "type": "string",
+              "title": "Name"
+            },
+            "partialLinkText": {
+              "type": "string",
+              "title": "PartialLinkText"
+            },
+            "property": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "title": "Name"
+                },
+                "value": {
+                  "type": "string",
+                  "title": "Value"
+                }
+              },
+              "additionalProperties": false,
+              "title": "Property"
+            },
+            "tagName": {
+              "type": "string",
+              "title": "TagName"
+            },
+            "xpath": {
+              "type": "string",
+              "title": "Xpath"
+            }
+          },
+          "additionalProperties": false,
+          "title": "Element"
+        },
+        "validate": {
+          "type": "object",
+          "properties": {
+            "attributes": {
+              "title": "Attributes",
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "title": "Name"
+                  },
+                  "value": {
+                    "type": "string",
+                    "title": "Value"
+                  }
+                },
+                "additionalProperties": false,
+                "title": "Attributes"
+              }
+            },
+            "displayed": {
+              "type": "boolean",
+              "title": "Displayed"
+            },
+            "enabled": {
+              "type": "boolean",
+              "title": "Enabled"
+            },
+            "styles": {
+              "title": "Styles",
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "title": "Name"
+                  },
+                  "value": {
+                    "type": "string",
+                    "title": "Value"
+                  }
+                },
+                "additionalProperties": false,
+                "title": "Styles"
+              }
+            },
+            "tagName": {
+              "type": "string",
+              "title": "TagName"
+            },
+            "text": {
+              "type": "string",
+              "title": "Text"
+            }
+          },
+          "additionalProperties": false,
+          "title": "Validate"
+        }
+      },
+      "additionalProperties": false    }
+  },
+  "selenium-focusWindow": {
+    "kind": "testAction",
+    "version": "4.10.1",
+    "name": "selenium-focusWindow",
+    "group": "selenium",
+    "module": "citrus-selenium",
+    "title": "FocusWindow",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "title": "Name"
+        },
+        "window": {
+          "type": "string",
+          "title": "Window"
+        }
+      },
+      "additionalProperties": false    }
+  },
+  "selenium-getStoredFile": {
+    "kind": "testAction",
+    "version": "4.10.1",
+    "name": "selenium-getStoredFile",
+    "group": "selenium",
+    "module": "citrus-selenium",
+    "title": "GetStoredFile",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "fileName": {
+          "type": "string",
+          "title": "FileName"
+        }
+      },
+      "additionalProperties": false    }
+  },
+  "selenium-hover": {
+    "kind": "testAction",
+    "version": "4.10.1",
+    "name": "selenium-hover",
+    "group": "selenium",
+    "module": "citrus-selenium",
+    "title": "Hover",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "element": {
+          "type": "object",
+          "properties": {
+            "className": {
+              "type": "string",
+              "title": "ClassName"
+            },
+            "cssSelector": {
+              "type": "string",
+              "title": "CssSelector"
+            },
+            "id": {
+              "type": "string",
+              "title": "Id"
+            },
+            "linkText": {
+              "type": "string",
+              "title": "LinkText"
+            },
+            "name": {
+              "type": "string",
+              "title": "Name"
+            },
+            "partialLinkText": {
+              "type": "string",
+              "title": "PartialLinkText"
+            },
+            "property": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "title": "Name"
+                },
+                "value": {
+                  "type": "string",
+                  "title": "Value"
+                }
+              },
+              "additionalProperties": false,
+              "title": "Property"
+            },
+            "tagName": {
+              "type": "string",
+              "title": "TagName"
+            },
+            "xpath": {
+              "type": "string",
+              "title": "Xpath"
+            }
+          },
+          "additionalProperties": false,
+          "title": "Element"
+        }
+      },
+      "additionalProperties": false    }
+  },
+  "selenium-javaScript": {
+    "kind": "testAction",
+    "version": "4.10.1",
+    "name": "selenium-javaScript",
+    "group": "selenium",
+    "module": "citrus-selenium",
+    "title": "JavaScript",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "argument": {
+          "title": "Argument"
+        },
+        "arguments": {
+          "title": "Arguments",
+          "type": "array",
+          "items": {
+            "title": "Arguments"
+          }
+        },
+        "error": {
+          "type": "string",
+          "title": "Error"
+        },
+        "errors": {
+          "title": "Errors",
+          "type": "array",
+          "items": {
+            "type": "string",
+            "title": "Errors"
+          }
+        },
+        "script": {
+          "type": "string",
+          "title": "Script"
+        }
+      },
+      "additionalProperties": false    }
+  },
+  "selenium-navigate": {
+    "kind": "testAction",
+    "version": "4.10.1",
+    "name": "selenium-navigate",
+    "group": "selenium",
+    "module": "citrus-selenium",
+    "title": "Navigate",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "page": {
+          "type": "string",
+          "title": "Page"
+        }
+      },
+      "additionalProperties": false    }
+  },
+  "selenium-openWindow": {
+    "kind": "testAction",
+    "version": "4.10.1",
+    "name": "selenium-openWindow",
+    "group": "selenium",
+    "module": "citrus-selenium",
+    "title": "OpenWindow",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "title": "Name"
+        },
+        "window": {
+          "type": "string",
+          "title": "Window"
+        }
+      },
+      "additionalProperties": false    }
+  },
+  "selenium-page": {
+    "kind": "testAction",
+    "version": "4.10.1",
+    "name": "selenium-page",
+    "group": "selenium",
+    "module": "citrus-selenium",
+    "title": "Page",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "action": {
+          "type": "string",
+          "title": "Action"
+        },
+        "argument": {
+          "type": "string",
+          "title": "Argument"
+        },
+        "arguments": {
+          "title": "Arguments",
+          "type": "array",
+          "items": {
+            "type": "string",
+            "title": "Arguments"
+          }
+        },
+        "execute": {
+          "type": "string",
+          "title": "Execute"
+        },
+        "name": {
+          "type": "string",
+          "title": "Name"
+        },
+        "type": {
+          "type": "string",
+          "title": "Type"
+        },
+        "validator": {
+          "type": "string",
+          "title": "Validator"
+        }
+      },
+      "additionalProperties": false    }
+  },
+  "selenium-screenshot": {
+    "kind": "testAction",
+    "version": "4.10.1",
+    "name": "selenium-screenshot",
+    "group": "selenium",
+    "module": "citrus-selenium",
+    "title": "Screenshot",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "outputDir": {
+          "type": "string",
+          "title": "OutputDir"
+        }
+      },
+      "additionalProperties": false    }
+  },
+  "selenium-setInput": {
+    "kind": "testAction",
+    "version": "4.10.1",
+    "name": "selenium-setInput",
+    "group": "selenium",
+    "module": "citrus-selenium",
+    "title": "SetInput",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "element": {
+          "type": "object",
+          "properties": {
+            "className": {
+              "type": "string",
+              "title": "ClassName"
+            },
+            "cssSelector": {
+              "type": "string",
+              "title": "CssSelector"
+            },
+            "id": {
+              "type": "string",
+              "title": "Id"
+            },
+            "linkText": {
+              "type": "string",
+              "title": "LinkText"
+            },
+            "name": {
+              "type": "string",
+              "title": "Name"
+            },
+            "partialLinkText": {
+              "type": "string",
+              "title": "PartialLinkText"
+            },
+            "property": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "title": "Name"
+                },
+                "value": {
+                  "type": "string",
+                  "title": "Value"
+                }
+              },
+              "additionalProperties": false,
+              "title": "Property"
+            },
+            "tagName": {
+              "type": "string",
+              "title": "TagName"
+            },
+            "xpath": {
+              "type": "string",
+              "title": "Xpath"
+            }
+          },
+          "additionalProperties": false,
+          "title": "Element"
+        },
+        "value": {
+          "type": "string",
+          "title": "Value"
+        }
+      },
+      "additionalProperties": false    }
+  },
+  "selenium-start": {
+    "kind": "testAction",
+    "version": "4.10.1",
+    "name": "selenium-start",
+    "group": "selenium",
+    "module": "citrus-selenium",
+    "title": "Start",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "allowAlreadyStarted": {
+          "type": "boolean",
+          "title": "AllowAlreadyStarted"
+        },
+        "browser": {
+          "type": "string",
+          "title": "Browser",
+          "description": "Sets the Selenium browser.Uses an endpoint URI or references an endpoint name."
+        }
+      },
+      "additionalProperties": false    }
+  },
+  "selenium-stop": {
+    "kind": "testAction",
+    "version": "4.10.1",
+    "name": "selenium-stop",
+    "group": "selenium",
+    "module": "citrus-selenium",
+    "title": "Stop",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "browser": {
+          "type": "string",
+          "title": "Browser",
+          "description": "Sets the Selenium browser.Uses an endpoint URI or references an endpoint name."
+        }
+      },
+      "additionalProperties": false    }
+  },
+  "selenium-storeFile": {
+    "kind": "testAction",
+    "version": "4.10.1",
+    "name": "selenium-storeFile",
+    "group": "selenium",
+    "module": "citrus-selenium",
+    "title": "StoreFile",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "filePath": {
+          "type": "string",
+          "title": "FilePath"
+        }
+      },
+      "additionalProperties": false    }
+  },
+  "selenium-switchWindow": {
+    "kind": "testAction",
+    "version": "4.10.1",
+    "name": "selenium-switchWindow",
+    "group": "selenium",
+    "module": "citrus-selenium",
+    "title": "SwitchWindow",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "title": "Name"
+        },
+        "window": {
+          "type": "string",
+          "title": "Window"
+        }
+      },
+      "additionalProperties": false    }
+  },
+  "selenium-waitUntil": {
+    "kind": "testAction",
+    "version": "4.10.1",
+    "name": "selenium-waitUntil",
+    "group": "selenium",
+    "module": "citrus-selenium",
+    "title": "WaitUntil",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "condition": {
+          "type": "string",
+          "title": "Condition"
+        },
+        "element": {
+          "type": "object",
+          "properties": {
+            "className": {
+              "type": "string",
+              "title": "ClassName"
+            },
+            "cssSelector": {
+              "type": "string",
+              "title": "CssSelector"
+            },
+            "id": {
+              "type": "string",
+              "title": "Id"
+            },
+            "linkText": {
+              "type": "string",
+              "title": "LinkText"
+            },
+            "name": {
+              "type": "string",
+              "title": "Name"
+            },
+            "partialLinkText": {
+              "type": "string",
+              "title": "PartialLinkText"
+            },
+            "property": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "title": "Name"
+                },
+                "value": {
+                  "type": "string",
+                  "title": "Value"
+                }
+              },
+              "additionalProperties": false,
+              "title": "Property"
+            },
+            "tagName": {
+              "type": "string",
+              "title": "TagName"
+            },
+            "xpath": {
+              "type": "string",
+              "title": "Xpath"
+            }
+          },
+          "additionalProperties": false,
+          "title": "Element"
+        },
+        "timeout": {
+          "type": "integer",
+          "title": "Timeout"
+        },
+        "until": {
+          "type": "string",
+          "title": "Until"
+        }
+      },
+      "additionalProperties": false    }
+  },
+  "send": {
+    "kind": "testAction",
+    "version": "4.10.1",
+    "name": "send",
+    "title": "Send",
+    "description": "Send message test action.",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "actor": {
+          "type": "string",
+          "title": "Actor",
+          "$comment": "group:advanced"
+        },
+        "description": {
+          "type": "string",
+          "title": "Description",
+          "description": "Test action description printed when the action is executed.",
+          "$comment": "group:advanced"
+        },
+        "endpoint": {
+          "type": "string",
+          "title": "Endpoint",
+          "description": "The message endpoint name or URI. Uses an endpoint URI or references an endpoint name."
+        },
+        "extract": {
+          "type": "object",
+          "properties": {
+            "body": {
+              "title": "Body",
+              "description": "Extract elements from the message body into test variables.",
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "path": {
+                    "type": "string",
+                    "title": "Path",
+                    "description": "The path expression to evaluate."
+                  },
+                  "resultType": {
+                    "type": "string",
+                    "title": "ResultType",
+                    "description": "The expression result type. By default the path expression evaluate to String values.With this setting you can force another expression result type.",
+                    "$comment": "group:advanced"
+                  },
+                  "variable": {
+                    "type": "string",
+                    "title": "Variable",
+                    "description": "The test variable name."
+                  }
+                },
+                "required": [
+                  "variable"
+                ],
+                "additionalProperties": false,
+                "title": "Body",
+                "description": "Extract elements from the message body into test variables."
+              }
+            },
+            "header": {
+              "title": "Header",
+              "description": "Extract elements from the message header into test variables.",
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "title": "Name",
+                    "description": "The name of the message header."
+                  },
+                  "variable": {
+                    "type": "string",
+                    "title": "Variable",
+                    "description": "The test variable name."
+                  }
+                },
+                "required": [
+                  "name",
+                  "variable"
+                ],
+                "additionalProperties": false,
+                "title": "Header",
+                "description": "Extract elements from the message header into test variables."
+              }
+            }
+          },
+          "additionalProperties": false,
+          "title": "Extract",
+          "description": "Extract message content to test variables before the message is sent.",
+          "$comment": "group:extract"
+        },
+        "fork": {
+          "type": "boolean",
+          "title": "Fork",
+          "description": "When set the send operation does not block while waiting for the response."
+        },
+        "message": {
+          "type": "object",
+          "properties": {
+            "body": {
+              "type": "object",
+              "properties": {
+                "data": {
+                },
+                "resource": {
+                },
+                "script": {
+                }
+              },
+              "additionalProperties": false,
+              "anyOf": [
+                {
+                  "oneOf": [
+                    {
+                      "type": "object",
+                      "properties": {
+                        "data": {
+                          "type": "string",
+                          "title": "Data",
+                          "description": "The message body content as inline data."
+                        }
+                      }
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "resource": {
+                          "type": "object",
+                          "properties": {
+                            "charset": {
+                              "type": "string",
+                              "title": "Charset",
+                              "$comment": "group:advanced"
+                            },
+                            "file": {
+                              "type": "string",
+                              "title": "File"
+                            }
+                          },
+                          "additionalProperties": false,
+                          "title": "Resource",
+                          "description": "The message body loaded from a file resource."
+                        }
+                      }
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "script": {
+                          "type": "object",
+                          "properties": {
+                            "charset": {
+                              "type": "string",
+                              "title": "Charset",
+                              "description": "The charset used to load the file resource.",
+                              "$comment": "group:advanced"
+                            },
+                            "content": {
+                              "type": "string",
+                              "title": "Content",
+                              "description": "The script content as inline data."
+                            },
+                            "file": {
+                              "type": "string",
+                              "title": "File",
+                              "description": "The script content loaded as a file resource."
+                            },
+                            "type": {
+                              "type": "string",
+                              "title": "Type",
+                              "description": "The script type.",
+                              "default": "groovy"
+                            }
+                          },
+                          "additionalProperties": false,
+                          "title": "Script",
+                          "description": "The message body set via script."
+                        }
+                      }
+                    }
+                  ]
+                }
+              ],
+              "title": "Body",
+              "description": "The message body."
+            },
+            "dataDictionary": {
+              "type": "string",
+              "title": "DataDictionary",
+              "description": "Sets a data dictionary that transforms message content before it is being processed.",
+              "$comment": "group:dictionary"
+            },
+            "expression": {
+              "title": "Expression",
+              "description": "List of path expressions to evaluate on the message content before processing the message.",
+              "$comment": "group:advanced",
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "path": {
+                    "type": "string",
+                    "title": "Path",
+                    "description": "The path expression to evaluate."
+                  },
+                  "value": {
+                    "type": "string",
+                    "title": "Value",
+                    "description": "The expected expression result value."
+                  }
+                },
+                "required": [
+                  "path",
+                  "value"
+                ],
+                "additionalProperties": false,
+                "title": "Expression",
+                "description": "List of path expressions to evaluate on the message content before processing the message.",
+                "$comment": "group:advanced"
+              }
+            },
+            "headerIgnoreCase": {
+              "type": "string",
+              "title": "HeaderIgnoreCase",
+              "description": "When enabled the header case is not verified.",
+              "$comment": "group:advanced"
+            },
+            "headers": {
+              "title": "Headers",
+              "description": "The message headers.",
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "data": {
+                  },
+                  "name": {
+                    "type": "string",
+                    "title": "Name",
+                    "description": "The message header name."
+                  },
+                  "resource": {
+                  },
+                  "type": {
+                    "type": "string",
+                    "title": "Type",
+                    "description": "The message header type to create typed message headers.",
+                    "$comment": "group:advanced"
+                  },
+                  "value": {
+                  }
+                },
+                "additionalProperties": false,
+                "anyOf": [
+                  {
+                    "oneOf": [
+                      {
+                        "type": "object",
+                        "properties": {
+                          "value": {
+                            "type": "string",
+                            "title": "Value",
+                            "description": "The message header value."
+                          }
+                        }
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "resource": {
+                            "type": "object",
+                            "properties": {
+                              "charset": {
+                                "type": "string",
+                                "title": "Charset",
+                                "description": "Optional file resource charset used to read the file content.",
+                                "$comment": "group:advanced"
+                              },
+                              "file": {
+                                "type": "string",
+                                "title": "File",
+                                "description": "The file resource path."
+                              }
+                            },
+                            "required": [
+                              "file"
+                            ],
+                            "additionalProperties": false,
+                            "title": "Resource",
+                            "description": "The header data loaded from a file resource."
+                          }
+                        }
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "data": {
+                            "type": "string",
+                            "title": "Data",
+                            "description": "The message header value as inline data."
+                          }
+                        }
+                      }
+                    ]
+                  }
+                ],
+                "title": "Headers",
+                "description": "The message headers."
+              }
+            },
+            "name": {
+              "type": "string",
+              "title": "Name",
+              "description": "The message name. Named messages may be referenced in subsequent test steps."
+            },
+            "schema": {
+              "type": "string",
+              "title": "Schema",
+              "description": "The reference to a schema in the bean registry that should be used for validation.",
+              "$comment": "group:schema"
+            },
+            "schemaRepository": {
+              "type": "string",
+              "title": "SchemaRepository",
+              "description": "The schema repository holding the schema.",
+              "$comment": "group:schema"
+            },
+            "schemaValidation": {
+              "type": "boolean",
+              "title": "SchemaValidation",
+              "description": "Enables the schema validation.",
+              "$comment": "group:schema"
+            },
+            "type": {
+              "type": "string",
+              "title": "Type",
+              "description": "The message type. Gives the validator a hint which validatory are capable of performing proper message validation.",
+              "$comment": "group:advanced"
+            }
+          },
+          "additionalProperties": false,
+          "title": "Message",
+          "description": "The message to send."
+        }
+      },
+      "required": [
+        "endpoint"
+      ],
+      "additionalProperties": false    }
+  },
+  "sleep": {
+    "kind": "testAction",
+    "version": "4.10.1",
+    "name": "sleep",
+    "title": "Sleep",
+    "description": "Sleep test action.",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "description": {
+          "type": "string",
+          "title": "Description",
+          "description": "Test action description printed when the action is executed.",
+          "$comment": "group:advanced"
+        },
+        "milliseconds": {
+          "type": "string",
+          "title": "Milliseconds",
+          "description": "Time to sleep in milliseconds."
+        },
+        "seconds": {
+          "type": "string",
+          "title": "Seconds",
+          "description": "Time to sleep in seconds."
+        }
+      },
+      "additionalProperties": false    }
+  },
+  "soap": {
+    "kind": "testActionGroup",
+    "version": "4.10.1",
+    "name": "soap",
+    "module": "citrus-ws",
+    "title": "Soap",
+    "description": "SOAP Web Services related test actions.",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "actor": {
+          "type": "string",
+          "title": "Actor",
+          "$comment": "group:advanced"
+        },
+        "client": {
+          "type": "string",
+          "title": "Client",
+          "description": "Sets the SOAP Http client. Uses an endpoint URI or references an endpoint name."
+        },
+        "description": {
+          "type": "string",
+          "title": "Description",
+          "description": "Test action description printed when the action is executed.",
+          "$comment": "group:advanced"
+        },
+        "server": {
+          "type": "string",
+          "title": "Server",
+          "description": "Sets the SOAP Http server."
+        }
+      },
+      "additionalProperties": false    }
+  },
+  "soap-receiveRequest": {
+    "kind": "testAction",
+    "version": "4.10.1",
+    "name": "soap-receiveRequest",
+    "group": "soap",
+    "module": "citrus-ws",
+    "title": "ReceiveRequest",
+    "description": "Receives a SOAP request as a server.",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "attachmentValidator": {
+          "type": "string",
+          "title": "AttachmentValidator",
+          "description": "Explicit SOAP attachment validator.",
+          "$comment": "group:advanced"
+        },
+        "extract": {
+          "type": "object",
+          "properties": {
+            "body": {
+              "title": "Body",
+              "description": "Extract elements from the message body into test variables.",
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "path": {
+                    "type": "string",
+                    "title": "Path",
+                    "description": "The path expression to evaluate."
+                  },
+                  "resultType": {
+                    "type": "string",
+                    "title": "ResultType",
+                    "description": "The expression result type. By default the path expression evaluate to String values.With this setting you can force another expression result type.",
+                    "$comment": "group:advanced"
+                  },
+                  "variable": {
+                    "type": "string",
+                    "title": "Variable",
+                    "description": "The test variable name."
+                  }
+                },
+                "required": [
+                  "variable"
+                ],
+                "additionalProperties": false,
+                "title": "Body",
+                "description": "Extract elements from the message body into test variables."
+              }
+            },
+            "header": {
+              "title": "Header",
+              "description": "Extract elements from the message header into test variables.",
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "title": "Name",
+                    "description": "The name of the message header."
+                  },
+                  "variable": {
+                    "type": "string",
+                    "title": "Variable",
+                    "description": "The test variable name."
+                  }
+                },
+                "required": [
+                  "name",
+                  "variable"
+                ],
+                "additionalProperties": false,
+                "title": "Header",
+                "description": "Extract elements from the message header into test variables."
+              }
+            }
+          },
+          "additionalProperties": false,
+          "title": "Extract",
+          "description": "Extract message content to test variables.",
+          "$comment": "group:advanced"
+        },
+        "headerValidator": {
+          "type": "string",
+          "title": "HeaderValidator",
+          "description": "Explicit message header validator.",
+          "$comment": "group:advanced"
+        },
+        "headerValidators": {
+          "type": "string",
+          "title": "HeaderValidators",
+          "description": "List of message header validators used to validate the message.",
+          "$comment": "group:advanced"
+        },
+        "message": {
+          "type": "object",
+          "properties": {
+            "accept": {
+              "type": "string",
+              "title": "Accept",
+              "description": "The SOAP request accept header.",
+              "$comment": "group:advanced"
+            },
+            "attachments": {
+              "title": "Attachments",
+              "description": "List of SOAP attachments for this message.",
+              "$comment": "group:advanced",
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "charset": {
+                    "type": "string",
+                    "title": "Charset",
+                    "description": "The SOAP attachment charset.",
+                    "$comment": "group:advanced"
+                  },
+                  "content": {
+                    "type": "string",
+                    "title": "Content",
+                    "description": "The SOAP attachment content."
+                  },
+                  "contentId": {
+                    "type": "string",
+                    "title": "ContentId",
+                    "description": "The SOAP attachment content id."
+                  },
+                  "contentType": {
+                    "type": "string",
+                    "title": "ContentType",
+                    "description": "The SOAP attachment content type"
+                  },
+                  "resource": {
+                    "type": "string",
+                    "title": "Resource",
+                    "description": "The SOAP attachment content loaded from a file resource."
+                  }
+                },
+                "additionalProperties": false,
+                "title": "Attachments",
+                "description": "List of SOAP attachments for this message.",
+                "$comment": "group:advanced"
+              }
+            },
+            "body": {
+              "type": "object",
+              "properties": {
+                "data": {
+                },
+                "resource": {
+                },
+                "script": {
+                }
+              },
+              "additionalProperties": false,
+              "anyOf": [
+                {
+                  "oneOf": [
+                    {
+                      "type": "object",
+                      "properties": {
+                        "data": {
+                          "type": "string",
+                          "title": "Data",
+                          "description": "The message body content as inline data."
+                        }
+                      }
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "resource": {
+                          "type": "object",
+                          "properties": {
+                            "charset": {
+                              "type": "string",
+                              "title": "Charset",
+                              "$comment": "group:advanced"
+                            },
+                            "file": {
+                              "type": "string",
+                              "title": "File"
+                            }
+                          },
+                          "additionalProperties": false,
+                          "title": "Resource",
+                          "description": "The message body loaded from a file resource."
+                        }
+                      }
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "script": {
+                          "type": "object",
+                          "properties": {
+                            "charset": {
+                              "type": "string",
+                              "title": "Charset",
+                              "description": "The charset used to load the file resource.",
+                              "$comment": "group:advanced"
+                            },
+                            "content": {
+                              "type": "string",
+                              "title": "Content",
+                              "description": "The script content as inline data."
+                            },
+                            "file": {
+                              "type": "string",
+                              "title": "File",
+                              "description": "The script content loaded as a file resource."
+                            },
+                            "type": {
+                              "type": "string",
+                              "title": "Type",
+                              "description": "The script type.",
+                              "default": "groovy"
+                            }
+                          },
+                          "additionalProperties": false,
+                          "title": "Script",
+                          "description": "The message body set via script."
+                        }
+                      }
+                    }
+                  ]
+                }
+              ],
+              "title": "Body",
+              "description": "The message body."
+            },
+            "contentType": {
+              "type": "string",
+              "title": "ContentType",
+              "description": "The SOAP request content type."
+            },
+            "dataDictionary": {
+              "type": "string",
+              "title": "DataDictionary",
+              "description": "Sets a data dictionary that transforms message content before it is being processed.",
+              "$comment": "group:dictionary"
+            },
+            "expression": {
+              "title": "Expression",
+              "description": "List of path expressions to evaluate on the message content before processing the message.",
+              "$comment": "group:advanced",
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "path": {
+                    "type": "string",
+                    "title": "Path",
+                    "description": "The path expression to evaluate."
+                  },
+                  "value": {
+                    "type": "string",
+                    "title": "Value",
+                    "description": "The expected expression result value."
+                  }
+                },
+                "required": [
+                  "path",
+                  "value"
+                ],
+                "additionalProperties": false,
+                "title": "Expression",
+                "description": "List of path expressions to evaluate on the message content before processing the message.",
+                "$comment": "group:advanced"
+              }
+            },
+            "headerIgnoreCase": {
+              "type": "string",
+              "title": "HeaderIgnoreCase",
+              "description": "When enabled the header case is not verified.",
+              "$comment": "group:advanced"
+            },
+            "headers": {
+              "title": "Headers",
+              "description": "The message headers.",
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "data": {
+                  },
+                  "name": {
+                    "type": "string",
+                    "title": "Name",
+                    "description": "The message header name."
+                  },
+                  "resource": {
+                  },
+                  "type": {
+                    "type": "string",
+                    "title": "Type",
+                    "description": "The message header type to create typed message headers.",
+                    "$comment": "group:advanced"
+                  },
+                  "value": {
+                  }
+                },
+                "additionalProperties": false,
+                "anyOf": [
+                  {
+                    "oneOf": [
+                      {
+                        "type": "object",
+                        "properties": {
+                          "value": {
+                            "type": "string",
+                            "title": "Value",
+                            "description": "The message header value."
+                          }
+                        }
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "resource": {
+                            "type": "object",
+                            "properties": {
+                              "charset": {
+                                "type": "string",
+                                "title": "Charset",
+                                "description": "Optional file resource charset used to read the file content.",
+                                "$comment": "group:advanced"
+                              },
+                              "file": {
+                                "type": "string",
+                                "title": "File",
+                                "description": "The file resource path."
+                              }
+                            },
+                            "required": [
+                              "file"
+                            ],
+                            "additionalProperties": false,
+                            "title": "Resource",
+                            "description": "The header data loaded from a file resource."
+                          }
+                        }
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "data": {
+                            "type": "string",
+                            "title": "Data",
+                            "description": "The message header value as inline data."
+                          }
+                        }
+                      }
+                    ]
+                  }
+                ],
+                "title": "Headers",
+                "description": "The message headers."
+              }
+            },
+            "mtomEnabled": {
+              "type": "boolean",
+              "title": "MtomEnabled",
+              "description": "Enables SOAP MTOM.",
+              "$comment": "group:advanced"
+            },
+            "name": {
+              "type": "string",
+              "title": "Name",
+              "description": "The message name. Named messages may be referenced in subsequent test steps."
+            },
+            "path": {
+              "type": "string",
+              "title": "Path",
+              "description": "The SOAP request path."
+            },
+            "schema": {
+              "type": "string",
+              "title": "Schema",
+              "description": "The reference to a schema in the bean registry that should be used for validation.",
+              "$comment": "group:schema"
+            },
+            "schemaRepository": {
+              "type": "string",
+              "title": "SchemaRepository",
+              "description": "The schema repository holding the schema.",
+              "$comment": "group:schema"
+            },
+            "schemaValidation": {
+              "type": "boolean",
+              "title": "SchemaValidation",
+              "description": "Enables the schema validation.",
+              "$comment": "group:schema"
+            },
+            "soapAction": {
+              "type": "string",
+              "title": "SoapAction",
+              "description": "The SOAP action."
+            },
+            "type": {
+              "type": "string",
+              "title": "Type",
+              "description": "The message type. Gives the validator a hint which validatory are capable of performing proper message validation.",
+              "$comment": "group:advanced"
+            },
+            "version": {
+              "type": "string",
+              "title": "Version",
+              "description": "The SOAP version.",
+              "$comment": "group:advanced"
+            }
+          },
+          "additionalProperties": false,
+          "title": "Message",
+          "description": "The expected SOAP request message."
+        },
+        "select": {
+          "type": "string",
+          "title": "Select",
+          "description": "Message selector expression to selectively consume messages.",
+          "$comment": "group:advanced"
+        },
+        "selector": {
+          "type": "object",
+          "properties": {
+            "element": {
+              "title": "Element",
+              "description": "List of elements to build the selector expression.",
+              "$comment": "group:advanced",
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "title": "Name",
+                    "description": "Select element key name."
+                  },
+                  "value": {
+                    "type": "string",
+                    "title": "Value",
+                    "description": "Select expression value."
+                  }
+                },
+                "required": [
+                  "name",
+                  "value"
+                ],
+                "additionalProperties": false,
+                "title": "Element",
+                "description": "List of elements to build the selector expression.",
+                "$comment": "group:advanced"
+              }
+            },
+            "value": {
+              "type": "string",
+              "title": "Value",
+              "description": "Selector expression value."
+            }
+          },
+          "additionalProperties": false,
+          "title": "Selector",
+          "description": "Message selector to selectively consume messages.",
+          "$comment": "group:advanced"
+        },
+        "timeout": {
+          "type": "integer",
+          "title": "Timeout",
+          "description": "Timeout while waiting for the incoming SOAP request."
+        },
+        "validator": {
+          "type": "string",
+          "title": "Validator",
+          "description": "Explicit message validator.",
+          "$comment": "group:advanced"
+        },
+        "validators": {
+          "type": "string",
+          "title": "Validators",
+          "description": "List of message validators used to validate the message.",
+          "$comment": "group:advanced"
+        }
+      },
+      "required": [
+        "message"
+      ],
+      "additionalProperties": false    }
+  },
+  "soap-receiveResponse": {
+    "kind": "testAction",
+    "version": "4.10.1",
+    "name": "soap-receiveResponse",
+    "group": "soap",
+    "module": "citrus-ws",
+    "title": "ReceiveResponse",
+    "description": "Receives a SOAP response as a client.",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "attachmentValidator": {
+          "type": "string",
+          "title": "AttachmentValidator",
+          "description": "Explicit SOAP attachment validator.",
+          "$comment": "group:advanced"
+        },
+        "extract": {
+          "type": "object",
+          "properties": {
+            "body": {
+              "title": "Body",
+              "description": "Extract elements from the message body into test variables.",
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "path": {
+                    "type": "string",
+                    "title": "Path",
+                    "description": "The path expression to evaluate."
+                  },
+                  "resultType": {
+                    "type": "string",
+                    "title": "ResultType",
+                    "description": "The expression result type. By default the path expression evaluate to String values.With this setting you can force another expression result type.",
+                    "$comment": "group:advanced"
+                  },
+                  "variable": {
+                    "type": "string",
+                    "title": "Variable",
+                    "description": "The test variable name."
+                  }
+                },
+                "required": [
+                  "variable"
+                ],
+                "additionalProperties": false,
+                "title": "Body",
+                "description": "Extract elements from the message body into test variables."
+              }
+            },
+            "header": {
+              "title": "Header",
+              "description": "Extract elements from the message header into test variables.",
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "title": "Name",
+                    "description": "The name of the message header."
+                  },
+                  "variable": {
+                    "type": "string",
+                    "title": "Variable",
+                    "description": "The test variable name."
+                  }
+                },
+                "required": [
+                  "name",
+                  "variable"
+                ],
+                "additionalProperties": false,
+                "title": "Header",
+                "description": "Extract elements from the message header into test variables."
+              }
+            }
+          },
+          "additionalProperties": false,
+          "title": "Extract",
+          "description": "Extract message content to test variables.",
+          "$comment": "group:advanced"
+        },
+        "headerValidator": {
+          "type": "string",
+          "title": "HeaderValidator",
+          "description": "Explicit message header validator.",
+          "$comment": "group:advanced"
+        },
+        "headerValidators": {
+          "type": "string",
+          "title": "HeaderValidators",
+          "description": "List of message header validators used to validate the message.",
+          "$comment": "group:advanced"
+        },
+        "message": {
+          "type": "object",
+          "properties": {
+            "attachments": {
+              "title": "Attachments",
+              "description": "List of SOAP attachments for this message.",
+              "$comment": "group:advanced",
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "charset": {
+                    "type": "string",
+                    "title": "Charset",
+                    "description": "The SOAP attachment charset.",
+                    "$comment": "group:advanced"
+                  },
+                  "content": {
+                    "type": "string",
+                    "title": "Content",
+                    "description": "The SOAP attachment content."
+                  },
+                  "contentId": {
+                    "type": "string",
+                    "title": "ContentId",
+                    "description": "The SOAP attachment content id."
+                  },
+                  "contentType": {
+                    "type": "string",
+                    "title": "ContentType",
+                    "description": "The SOAP attachment content type"
+                  },
+                  "resource": {
+                    "type": "string",
+                    "title": "Resource",
+                    "description": "The SOAP attachment content loaded from a file resource."
+                  }
+                },
+                "additionalProperties": false,
+                "title": "Attachments",
+                "description": "List of SOAP attachments for this message.",
+                "$comment": "group:advanced"
+              }
+            },
+            "body": {
+              "type": "object",
+              "properties": {
+                "data": {
+                },
+                "resource": {
+                },
+                "script": {
+                }
+              },
+              "additionalProperties": false,
+              "anyOf": [
+                {
+                  "oneOf": [
+                    {
+                      "type": "object",
+                      "properties": {
+                        "data": {
+                          "type": "string",
+                          "title": "Data",
+                          "description": "The message body content as inline data."
+                        }
+                      }
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "resource": {
+                          "type": "object",
+                          "properties": {
+                            "charset": {
+                              "type": "string",
+                              "title": "Charset",
+                              "$comment": "group:advanced"
+                            },
+                            "file": {
+                              "type": "string",
+                              "title": "File"
+                            }
+                          },
+                          "additionalProperties": false,
+                          "title": "Resource",
+                          "description": "The message body loaded from a file resource."
+                        }
+                      }
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "script": {
+                          "type": "object",
+                          "properties": {
+                            "charset": {
+                              "type": "string",
+                              "title": "Charset",
+                              "description": "The charset used to load the file resource.",
+                              "$comment": "group:advanced"
+                            },
+                            "content": {
+                              "type": "string",
+                              "title": "Content",
+                              "description": "The script content as inline data."
+                            },
+                            "file": {
+                              "type": "string",
+                              "title": "File",
+                              "description": "The script content loaded as a file resource."
+                            },
+                            "type": {
+                              "type": "string",
+                              "title": "Type",
+                              "description": "The script type.",
+                              "default": "groovy"
+                            }
+                          },
+                          "additionalProperties": false,
+                          "title": "Script",
+                          "description": "The message body set via script."
+                        }
+                      }
+                    }
+                  ]
+                }
+              ],
+              "title": "Body",
+              "description": "The message body."
+            },
+            "contentType": {
+              "type": "string",
+              "title": "ContentType",
+              "description": "The SOAP response content type."
+            },
+            "dataDictionary": {
+              "type": "string",
+              "title": "DataDictionary",
+              "description": "Sets a data dictionary that transforms message content before it is being processed.",
+              "$comment": "group:dictionary"
+            },
+            "expression": {
+              "title": "Expression",
+              "description": "List of path expressions to evaluate on the message content before processing the message.",
+              "$comment": "group:advanced",
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "path": {
+                    "type": "string",
+                    "title": "Path",
+                    "description": "The path expression to evaluate."
+                  },
+                  "value": {
+                    "type": "string",
+                    "title": "Value",
+                    "description": "The expected expression result value."
+                  }
+                },
+                "required": [
+                  "path",
+                  "value"
+                ],
+                "additionalProperties": false,
+                "title": "Expression",
+                "description": "List of path expressions to evaluate on the message content before processing the message.",
+                "$comment": "group:advanced"
+              }
+            },
+            "headerIgnoreCase": {
+              "type": "string",
+              "title": "HeaderIgnoreCase",
+              "description": "When enabled the header case is not verified.",
+              "$comment": "group:advanced"
+            },
+            "headers": {
+              "title": "Headers",
+              "description": "The message headers.",
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "data": {
+                  },
+                  "name": {
+                    "type": "string",
+                    "title": "Name",
+                    "description": "The message header name."
+                  },
+                  "resource": {
+                  },
+                  "type": {
+                    "type": "string",
+                    "title": "Type",
+                    "description": "The message header type to create typed message headers.",
+                    "$comment": "group:advanced"
+                  },
+                  "value": {
+                  }
+                },
+                "additionalProperties": false,
+                "anyOf": [
+                  {
+                    "oneOf": [
+                      {
+                        "type": "object",
+                        "properties": {
+                          "value": {
+                            "type": "string",
+                            "title": "Value",
+                            "description": "The message header value."
+                          }
+                        }
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "resource": {
+                            "type": "object",
+                            "properties": {
+                              "charset": {
+                                "type": "string",
+                                "title": "Charset",
+                                "description": "Optional file resource charset used to read the file content.",
+                                "$comment": "group:advanced"
+                              },
+                              "file": {
+                                "type": "string",
+                                "title": "File",
+                                "description": "The file resource path."
+                              }
+                            },
+                            "required": [
+                              "file"
+                            ],
+                            "additionalProperties": false,
+                            "title": "Resource",
+                            "description": "The header data loaded from a file resource."
+                          }
+                        }
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "data": {
+                            "type": "string",
+                            "title": "Data",
+                            "description": "The message header value as inline data."
+                          }
+                        }
+                      }
+                    ]
+                  }
+                ],
+                "title": "Headers",
+                "description": "The message headers."
+              }
+            },
+            "name": {
+              "type": "string",
+              "title": "Name",
+              "description": "The message name. Named messages may be referenced in subsequent test steps."
+            },
+            "reasonPhrase": {
+              "type": "string",
+              "title": "ReasonPhrase",
+              "description": "The SOAP response reason phrase.",
+              "$comment": "group:advanced"
+            },
+            "schema": {
+              "type": "string",
+              "title": "Schema",
+              "description": "The reference to a schema in the bean registry that should be used for validation.",
+              "$comment": "group:schema"
+            },
+            "schemaRepository": {
+              "type": "string",
+              "title": "SchemaRepository",
+              "description": "The schema repository holding the schema.",
+              "$comment": "group:schema"
+            },
+            "schemaValidation": {
+              "type": "boolean",
+              "title": "SchemaValidation",
+              "description": "Enables the schema validation.",
+              "$comment": "group:schema"
+            },
+            "status": {
+              "type": "string",
+              "title": "Status",
+              "description": "The SOAP response status."
+            },
+            "type": {
+              "type": "string",
+              "title": "Type",
+              "description": "The message type. Gives the validator a hint which validatory are capable of performing proper message validation.",
+              "$comment": "group:advanced"
+            },
+            "version": {
+              "type": "string",
+              "title": "Version",
+              "description": "The SOAP version.",
+              "$comment": "group:advanced"
+            }
+          },
+          "additionalProperties": false,
+          "title": "Message",
+          "description": "The expected SOAP response message."
+        },
+        "select": {
+          "type": "string",
+          "title": "Select",
+          "description": "Message selector to selectively consume messages.",
+          "$comment": "group:advanced"
+        },
+        "selector": {
+          "type": "object",
+          "properties": {
+            "element": {
+              "title": "Element",
+              "description": "List of elements to build the selector expression.",
+              "$comment": "group:advanced",
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "title": "Name",
+                    "description": "Select element key name."
+                  },
+                  "value": {
+                    "type": "string",
+                    "title": "Value",
+                    "description": "Select expression value."
+                  }
+                },
+                "required": [
+                  "name",
+                  "value"
+                ],
+                "additionalProperties": false,
+                "title": "Element",
+                "description": "List of elements to build the selector expression.",
+                "$comment": "group:advanced"
+              }
+            },
+            "value": {
+              "type": "string",
+              "title": "Value",
+              "description": "Selector expression value."
+            }
+          },
+          "additionalProperties": false,
+          "title": "Selector",
+          "description": "Message selector to selectively consume messages.",
+          "$comment": "group:advanced"
+        },
+        "timeout": {
+          "type": "integer",
+          "title": "Timeout",
+          "description": "Timeout while waiting for the SOAP response message."
+        },
+        "validate": {
+          "title": "Validate",
+          "description": "Message validation expressions.",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "jsonPath": {
+                "title": "JsonPath",
+                "description": "JsonPath validation expression.",
+                "$comment": "group:jsonPath",
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "expression": {
+                      "type": "string",
+                      "title": "Expression",
+                      "description": "The Json path expression to evaluate."
+                    },
+                    "value": {
+                      "type": "string",
+                      "title": "Value",
+                      "description": "The expected result."
+                    }
+                  },
+                  "required": [
+                    "expression",
+                    "value"
+                  ],
+                  "additionalProperties": false,
+                  "title": "JsonPath",
+                  "description": "JsonPath validation expression.",
+                  "$comment": "group:jsonPath"
+                }
+              },
+              "namespace": {
+                "title": "Namespace",
+                "description": "List of expected namespaces.",
+                "$comment": "group:xml",
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "prefix": {
+                      "type": "string",
+                      "title": "Prefix",
+                      "description": "The expected namespace prefix."
+                    },
+                    "value": {
+                      "type": "string",
+                      "title": "Value",
+                      "description": "The expected namespace value."
+                    }
+                  },
+                  "required": [
+                    "prefix",
+                    "value"
+                  ],
+                  "additionalProperties": false,
+                  "title": "Namespace",
+                  "description": "List of expected namespaces.",
+                  "$comment": "group:xml"
+                }
+              },
+              "path": {
+                "type": "string",
+                "title": "Path",
+                "description": "Message validation expression."
+              },
+              "resultType": {
+                "type": "string",
+                "title": "ResultType",
+                "description": "Expected expression result type.",
+                "$comment": "group:advanced"
+              },
+              "script": {
+                "type": "object",
+                "properties": {
+                  "charset": {
+                    "type": "string",
+                    "title": "Charset",
+                    "description": "The charset used to load the file resource.",
+                    "$comment": "group:advanced"
+                  },
+                  "content": {
+                    "type": "string",
+                    "title": "Content",
+                    "description": "The script content as inline data."
+                  },
+                  "file": {
+                    "type": "string",
+                    "title": "File",
+                    "description": "The script content loaded as a file resource."
+                  },
+                  "type": {
+                    "type": "string",
+                    "title": "Type",
+                    "description": "The script type.",
+                    "default": "groovy"
+                  }
+                },
+                "additionalProperties": false,
+                "title": "Script",
+                "description": "Script that builds the expected validate value.",
+                "$comment": "group:script"
+              },
+              "value": {
+                "type": "string",
+                "title": "Value",
+                "description": "Expected message validation expression value."
+              },
+              "xpath": {
+                "title": "Xpath",
+                "description": "Xpath validation expression.",
+                "$comment": "group:xml",
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "expression": {
+                      "type": "string",
+                      "title": "Expression",
+                      "description": "The Xpath expression to evaluate."
+                    },
+                    "resultType": {
+                      "type": "string",
+                      "title": "ResultType",
+                      "description": "The expected result type.",
+                      "$comment": "group:advanced"
+                    },
+                    "value": {
+                      "type": "string",
+                      "title": "Value",
+                      "description": "The expected result."
+                    }
+                  },
+                  "required": [
+                    "expression",
+                    "value"
+                  ],
+                  "additionalProperties": false,
+                  "title": "Xpath",
+                  "description": "Xpath validation expression.",
+                  "$comment": "group:xml"
+                }
+              }
+            },
+            "additionalProperties": false,
+            "title": "Validate",
+            "description": "Message validation expressions."
+          }
+        },
+        "validator": {
+          "type": "string",
+          "title": "Validator",
+          "description": "Explicit message validator.",
+          "$comment": "group:advanced"
+        },
+        "validators": {
+          "type": "string",
+          "title": "Validators",
+          "description": "List of message validators used to validate the message.",
+          "$comment": "group:advanced"
+        }
+      },
+      "required": [
+        "message"
+      ],
+      "additionalProperties": false    }
+  },
+  "soap-sendFault": {
+    "kind": "testAction",
+    "version": "4.10.1",
+    "name": "soap-sendFault",
+    "group": "soap",
+    "module": "citrus-ws",
+    "title": "SendFault",
+    "description": "Sends a SOAP fault response as a server",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "extract": {
+          "type": "object",
+          "properties": {
+            "body": {
+              "title": "Body",
+              "description": "Extract elements from the message body into test variables.",
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "path": {
+                    "type": "string",
+                    "title": "Path",
+                    "description": "The path expression to evaluate."
+                  },
+                  "resultType": {
+                    "type": "string",
+                    "title": "ResultType",
+                    "description": "The expression result type. By default the path expression evaluate to String values.With this setting you can force another expression result type.",
+                    "$comment": "group:advanced"
+                  },
+                  "variable": {
+                    "type": "string",
+                    "title": "Variable",
+                    "description": "The test variable name."
+                  }
+                },
+                "required": [
+                  "variable"
+                ],
+                "additionalProperties": false,
+                "title": "Body",
+                "description": "Extract elements from the message body into test variables."
+              }
+            },
+            "header": {
+              "title": "Header",
+              "description": "Extract elements from the message header into test variables.",
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "title": "Name",
+                    "description": "The name of the message header."
+                  },
+                  "variable": {
+                    "type": "string",
+                    "title": "Variable",
+                    "description": "The test variable name."
+                  }
+                },
+                "required": [
+                  "name",
+                  "variable"
+                ],
+                "additionalProperties": false,
+                "title": "Header",
+                "description": "Extract elements from the message header into test variables."
+              }
+            }
+          },
+          "additionalProperties": false,
+          "title": "Extract",
+          "description": "Extract message content to test variables.",
+          "$comment": "group:advanced"
+        },
+        "message": {
+          "type": "object",
+          "properties": {
+            "attachments": {
+              "title": "Attachments",
+              "description": "List of SOAP attachments for this message.",
+              "$comment": "group:advanced",
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "charset": {
+                    "type": "string",
+                    "title": "Charset",
+                    "description": "The SOAP attachment charset.",
+                    "$comment": "group:advanced"
+                  },
+                  "content": {
+                    "type": "string",
+                    "title": "Content",
+                    "description": "The SOAP attachment content."
+                  },
+                  "contentId": {
+                    "type": "string",
+                    "title": "ContentId",
+                    "description": "The SOAP attachment content id."
+                  },
+                  "contentType": {
+                    "type": "string",
+                    "title": "ContentType",
+                    "description": "The SOAP attachment content type"
+                  },
+                  "resource": {
+                    "type": "string",
+                    "title": "Resource",
+                    "description": "The SOAP attachment content loaded from a file resource."
+                  }
+                },
+                "additionalProperties": false,
+                "title": "Attachments",
+                "description": "List of SOAP attachments for this message.",
+                "$comment": "group:advanced"
+              }
+            },
+            "body": {
+              "type": "object",
+              "properties": {
+                "data": {
+                },
+                "resource": {
+                },
+                "script": {
+                }
+              },
+              "additionalProperties": false,
+              "anyOf": [
+                {
+                  "oneOf": [
+                    {
+                      "type": "object",
+                      "properties": {
+                        "data": {
+                          "type": "string",
+                          "title": "Data",
+                          "description": "The message body content as inline data."
+                        }
+                      }
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "resource": {
+                          "type": "object",
+                          "properties": {
+                            "charset": {
+                              "type": "string",
+                              "title": "Charset",
+                              "$comment": "group:advanced"
+                            },
+                            "file": {
+                              "type": "string",
+                              "title": "File"
+                            }
+                          },
+                          "additionalProperties": false,
+                          "title": "Resource",
+                          "description": "The message body loaded from a file resource."
+                        }
+                      }
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "script": {
+                          "type": "object",
+                          "properties": {
+                            "charset": {
+                              "type": "string",
+                              "title": "Charset",
+                              "description": "The charset used to load the file resource.",
+                              "$comment": "group:advanced"
+                            },
+                            "content": {
+                              "type": "string",
+                              "title": "Content",
+                              "description": "The script content as inline data."
+                            },
+                            "file": {
+                              "type": "string",
+                              "title": "File",
+                              "description": "The script content loaded as a file resource."
+                            },
+                            "type": {
+                              "type": "string",
+                              "title": "Type",
+                              "description": "The script type.",
+                              "default": "groovy"
+                            }
+                          },
+                          "additionalProperties": false,
+                          "title": "Script",
+                          "description": "The message body set via script."
+                        }
+                      }
+                    }
+                  ]
+                }
+              ],
+              "title": "Body",
+              "description": "The message body."
+            },
+            "contentType": {
+              "type": "string",
+              "title": "ContentType",
+              "description": "The SOAP response content type."
+            },
+            "dataDictionary": {
+              "type": "string",
+              "title": "DataDictionary",
+              "description": "Sets a data dictionary that transforms message content before it is being processed.",
+              "$comment": "group:dictionary"
+            },
+            "expression": {
+              "title": "Expression",
+              "description": "List of path expressions to evaluate on the message content before processing the message.",
+              "$comment": "group:advanced",
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "path": {
+                    "type": "string",
+                    "title": "Path",
+                    "description": "The path expression to evaluate."
+                  },
+                  "value": {
+                    "type": "string",
+                    "title": "Value",
+                    "description": "The expected expression result value."
+                  }
+                },
+                "required": [
+                  "path",
+                  "value"
+                ],
+                "additionalProperties": false,
+                "title": "Expression",
+                "description": "List of path expressions to evaluate on the message content before processing the message.",
+                "$comment": "group:advanced"
+              }
+            },
+            "faultActor": {
+              "type": "string",
+              "title": "FaultActor",
+              "description": "The SOAP fault actor.",
+              "$comment": "group:advanced"
+            },
+            "faultCode": {
+              "type": "string",
+              "title": "FaultCode",
+              "description": "The SOAP fault code."
+            },
+            "faultDetails": {
+              "title": "FaultDetails",
+              "description": "The SOAP fault details.",
+              "$comment": "group:advanced",
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "content": {
+                    "type": "string",
+                    "title": "Content",
+                    "description": "The SOAP fault detail content."
+                  },
+                  "resource": {
+                    "type": "string",
+                    "title": "Resource",
+                    "description": "The SOAP fault detail loaded from a file resource."
+                  }
+                },
+                "additionalProperties": false,
+                "title": "FaultDetails",
+                "description": "The SOAP fault details.",
+                "$comment": "group:advanced"
+              }
+            },
+            "faultString": {
+              "type": "string",
+              "title": "FaultString",
+              "description": "The SOAP fault string."
+            },
+            "headerIgnoreCase": {
+              "type": "string",
+              "title": "HeaderIgnoreCase",
+              "description": "When enabled the header case is not verified.",
+              "$comment": "group:advanced"
+            },
+            "headers": {
+              "title": "Headers",
+              "description": "The message headers.",
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "data": {
+                  },
+                  "name": {
+                    "type": "string",
+                    "title": "Name",
+                    "description": "The message header name."
+                  },
+                  "resource": {
+                  },
+                  "type": {
+                    "type": "string",
+                    "title": "Type",
+                    "description": "The message header type to create typed message headers.",
+                    "$comment": "group:advanced"
+                  },
+                  "value": {
+                  }
+                },
+                "additionalProperties": false,
+                "anyOf": [
+                  {
+                    "oneOf": [
+                      {
+                        "type": "object",
+                        "properties": {
+                          "value": {
+                            "type": "string",
+                            "title": "Value",
+                            "description": "The message header value."
+                          }
+                        }
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "resource": {
+                            "type": "object",
+                            "properties": {
+                              "charset": {
+                                "type": "string",
+                                "title": "Charset",
+                                "description": "Optional file resource charset used to read the file content.",
+                                "$comment": "group:advanced"
+                              },
+                              "file": {
+                                "type": "string",
+                                "title": "File",
+                                "description": "The file resource path."
+                              }
+                            },
+                            "required": [
+                              "file"
+                            ],
+                            "additionalProperties": false,
+                            "title": "Resource",
+                            "description": "The header data loaded from a file resource."
+                          }
+                        }
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "data": {
+                            "type": "string",
+                            "title": "Data",
+                            "description": "The message header value as inline data."
+                          }
+                        }
+                      }
+                    ]
+                  }
+                ],
+                "title": "Headers",
+                "description": "The message headers."
+              }
+            },
+            "name": {
+              "type": "string",
+              "title": "Name",
+              "description": "The message name. Named messages may be referenced in subsequent test steps."
+            },
+            "reasonPhrase": {
+              "type": "string",
+              "title": "ReasonPhrase",
+              "description": "The SOAP response reason phrase.",
+              "$comment": "group:advanced"
+            },
+            "schema": {
+              "type": "string",
+              "title": "Schema",
+              "description": "The reference to a schema in the bean registry that should be used for validation.",
+              "$comment": "group:schema"
+            },
+            "schemaRepository": {
+              "type": "string",
+              "title": "SchemaRepository",
+              "description": "The schema repository holding the schema.",
+              "$comment": "group:schema"
+            },
+            "schemaValidation": {
+              "type": "boolean",
+              "title": "SchemaValidation",
+              "description": "Enables the schema validation.",
+              "$comment": "group:schema"
+            },
+            "status": {
+              "type": "string",
+              "title": "Status",
+              "description": "The SOAP response status."
+            },
+            "type": {
+              "type": "string",
+              "title": "Type",
+              "description": "The message type. Gives the validator a hint which validatory are capable of performing proper message validation.",
+              "$comment": "group:advanced"
+            },
+            "version": {
+              "type": "string",
+              "title": "Version",
+              "description": "The SOAP version.",
+              "$comment": "group:advanced"
+            }
+          },
+          "additionalProperties": false,
+          "title": "Message",
+          "description": "The SOAP fault response message to send."
+        }
+      },
+      "required": [
+        "message"
+      ],
+      "additionalProperties": false    }
+  },
+  "soap-sendRequest": {
+    "kind": "testAction",
+    "version": "4.10.1",
+    "name": "soap-sendRequest",
+    "group": "soap",
+    "module": "citrus-ws",
+    "title": "SendRequest",
+    "description": "Sends a SOAP request as a client.",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "extract": {
+          "type": "object",
+          "properties": {
+            "body": {
+              "title": "Body",
+              "description": "Extract elements from the message body into test variables.",
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "path": {
+                    "type": "string",
+                    "title": "Path",
+                    "description": "The path expression to evaluate."
+                  },
+                  "resultType": {
+                    "type": "string",
+                    "title": "ResultType",
+                    "description": "The expression result type. By default the path expression evaluate to String values.With this setting you can force another expression result type.",
+                    "$comment": "group:advanced"
+                  },
+                  "variable": {
+                    "type": "string",
+                    "title": "Variable",
+                    "description": "The test variable name."
+                  }
+                },
+                "required": [
+                  "variable"
+                ],
+                "additionalProperties": false,
+                "title": "Body",
+                "description": "Extract elements from the message body into test variables."
+              }
+            },
+            "header": {
+              "title": "Header",
+              "description": "Extract elements from the message header into test variables.",
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "title": "Name",
+                    "description": "The name of the message header."
+                  },
+                  "variable": {
+                    "type": "string",
+                    "title": "Variable",
+                    "description": "The test variable name."
+                  }
+                },
+                "required": [
+                  "name",
+                  "variable"
+                ],
+                "additionalProperties": false,
+                "title": "Header",
+                "description": "Extract elements from the message header into test variables."
+              }
+            }
+          },
+          "additionalProperties": false,
+          "title": "Extract",
+          "description": "Extract message content to test variables.",
+          "$comment": "group:advanced"
+        },
+        "fork": {
+          "type": "boolean",
+          "title": "Fork",
+          "description": "When enabled the send operation does not block while waiting for the response."
+        },
+        "message": {
+          "type": "object",
+          "properties": {
+            "accept": {
+              "type": "string",
+              "title": "Accept",
+              "description": "The SOAP request accept header.",
+              "$comment": "group:advanced"
+            },
+            "attachments": {
+              "title": "Attachments",
+              "description": "List of SOAP attachments for this message.",
+              "$comment": "group:advanced",
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "charset": {
+                    "type": "string",
+                    "title": "Charset",
+                    "description": "The SOAP attachment charset.",
+                    "$comment": "group:advanced"
+                  },
+                  "content": {
+                    "type": "string",
+                    "title": "Content",
+                    "description": "The SOAP attachment content."
+                  },
+                  "contentId": {
+                    "type": "string",
+                    "title": "ContentId",
+                    "description": "The SOAP attachment content id."
+                  },
+                  "contentType": {
+                    "type": "string",
+                    "title": "ContentType",
+                    "description": "The SOAP attachment content type"
+                  },
+                  "resource": {
+                    "type": "string",
+                    "title": "Resource",
+                    "description": "The SOAP attachment content loaded from a file resource."
+                  }
+                },
+                "additionalProperties": false,
+                "title": "Attachments",
+                "description": "List of SOAP attachments for this message.",
+                "$comment": "group:advanced"
+              }
+            },
+            "body": {
+              "type": "object",
+              "properties": {
+                "data": {
+                },
+                "resource": {
+                },
+                "script": {
+                }
+              },
+              "additionalProperties": false,
+              "anyOf": [
+                {
+                  "oneOf": [
+                    {
+                      "type": "object",
+                      "properties": {
+                        "data": {
+                          "type": "string",
+                          "title": "Data",
+                          "description": "The message body content as inline data."
+                        }
+                      }
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "resource": {
+                          "type": "object",
+                          "properties": {
+                            "charset": {
+                              "type": "string",
+                              "title": "Charset",
+                              "$comment": "group:advanced"
+                            },
+                            "file": {
+                              "type": "string",
+                              "title": "File"
+                            }
+                          },
+                          "additionalProperties": false,
+                          "title": "Resource",
+                          "description": "The message body loaded from a file resource."
+                        }
+                      }
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "script": {
+                          "type": "object",
+                          "properties": {
+                            "charset": {
+                              "type": "string",
+                              "title": "Charset",
+                              "description": "The charset used to load the file resource.",
+                              "$comment": "group:advanced"
+                            },
+                            "content": {
+                              "type": "string",
+                              "title": "Content",
+                              "description": "The script content as inline data."
+                            },
+                            "file": {
+                              "type": "string",
+                              "title": "File",
+                              "description": "The script content loaded as a file resource."
+                            },
+                            "type": {
+                              "type": "string",
+                              "title": "Type",
+                              "description": "The script type.",
+                              "default": "groovy"
+                            }
+                          },
+                          "additionalProperties": false,
+                          "title": "Script",
+                          "description": "The message body set via script."
+                        }
+                      }
+                    }
+                  ]
+                }
+              ],
+              "title": "Body",
+              "description": "The message body."
+            },
+            "contentType": {
+              "type": "string",
+              "title": "ContentType",
+              "description": "The SOAP request content type."
+            },
+            "dataDictionary": {
+              "type": "string",
+              "title": "DataDictionary",
+              "description": "Sets a data dictionary that transforms message content before it is being processed.",
+              "$comment": "group:dictionary"
+            },
+            "expression": {
+              "title": "Expression",
+              "description": "List of path expressions to evaluate on the message content before processing the message.",
+              "$comment": "group:advanced",
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "path": {
+                    "type": "string",
+                    "title": "Path",
+                    "description": "The path expression to evaluate."
+                  },
+                  "value": {
+                    "type": "string",
+                    "title": "Value",
+                    "description": "The expected expression result value."
+                  }
+                },
+                "required": [
+                  "path",
+                  "value"
+                ],
+                "additionalProperties": false,
+                "title": "Expression",
+                "description": "List of path expressions to evaluate on the message content before processing the message.",
+                "$comment": "group:advanced"
+              }
+            },
+            "headerIgnoreCase": {
+              "type": "string",
+              "title": "HeaderIgnoreCase",
+              "description": "When enabled the header case is not verified.",
+              "$comment": "group:advanced"
+            },
+            "headers": {
+              "title": "Headers",
+              "description": "The message headers.",
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "data": {
+                  },
+                  "name": {
+                    "type": "string",
+                    "title": "Name",
+                    "description": "The message header name."
+                  },
+                  "resource": {
+                  },
+                  "type": {
+                    "type": "string",
+                    "title": "Type",
+                    "description": "The message header type to create typed message headers.",
+                    "$comment": "group:advanced"
+                  },
+                  "value": {
+                  }
+                },
+                "additionalProperties": false,
+                "anyOf": [
+                  {
+                    "oneOf": [
+                      {
+                        "type": "object",
+                        "properties": {
+                          "value": {
+                            "type": "string",
+                            "title": "Value",
+                            "description": "The message header value."
+                          }
+                        }
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "resource": {
+                            "type": "object",
+                            "properties": {
+                              "charset": {
+                                "type": "string",
+                                "title": "Charset",
+                                "description": "Optional file resource charset used to read the file content.",
+                                "$comment": "group:advanced"
+                              },
+                              "file": {
+                                "type": "string",
+                                "title": "File",
+                                "description": "The file resource path."
+                              }
+                            },
+                            "required": [
+                              "file"
+                            ],
+                            "additionalProperties": false,
+                            "title": "Resource",
+                            "description": "The header data loaded from a file resource."
+                          }
+                        }
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "data": {
+                            "type": "string",
+                            "title": "Data",
+                            "description": "The message header value as inline data."
+                          }
+                        }
+                      }
+                    ]
+                  }
+                ],
+                "title": "Headers",
+                "description": "The message headers."
+              }
+            },
+            "mtomEnabled": {
+              "type": "boolean",
+              "title": "MtomEnabled",
+              "description": "Enables SOAP MTOM.",
+              "$comment": "group:advanced"
+            },
+            "name": {
+              "type": "string",
+              "title": "Name",
+              "description": "The message name. Named messages may be referenced in subsequent test steps."
+            },
+            "path": {
+              "type": "string",
+              "title": "Path",
+              "description": "The SOAP request path."
+            },
+            "schema": {
+              "type": "string",
+              "title": "Schema",
+              "description": "The reference to a schema in the bean registry that should be used for validation.",
+              "$comment": "group:schema"
+            },
+            "schemaRepository": {
+              "type": "string",
+              "title": "SchemaRepository",
+              "description": "The schema repository holding the schema.",
+              "$comment": "group:schema"
+            },
+            "schemaValidation": {
+              "type": "boolean",
+              "title": "SchemaValidation",
+              "description": "Enables the schema validation.",
+              "$comment": "group:schema"
+            },
+            "soapAction": {
+              "type": "string",
+              "title": "SoapAction",
+              "description": "The SOAP action."
+            },
+            "type": {
+              "type": "string",
+              "title": "Type",
+              "description": "The message type. Gives the validator a hint which validatory are capable of performing proper message validation.",
+              "$comment": "group:advanced"
+            },
+            "version": {
+              "type": "string",
+              "title": "Version",
+              "description": "The SOAP version.",
+              "$comment": "group:advanced"
+            }
+          },
+          "additionalProperties": false,
+          "title": "Message",
+          "description": "The SOAP request message."
+        },
+        "uri": {
+          "type": "string",
+          "title": "Uri",
+          "description": "Http endpoint URI overwrite.",
+          "$comment": "group:advanced"
+        }
+      },
+      "required": [
+        "message"
+      ],
+      "additionalProperties": false    }
+  },
+  "soap-sendResponse": {
+    "kind": "testAction",
+    "version": "4.10.1",
+    "name": "soap-sendResponse",
+    "group": "soap",
+    "module": "citrus-ws",
+    "title": "SendResponse",
+    "description": "Sends a SOAP response as a server.",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "extract": {
+          "type": "object",
+          "properties": {
+            "body": {
+              "title": "Body",
+              "description": "Extract elements from the message body into test variables.",
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "path": {
+                    "type": "string",
+                    "title": "Path",
+                    "description": "The path expression to evaluate."
+                  },
+                  "resultType": {
+                    "type": "string",
+                    "title": "ResultType",
+                    "description": "The expression result type. By default the path expression evaluate to String values.With this setting you can force another expression result type.",
+                    "$comment": "group:advanced"
+                  },
+                  "variable": {
+                    "type": "string",
+                    "title": "Variable",
+                    "description": "The test variable name."
+                  }
+                },
+                "required": [
+                  "variable"
+                ],
+                "additionalProperties": false,
+                "title": "Body",
+                "description": "Extract elements from the message body into test variables."
+              }
+            },
+            "header": {
+              "title": "Header",
+              "description": "Extract elements from the message header into test variables.",
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "title": "Name",
+                    "description": "The name of the message header."
+                  },
+                  "variable": {
+                    "type": "string",
+                    "title": "Variable",
+                    "description": "The test variable name."
+                  }
+                },
+                "required": [
+                  "name",
+                  "variable"
+                ],
+                "additionalProperties": false,
+                "title": "Header",
+                "description": "Extract elements from the message header into test variables."
+              }
+            }
+          },
+          "additionalProperties": false,
+          "title": "Extract",
+          "description": "Extract message content to test variables.",
+          "$comment": "group:advanced"
+        },
+        "message": {
+          "type": "object",
+          "properties": {
+            "attachments": {
+              "title": "Attachments",
+              "description": "List of SOAP attachments for this message.",
+              "$comment": "group:advanced",
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "charset": {
+                    "type": "string",
+                    "title": "Charset",
+                    "description": "The SOAP attachment charset.",
+                    "$comment": "group:advanced"
+                  },
+                  "content": {
+                    "type": "string",
+                    "title": "Content",
+                    "description": "The SOAP attachment content."
+                  },
+                  "contentId": {
+                    "type": "string",
+                    "title": "ContentId",
+                    "description": "The SOAP attachment content id."
+                  },
+                  "contentType": {
+                    "type": "string",
+                    "title": "ContentType",
+                    "description": "The SOAP attachment content type"
+                  },
+                  "resource": {
+                    "type": "string",
+                    "title": "Resource",
+                    "description": "The SOAP attachment content loaded from a file resource."
+                  }
+                },
+                "additionalProperties": false,
+                "title": "Attachments",
+                "description": "List of SOAP attachments for this message.",
+                "$comment": "group:advanced"
+              }
+            },
+            "body": {
+              "type": "object",
+              "properties": {
+                "data": {
+                },
+                "resource": {
+                },
+                "script": {
+                }
+              },
+              "additionalProperties": false,
+              "anyOf": [
+                {
+                  "oneOf": [
+                    {
+                      "type": "object",
+                      "properties": {
+                        "data": {
+                          "type": "string",
+                          "title": "Data",
+                          "description": "The message body content as inline data."
+                        }
+                      }
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "resource": {
+                          "type": "object",
+                          "properties": {
+                            "charset": {
+                              "type": "string",
+                              "title": "Charset",
+                              "$comment": "group:advanced"
+                            },
+                            "file": {
+                              "type": "string",
+                              "title": "File"
+                            }
+                          },
+                          "additionalProperties": false,
+                          "title": "Resource",
+                          "description": "The message body loaded from a file resource."
+                        }
+                      }
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "script": {
+                          "type": "object",
+                          "properties": {
+                            "charset": {
+                              "type": "string",
+                              "title": "Charset",
+                              "description": "The charset used to load the file resource.",
+                              "$comment": "group:advanced"
+                            },
+                            "content": {
+                              "type": "string",
+                              "title": "Content",
+                              "description": "The script content as inline data."
+                            },
+                            "file": {
+                              "type": "string",
+                              "title": "File",
+                              "description": "The script content loaded as a file resource."
+                            },
+                            "type": {
+                              "type": "string",
+                              "title": "Type",
+                              "description": "The script type.",
+                              "default": "groovy"
+                            }
+                          },
+                          "additionalProperties": false,
+                          "title": "Script",
+                          "description": "The message body set via script."
+                        }
+                      }
+                    }
+                  ]
+                }
+              ],
+              "title": "Body",
+              "description": "The message body."
+            },
+            "contentType": {
+              "type": "string",
+              "title": "ContentType",
+              "description": "The SOAP response content type."
+            },
+            "dataDictionary": {
+              "type": "string",
+              "title": "DataDictionary",
+              "description": "Sets a data dictionary that transforms message content before it is being processed.",
+              "$comment": "group:dictionary"
+            },
+            "expression": {
+              "title": "Expression",
+              "description": "List of path expressions to evaluate on the message content before processing the message.",
+              "$comment": "group:advanced",
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "path": {
+                    "type": "string",
+                    "title": "Path",
+                    "description": "The path expression to evaluate."
+                  },
+                  "value": {
+                    "type": "string",
+                    "title": "Value",
+                    "description": "The expected expression result value."
+                  }
+                },
+                "required": [
+                  "path",
+                  "value"
+                ],
+                "additionalProperties": false,
+                "title": "Expression",
+                "description": "List of path expressions to evaluate on the message content before processing the message.",
+                "$comment": "group:advanced"
+              }
+            },
+            "headerIgnoreCase": {
+              "type": "string",
+              "title": "HeaderIgnoreCase",
+              "description": "When enabled the header case is not verified.",
+              "$comment": "group:advanced"
+            },
+            "headers": {
+              "title": "Headers",
+              "description": "The message headers.",
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "data": {
+                  },
+                  "name": {
+                    "type": "string",
+                    "title": "Name",
+                    "description": "The message header name."
+                  },
+                  "resource": {
+                  },
+                  "type": {
+                    "type": "string",
+                    "title": "Type",
+                    "description": "The message header type to create typed message headers.",
+                    "$comment": "group:advanced"
+                  },
+                  "value": {
+                  }
+                },
+                "additionalProperties": false,
+                "anyOf": [
+                  {
+                    "oneOf": [
+                      {
+                        "type": "object",
+                        "properties": {
+                          "value": {
+                            "type": "string",
+                            "title": "Value",
+                            "description": "The message header value."
+                          }
+                        }
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "resource": {
+                            "type": "object",
+                            "properties": {
+                              "charset": {
+                                "type": "string",
+                                "title": "Charset",
+                                "description": "Optional file resource charset used to read the file content.",
+                                "$comment": "group:advanced"
+                              },
+                              "file": {
+                                "type": "string",
+                                "title": "File",
+                                "description": "The file resource path."
+                              }
+                            },
+                            "required": [
+                              "file"
+                            ],
+                            "additionalProperties": false,
+                            "title": "Resource",
+                            "description": "The header data loaded from a file resource."
+                          }
+                        }
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "data": {
+                            "type": "string",
+                            "title": "Data",
+                            "description": "The message header value as inline data."
+                          }
+                        }
+                      }
+                    ]
+                  }
+                ],
+                "title": "Headers",
+                "description": "The message headers."
+              }
+            },
+            "name": {
+              "type": "string",
+              "title": "Name",
+              "description": "The message name. Named messages may be referenced in subsequent test steps."
+            },
+            "reasonPhrase": {
+              "type": "string",
+              "title": "ReasonPhrase",
+              "description": "The SOAP response reason phrase.",
+              "$comment": "group:advanced"
+            },
+            "schema": {
+              "type": "string",
+              "title": "Schema",
+              "description": "The reference to a schema in the bean registry that should be used for validation.",
+              "$comment": "group:schema"
+            },
+            "schemaRepository": {
+              "type": "string",
+              "title": "SchemaRepository",
+              "description": "The schema repository holding the schema.",
+              "$comment": "group:schema"
+            },
+            "schemaValidation": {
+              "type": "boolean",
+              "title": "SchemaValidation",
+              "description": "Enables the schema validation.",
+              "$comment": "group:schema"
+            },
+            "status": {
+              "type": "string",
+              "title": "Status",
+              "description": "The SOAP response status."
+            },
+            "type": {
+              "type": "string",
+              "title": "Type",
+              "description": "The message type. Gives the validator a hint which validatory are capable of performing proper message validation.",
+              "$comment": "group:advanced"
+            },
+            "version": {
+              "type": "string",
+              "title": "Version",
+              "description": "The SOAP version.",
+              "$comment": "group:advanced"
+            }
+          },
+          "additionalProperties": false,
+          "title": "Message",
+          "description": "The SOAP response message to send."
+        }
+      },
+      "required": [
+        "message"
+      ],
+      "additionalProperties": false    }
+  },
+  "sql": {
+    "kind": "testAction",
+    "version": "4.10.1",
+    "name": "sql",
+    "module": "citrus-sql",
+    "title": "Sql",
+    "description": "SQL test actions.",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "dataSource": {
+          "type": "string",
+          "title": "DataSource"
+        },
+        "description": {
+          "type": "string",
+          "title": "Description",
+          "description": "Test action description printed when the action is executed.",
+          "$comment": "group:advanced"
+        },
+        "extract": {
+          "title": "Extract",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "column": {
+                "type": "string",
+                "title": "Column"
+              },
+              "variable": {
+                "type": "string",
+                "title": "Variable"
+              }
+            },
+            "additionalProperties": false,
+            "title": "Extract"
+          }
+        },
+        "ignoreErrors": {
+          "type": "boolean",
+          "title": "IgnoreErrors"
+        },
+        "statements": {
+          "title": "Statements",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "file": {
+                "type": "string",
+                "title": "File"
+              },
+              "statement": {
+                "type": "string",
+                "title": "Statement"
+              }
+            },
+            "additionalProperties": false,
+            "title": "Statements"
+          }
+        },
+        "transaction": {
+          "type": "object",
+          "properties": {
+            "isolationLevel": {
+              "type": "string",
+              "title": "IsolationLevel"
+            },
+            "manager": {
+              "type": "string",
+              "title": "Manager"
+            },
+            "timeout": {
+              "type": "string",
+              "title": "Timeout"
+            }
+          },
+          "additionalProperties": false,
+          "title": "Transaction"
+        },
+        "validate": {
+          "title": "Validate",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "column": {
+                "type": "string",
+                "title": "Column"
+              },
+              "script": {
+                "type": "object",
+                "properties": {
+                  "charset": {
+                    "type": "string",
+                    "title": "Charset"
+                  },
+                  "file": {
+                    "type": "string",
+                    "title": "File"
+                  },
+                  "type": {
+                    "type": "string",
+                    "title": "Type"
+                  },
+                  "value": {
+                    "type": "string",
+                    "title": "Value"
+                  }
+                },
+                "additionalProperties": false,
+                "title": "Script"
+              },
+              "value": {
+                "type": "string",
+                "title": "Value"
+              },
+              "values": {
+                "title": "Values",
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "title": "Values"
+                }
+              }
+            },
+            "additionalProperties": false,
+            "title": "Validate"
+          }
+        }
+      },
+      "required": [
+        "statements"
+      ],
+      "additionalProperties": false    }
+  },
+  "start": {
+    "kind": "testAction",
+    "version": "4.10.1",
+    "name": "start",
+    "title": "Start",
+    "description": "Start server test action.",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "server": {
+          "type": "string",
+          "title": "Server",
+          "description": "Uses an endpoint URI or references an endpoint name."
+        },
+        "servers": {
+          "title": "Servers",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string",
+                "title": "Name"
+              }
+            },
+            "additionalProperties": false,
+            "title": "Servers"
+          }
+        }
+      },
+      "additionalProperties": false    }
+  },
+  "stop": {
+    "kind": "testAction",
+    "version": "4.10.1",
+    "name": "stop",
+    "title": "Stop",
+    "description": "Stop server test action.",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "server": {
+          "type": "string",
+          "title": "Server",
+          "description": "Uses an endpoint URI or references an endpoint name."
+        },
+        "servers": {
+          "title": "Servers",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string",
+                "title": "Name",
+                "description": "Uses an endpoint URI or references an endpoint name."
+              }
+            },
+            "additionalProperties": false,
+            "title": "Servers"
+          }
+        }
+      },
+      "additionalProperties": false    }
+  },
+  "stopTime": {
+    "kind": "testAction",
+    "version": "4.10.1",
+    "name": "stopTime",
+    "title": "StopTime",
+    "description": "Stop time test action.",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "description": {
+          "type": "string",
+          "title": "Description",
+          "description": "Test action description printed when the action is executed.",
+          "$comment": "group:advanced"
+        },
+        "id": {
+          "type": "string",
+          "title": "Id",
+          "description": "The time line identifier."
+        },
+        "suffix": {
+          "type": "string",
+          "title": "Suffix",
+          "description": "Suffix added to the value test variable."
+        }
+      },
+      "additionalProperties": false    }
+  },
+  "stopTimer": {
+    "kind": "testAction",
+    "version": "4.10.1",
+    "name": "stopTimer",
+    "title": "StopTimer",
+    "description": "Stop timer test action.",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "description": {
+          "type": "string",
+          "title": "Description",
+          "description": "Test action description printed when the action is executed.",
+          "$comment": "group:advanced"
+        },
+        "id": {
+          "type": "string",
+          "title": "Id",
+          "description": "Name identifying the timer."
+        }
+      },
+      "required": [
+        "id"
+      ],
+      "additionalProperties": false    }
+  },
+  "testcontainers": {
+    "kind": "testActionGroup",
+    "version": "4.10.1",
+    "name": "testcontainers",
+    "module": "citrus-testcontainers",
+    "title": "Testcontainers",
+    "description": "Testcontainers test actions.",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "actor": {
+          "type": "string",
+          "title": "Actor",
+          "$comment": "group:advanced"
+        },
+        "description": {
+          "type": "string",
+          "title": "Description",
+          "description": "Test action description printed when the action is executed.",
+          "$comment": "group:advanced"
+        }
+      },
+      "additionalProperties": false    }
+  },
+  "testcontainers-compose": {
+    "kind": "testActionGroup",
+    "version": "4.10.1",
+    "name": "testcontainers-compose",
+    "group": "testcontainers",
+    "module": "citrus-testcontainers",
+    "title": "Compose",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "additionalProperties": false    }
+  },
+  "testcontainers-compose-down": {
+    "kind": "testAction",
+    "version": "4.10.1",
+    "name": "testcontainers-compose-down",
+    "group": "testcontainers-compose",
+    "title": "Down",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "title": "Name"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "additionalProperties": false    }
+  },
+  "testcontainers-compose-up": {
+    "kind": "testAction",
+    "version": "4.10.1",
+    "name": "testcontainers-compose-up",
+    "group": "testcontainers-compose",
+    "title": "Up",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "autoRemove": {
+          "type": "boolean",
+          "title": "AutoRemove"
+        },
+        "exposedServices": {
+          "title": "ExposedServices",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string",
+                "title": "Name"
+              },
+              "port": {
+                "type": "integer",
+                "title": "Port"
+              },
+              "waitFor": {
+                "type": "object",
+                "properties": {
+                  "disabled": {
+                    "type": "boolean",
+                    "title": "Disabled"
+                  },
+                  "logMessage": {
+                    "type": "string",
+                    "title": "LogMessage"
+                  },
+                  "url": {
+                    "type": "string",
+                    "title": "Url"
+                  }
+                },
+                "additionalProperties": false,
+                "title": "WaitFor"
+              }
+            },
+            "additionalProperties": false,
+            "title": "ExposedServices"
+          }
+        },
+        "file": {
+          "type": "string",
+          "title": "File"
+        },
+        "name": {
+          "type": "string",
+          "title": "Name"
+        },
+        "startUpTimeout": {
+          "type": "integer",
+          "title": "StartUpTimeout"
+        }
+      },
+      "additionalProperties": false    }
+  },
+  "testcontainers-start": {
+    "kind": "testActionGroup",
+    "version": "4.10.1",
+    "name": "testcontainers-start",
+    "group": "testcontainers",
+    "module": "citrus-testcontainers",
+    "title": "Start",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "additionalProperties": false    }
+  },
+  "testcontainers-start-container": {
+    "kind": "testAction",
+    "version": "4.10.1",
+    "name": "testcontainers-start-container",
+    "group": "testcontainers-start",
+    "title": "Container",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "autoRemove": {
+          "type": "boolean",
+          "title": "AutoRemove"
+        },
+        "command": {
+          "type": "string",
+          "title": "Command"
+        },
+        "env": {
+          "title": "Env",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string",
+                "title": "Name"
+              },
+              "value": {
+                "type": "string",
+                "title": "Value"
+              }
+            },
+            "additionalProperties": false,
+            "title": "Env"
+          }
+        },
+        "exposedPorts": {
+          "title": "ExposedPorts",
+          "type": "array",
+          "items": {
+            "type": "integer",
+            "title": "ExposedPorts"
+          }
+        },
+        "image": {
+          "type": "string",
+          "title": "Image"
+        },
+        "labels": {
+          "title": "Labels",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string",
+                "title": "Name"
+              },
+              "value": {
+                "type": "string",
+                "title": "Value"
+              }
+            },
+            "additionalProperties": false,
+            "title": "Labels"
+          }
+        },
+        "name": {
+          "type": "string",
+          "title": "Name"
+        },
+        "portBindings": {
+          "title": "PortBindings",
+          "type": "array",
+          "items": {
+            "type": "string",
+            "title": "PortBindings"
+          }
+        },
+        "serviceName": {
+          "type": "string",
+          "title": "ServiceName"
+        },
+        "startUpTimeout": {
+          "type": "integer",
+          "title": "StartUpTimeout"
+        },
+        "volumeMounts": {
+          "title": "VolumeMounts",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "file": {
+                "type": "string",
+                "title": "File"
+              },
+              "mountPath": {
+                "type": "string",
+                "title": "MountPath"
+              }
+            },
+            "additionalProperties": false,
+            "title": "VolumeMounts"
+          }
+        },
+        "waitFor": {
+          "type": "object",
+          "properties": {
+            "disabled": {
+              "type": "boolean",
+              "title": "Disabled"
+            },
+            "logMessage": {
+              "type": "string",
+              "title": "LogMessage"
+            },
+            "url": {
+              "type": "string",
+              "title": "Url"
+            }
+          },
+          "additionalProperties": false,
+          "title": "WaitFor"
+        }
+      },
+      "additionalProperties": false    }
+  },
+  "testcontainers-start-kafka": {
+    "kind": "testAction",
+    "version": "4.10.1",
+    "name": "testcontainers-start-kafka",
+    "group": "testcontainers-start",
+    "title": "Kafka",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "autoRemove": {
+          "type": "boolean",
+          "title": "AutoRemove"
+        },
+        "command": {
+          "type": "string",
+          "title": "Command"
+        },
+        "env": {
+          "title": "Env",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string",
+                "title": "Name"
+              },
+              "value": {
+                "type": "string",
+                "title": "Value"
+              }
+            },
+            "additionalProperties": false,
+            "title": "Env"
+          }
+        },
+        "exposedPorts": {
+          "title": "ExposedPorts",
+          "type": "array",
+          "items": {
+            "type": "integer",
+            "title": "ExposedPorts"
+          }
+        },
+        "image": {
+          "type": "string",
+          "title": "Image"
+        },
+        "implementation": {
+          "type": "string",
+          "title": "Implementation"
+        },
+        "labels": {
+          "title": "Labels",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string",
+                "title": "Name"
+              },
+              "value": {
+                "type": "string",
+                "title": "Value"
+              }
+            },
+            "additionalProperties": false,
+            "title": "Labels"
+          }
+        },
+        "name": {
+          "type": "string",
+          "title": "Name"
+        },
+        "port": {
+          "type": "integer",
+          "title": "Port"
+        },
+        "portBindings": {
+          "title": "PortBindings",
+          "type": "array",
+          "items": {
+            "type": "string",
+            "title": "PortBindings"
+          }
+        },
+        "serviceName": {
+          "type": "string",
+          "title": "ServiceName"
+        },
+        "startUpTimeout": {
+          "type": "integer",
+          "title": "StartUpTimeout"
+        },
+        "version": {
+          "type": "string",
+          "title": "Version"
+        },
+        "volumeMounts": {
+          "title": "VolumeMounts",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "file": {
+                "type": "string",
+                "title": "File"
+              },
+              "mountPath": {
+                "type": "string",
+                "title": "MountPath"
+              }
+            },
+            "additionalProperties": false,
+            "title": "VolumeMounts"
+          }
+        },
+        "waitFor": {
+          "type": "object",
+          "properties": {
+            "disabled": {
+              "type": "boolean",
+              "title": "Disabled"
+            },
+            "logMessage": {
+              "type": "string",
+              "title": "LogMessage"
+            },
+            "url": {
+              "type": "string",
+              "title": "Url"
+            }
+          },
+          "additionalProperties": false,
+          "title": "WaitFor"
+        }
+      },
+      "additionalProperties": false    }
+  },
+  "testcontainers-start-localstack": {
+    "kind": "testAction",
+    "version": "4.10.1",
+    "name": "testcontainers-start-localstack",
+    "group": "testcontainers-start",
+    "title": "Localstack",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "autoCreateClients": {
+          "type": "boolean",
+          "title": "AutoCreateClients"
+        },
+        "autoRemove": {
+          "type": "boolean",
+          "title": "AutoRemove"
+        },
+        "command": {
+          "type": "string",
+          "title": "Command"
+        },
+        "env": {
+          "title": "Env",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string",
+                "title": "Name"
+              },
+              "value": {
+                "type": "string",
+                "title": "Value"
+              }
+            },
+            "additionalProperties": false,
+            "title": "Env"
+          }
+        },
+        "exposedPorts": {
+          "title": "ExposedPorts",
+          "type": "array",
+          "items": {
+            "type": "integer",
+            "title": "ExposedPorts"
+          }
+        },
+        "image": {
+          "type": "string",
+          "title": "Image"
+        },
+        "labels": {
+          "title": "Labels",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string",
+                "title": "Name"
+              },
+              "value": {
+                "type": "string",
+                "title": "Value"
+              }
+            },
+            "additionalProperties": false,
+            "title": "Labels"
+          }
+        },
+        "name": {
+          "type": "string",
+          "title": "Name"
+        },
+        "options": {
+          "type": "object",
+          "title": "Options",
+          "additionalProperties": {
+            "type": "string",
+            "title": "Options"
+          }
+        },
+        "portBindings": {
+          "title": "PortBindings",
+          "type": "array",
+          "items": {
+            "type": "string",
+            "title": "PortBindings"
+          }
+        },
+        "serviceName": {
+          "type": "string",
+          "title": "ServiceName"
+        },
+        "services": {
+          "title": "Services",
+          "type": "array",
+          "items": {
+            "type": "string",
+            "title": "Services"
+          }
+        },
+        "startUpTimeout": {
+          "type": "integer",
+          "title": "StartUpTimeout"
+        },
+        "version": {
+          "type": "string",
+          "title": "Version"
+        },
+        "volumeMounts": {
+          "title": "VolumeMounts",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "file": {
+                "type": "string",
+                "title": "File"
+              },
+              "mountPath": {
+                "type": "string",
+                "title": "MountPath"
+              }
+            },
+            "additionalProperties": false,
+            "title": "VolumeMounts"
+          }
+        },
+        "waitFor": {
+          "type": "object",
+          "properties": {
+            "disabled": {
+              "type": "boolean",
+              "title": "Disabled"
+            },
+            "logMessage": {
+              "type": "string",
+              "title": "LogMessage"
+            },
+            "url": {
+              "type": "string",
+              "title": "Url"
+            }
+          },
+          "additionalProperties": false,
+          "title": "WaitFor"
+        }
+      },
+      "additionalProperties": false    }
+  },
+  "testcontainers-start-mongodb": {
+    "kind": "testAction",
+    "version": "4.10.1",
+    "name": "testcontainers-start-mongodb",
+    "group": "testcontainers-start",
+    "title": "Mongodb",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "autoRemove": {
+          "type": "boolean",
+          "title": "AutoRemove"
+        },
+        "command": {
+          "type": "string",
+          "title": "Command"
+        },
+        "env": {
+          "title": "Env",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string",
+                "title": "Name"
+              },
+              "value": {
+                "type": "string",
+                "title": "Value"
+              }
+            },
+            "additionalProperties": false,
+            "title": "Env"
+          }
+        },
+        "exposedPorts": {
+          "title": "ExposedPorts",
+          "type": "array",
+          "items": {
+            "type": "integer",
+            "title": "ExposedPorts"
+          }
+        },
+        "image": {
+          "type": "string",
+          "title": "Image"
+        },
+        "labels": {
+          "title": "Labels",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string",
+                "title": "Name"
+              },
+              "value": {
+                "type": "string",
+                "title": "Value"
+              }
+            },
+            "additionalProperties": false,
+            "title": "Labels"
+          }
+        },
+        "name": {
+          "type": "string",
+          "title": "Name"
+        },
+        "portBindings": {
+          "title": "PortBindings",
+          "type": "array",
+          "items": {
+            "type": "string",
+            "title": "PortBindings"
+          }
+        },
+        "serviceName": {
+          "type": "string",
+          "title": "ServiceName"
+        },
+        "startUpTimeout": {
+          "type": "integer",
+          "title": "StartUpTimeout"
+        },
+        "version": {
+          "type": "string",
+          "title": "Version"
+        },
+        "volumeMounts": {
+          "title": "VolumeMounts",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "file": {
+                "type": "string",
+                "title": "File"
+              },
+              "mountPath": {
+                "type": "string",
+                "title": "MountPath"
+              }
+            },
+            "additionalProperties": false,
+            "title": "VolumeMounts"
+          }
+        },
+        "waitFor": {
+          "type": "object",
+          "properties": {
+            "disabled": {
+              "type": "boolean",
+              "title": "Disabled"
+            },
+            "logMessage": {
+              "type": "string",
+              "title": "LogMessage"
+            },
+            "url": {
+              "type": "string",
+              "title": "Url"
+            }
+          },
+          "additionalProperties": false,
+          "title": "WaitFor"
+        }
+      },
+      "additionalProperties": false    }
+  },
+  "testcontainers-start-postgresql": {
+    "kind": "testAction",
+    "version": "4.10.1",
+    "name": "testcontainers-start-postgresql",
+    "group": "testcontainers-start",
+    "title": "Postgresql",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "autoRemove": {
+          "type": "boolean",
+          "title": "AutoRemove"
+        },
+        "command": {
+          "type": "string",
+          "title": "Command"
+        },
+        "dataSourceName": {
+          "type": "string",
+          "title": "DataSourceName"
+        },
+        "database": {
+          "type": "string",
+          "title": "Database"
+        },
+        "env": {
+          "title": "Env",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string",
+                "title": "Name"
+              },
+              "value": {
+                "type": "string",
+                "title": "Value"
+              }
+            },
+            "additionalProperties": false,
+            "title": "Env"
+          }
+        },
+        "exposedPorts": {
+          "title": "ExposedPorts",
+          "type": "array",
+          "items": {
+            "type": "integer",
+            "title": "ExposedPorts"
+          }
+        },
+        "image": {
+          "type": "string",
+          "title": "Image"
+        },
+        "initScript": {
+          "type": "object",
+          "properties": {
+            "file": {
+              "type": "string",
+              "title": "File"
+            },
+            "value": {
+              "type": "string",
+              "title": "Value"
+            }
+          },
+          "additionalProperties": false,
+          "title": "InitScript"
+        },
+        "labels": {
+          "title": "Labels",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string",
+                "title": "Name"
+              },
+              "value": {
+                "type": "string",
+                "title": "Value"
+              }
+            },
+            "additionalProperties": false,
+            "title": "Labels"
+          }
+        },
+        "name": {
+          "type": "string",
+          "title": "Name"
+        },
+        "password": {
+          "type": "string",
+          "title": "Password"
+        },
+        "portBindings": {
+          "title": "PortBindings",
+          "type": "array",
+          "items": {
+            "type": "string",
+            "title": "PortBindings"
+          }
+        },
+        "serviceName": {
+          "type": "string",
+          "title": "ServiceName"
+        },
+        "startUpTimeout": {
+          "type": "integer",
+          "title": "StartUpTimeout"
+        },
+        "username": {
+          "type": "string",
+          "title": "Username"
+        },
+        "version": {
+          "type": "string",
+          "title": "Version"
+        },
+        "volumeMounts": {
+          "title": "VolumeMounts",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "file": {
+                "type": "string",
+                "title": "File"
+              },
+              "mountPath": {
+                "type": "string",
+                "title": "MountPath"
+              }
+            },
+            "additionalProperties": false,
+            "title": "VolumeMounts"
+          }
+        },
+        "waitFor": {
+          "type": "object",
+          "properties": {
+            "disabled": {
+              "type": "boolean",
+              "title": "Disabled"
+            },
+            "logMessage": {
+              "type": "string",
+              "title": "LogMessage"
+            },
+            "url": {
+              "type": "string",
+              "title": "Url"
+            }
+          },
+          "additionalProperties": false,
+          "title": "WaitFor"
+        }
+      },
+      "additionalProperties": false    }
+  },
+  "testcontainers-start-redpanda": {
+    "kind": "testAction",
+    "version": "4.10.1",
+    "name": "testcontainers-start-redpanda",
+    "group": "testcontainers-start",
+    "title": "Redpanda",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "autoRemove": {
+          "type": "boolean",
+          "title": "AutoRemove"
+        },
+        "command": {
+          "type": "string",
+          "title": "Command"
+        },
+        "env": {
+          "title": "Env",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string",
+                "title": "Name"
+              },
+              "value": {
+                "type": "string",
+                "title": "Value"
+              }
+            },
+            "additionalProperties": false,
+            "title": "Env"
+          }
+        },
+        "exposedPorts": {
+          "title": "ExposedPorts",
+          "type": "array",
+          "items": {
+            "type": "integer",
+            "title": "ExposedPorts"
+          }
+        },
+        "image": {
+          "type": "string",
+          "title": "Image"
+        },
+        "labels": {
+          "title": "Labels",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string",
+                "title": "Name"
+              },
+              "value": {
+                "type": "string",
+                "title": "Value"
+              }
+            },
+            "additionalProperties": false,
+            "title": "Labels"
+          }
+        },
+        "name": {
+          "type": "string",
+          "title": "Name"
+        },
+        "portBindings": {
+          "title": "PortBindings",
+          "type": "array",
+          "items": {
+            "type": "string",
+            "title": "PortBindings"
+          }
+        },
+        "serviceName": {
+          "type": "string",
+          "title": "ServiceName"
+        },
+        "startUpTimeout": {
+          "type": "integer",
+          "title": "StartUpTimeout"
+        },
+        "version": {
+          "type": "string",
+          "title": "Version"
+        },
+        "volumeMounts": {
+          "title": "VolumeMounts",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "file": {
+                "type": "string",
+                "title": "File"
+              },
+              "mountPath": {
+                "type": "string",
+                "title": "MountPath"
+              }
+            },
+            "additionalProperties": false,
+            "title": "VolumeMounts"
+          }
+        },
+        "waitFor": {
+          "type": "object",
+          "properties": {
+            "disabled": {
+              "type": "boolean",
+              "title": "Disabled"
+            },
+            "logMessage": {
+              "type": "string",
+              "title": "LogMessage"
+            },
+            "url": {
+              "type": "string",
+              "title": "Url"
+            }
+          },
+          "additionalProperties": false,
+          "title": "WaitFor"
+        }
+      },
+      "additionalProperties": false    }
+  },
+  "testcontainers-stop": {
+    "kind": "testAction",
+    "version": "4.10.1",
+    "name": "testcontainers-stop",
+    "group": "testcontainers",
+    "module": "citrus-testcontainers",
+    "title": "Stop",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "title": "Name"
+        }
+      },
+      "additionalProperties": false    }
+  },
+  "trace": {
+    "kind": "testAction",
+    "version": "4.10.1",
+    "name": "trace",
+    "title": "Trace",
+    "description": "Trace variables test action.",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "variable": {
+          "type": "string",
+          "title": "Variable",
+          "description": "Name of the test variable to include."
+        },
+        "variables": {
+          "title": "Variables",
+          "description": "Test variable names to include.",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string",
+                "title": "Name"
+              }
+            },
+            "required": [
+              "name"
+            ],
+            "additionalProperties": false,
+            "title": "Variables",
+            "description": "Test variable names to include."
+          }
+        }
+      },
+      "additionalProperties": false    }
+  },
+  "transform": {
+    "kind": "testAction",
+    "version": "4.10.1",
+    "name": "transform",
+    "title": "Transform",
+    "description": "Transform test action.",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "description": {
+          "type": "string",
+          "title": "Description",
+          "description": "Test action description printed when the action is executed.",
+          "$comment": "group:advanced"
+        },
+        "result": {
+          "type": "string",
+          "title": "Result",
+          "description": "Set the target variable for the result."
+        },
+        "source": {
+          "type": "object",
+          "properties": {
+            "charset": {
+              "type": "string",
+              "title": "Charset",
+              "description": "Optional charset used when reading the file.",
+              "$comment": "group:advanced"
+            },
+            "file": {
+              "type": "string",
+              "title": "File",
+              "description": "The XML document file."
+            },
+            "value": {
+              "type": "string",
+              "title": "Value",
+              "description": "XML document as inline data."
+            }
+          },
+          "additionalProperties": false,
+          "title": "Source",
+          "description": "The XML document to transform"
+        },
+        "variable": {
+          "type": "string",
+          "title": "Variable",
+          "description": "Set the target variable for the result."
+        },
+        "xslt": {
+          "type": "object",
+          "properties": {
+            "charset": {
+              "type": "string",
+              "title": "Charset",
+              "description": "Optional charset used when reading the file.",
+              "$comment": "group:advanced"
+            },
+            "file": {
+              "type": "string",
+              "title": "File",
+              "description": "The XSLT document file."
+            },
+            "value": {
+              "type": "string",
+              "title": "Value",
+              "description": "The XSLT document as inline data."
+            }
+          },
+          "additionalProperties": false,
+          "title": "Xslt",
+          "description": "The XSLT document performing the transformation."
+        }
+      },
+      "required": [
+        "xslt"
+      ],
+      "additionalProperties": false    }
+  },
+  "waitFor": {
+    "kind": "testAction",
+    "version": "4.10.1",
+    "name": "waitFor",
+    "title": "WaitFor",
+    "description": "Wait for test action.",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "action": {
+        },
+        "description": {
+          "type": "string",
+          "title": "Description",
+          "description": "Test action description printed when the action is executed.",
+          "$comment": "group:advanced"
+        },
+        "file": {
+        },
+        "http": {
+        },
+        "interval": {
+          "type": "string",
+          "title": "Interval",
+          "description": "Interval in milliseconds to check for the given wait condition."
+        },
+        "message": {
+        },
+        "timeout": {
+          "type": "string",
+          "title": "Timeout",
+          "description": "Time to wait for the condition to become satisfied."
+        }
+      },
+      "additionalProperties": false,
+      "anyOf": [
+        {
+          "oneOf": [
+            {
+              "type": "object",
+              "properties": {
+                "message": {
+                  "type": "object",
+                  "properties": {
+                    "name": {
+                      "type": "string",
+                      "title": "Name",
+                      "description": "Message name in the message store."
+                    }
+                  },
+                  "additionalProperties": false,
+                  "title": "Message",
+                  "description": "Wait for given message to exist in message store."
+                }
+              }
+            },
+            {
+              "type": "object",
+              "properties": {
+                "http": {
+                  "type": "object",
+                  "properties": {
+                    "method": {
+                      "type": "string",
+                      "title": "Method",
+                      "description": "The Http request method to use."
+                    },
+                    "status": {
+                      "type": "string",
+                      "title": "Status",
+                      "description": "The expected Http status code."
+                    },
+                    "timeout": {
+                      "type": "string",
+                      "title": "Timeout",
+                      "description": "Http request timeout."
+                    },
+                    "url": {
+                      "type": "string",
+                      "title": "Url",
+                      "description": "Http request URL."
+                    }
+                  },
+                  "additionalProperties": false,
+                  "title": "Http",
+                  "description": "Wait for given Http endpoint to return a proper response code."
+                }
+              }
+            },
+            {
+              "type": "object",
+              "properties": {
+                "file": {
+                  "type": "object",
+                  "properties": {
+                    "path": {
+                      "type": "string",
+                      "title": "Path",
+                      "description": "File path to evaluate."
+                    }
+                  },
+                  "additionalProperties": false,
+                  "title": "File",
+                  "description": "Wait for given file path to exist."
+                }
+              }
+            },
+            {
+              "type": "object",
+              "properties": {
+                "action": {
+                  "type": "object",
+                  "title": "Action",
+                  "description": "Waits for the test action to complete."
+                }
+              }
+            }
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/catalog/citrus/4.10.1/citrus-catalog-aggregate-test-containers.json
+++ b/catalog/citrus/4.10.1/citrus-catalog-aggregate-test-containers.json
@@ -1,0 +1,573 @@
+{
+  "assert": {
+    "kind": "testContainer",
+    "version": "4.10.1",
+    "name": "assert",
+    "title": "Assert",
+    "description": "Assert exception test action.",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "description": {
+          "type": "string",
+          "title": "Description",
+          "description": "Test action description printed when the action is executed.",
+          "$comment": "group:advanced"
+        },
+        "exception": {
+          "type": "string",
+          "title": "Exception",
+          "description": "The type of the Java exception."
+        },
+        "message": {
+          "type": "string",
+          "title": "Message",
+          "description": "The expected exception message."
+        },
+        "when": {
+          "title": "When",
+          "description": "Nested test actions that raise the exception.",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "title": "When",
+            "description": "Nested test actions that raise the exception."
+          }
+        }
+      },
+      "required": [
+        "when"
+      ],
+      "additionalProperties": false    }
+  },
+  "async": {
+    "kind": "testContainer",
+    "version": "4.10.1",
+    "name": "async",
+    "title": "Async",
+    "description": "Async test action.",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "actions": {
+          "title": "Actions",
+          "description": "Sequence of test actions to execute.",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "title": "Actions",
+            "description": "Sequence of test actions to execute."
+          }
+        },
+        "description": {
+          "type": "string",
+          "title": "Description",
+          "description": "Test action description printed when the action is executed.",
+          "$comment": "group:advanced"
+        },
+        "error": {
+          "title": "Error",
+          "description": "Test actions executed when async container has failed.",
+          "$comment": "group:advanced",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "title": "Error",
+            "description": "Test actions executed when async container has failed.",
+            "$comment": "group:advanced"
+          }
+        },
+        "success": {
+          "title": "Success",
+          "description": "Test actions executed when async container is successful.",
+          "$comment": "group:advanced",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "title": "Success",
+            "description": "Test actions executed when async container is successful.",
+            "$comment": "group:advanced"
+          }
+        }
+      },
+      "required": [
+        "actions"
+      ],
+      "additionalProperties": false    }
+  },
+  "catch": {
+    "kind": "testContainer",
+    "version": "4.10.1",
+    "name": "catch",
+    "title": "Catch",
+    "description": "Catch exception test action.",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "description": {
+          "type": "string",
+          "title": "Description",
+          "description": "Test action description printed when the action is executed.",
+          "$comment": "group:advanced"
+        },
+        "exception": {
+          "type": "string",
+          "title": "Exception",
+          "description": "The exception type to catch."
+        },
+        "when": {
+          "title": "When",
+          "description": "Nested test actions that may raise an exception.",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "title": "When",
+            "description": "Nested test actions that may raise an exception."
+          }
+        }
+      },
+      "required": [
+        "when"
+      ],
+      "additionalProperties": false    }
+  },
+  "conditional": {
+    "kind": "testContainer",
+    "version": "4.10.1",
+    "name": "conditional",
+    "title": "Conditional",
+    "description": "Conditional test action.",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "actions": {
+          "title": "Actions",
+          "description": "Test actions that get executed when the condition matches.",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "title": "Actions",
+            "description": "Test actions that get executed when the condition matches."
+          }
+        },
+        "description": {
+          "type": "string",
+          "title": "Description",
+          "description": "Test action description printed when the action is executed.",
+          "$comment": "group:advanced"
+        },
+        "when": {
+          "type": "string",
+          "title": "When",
+          "description": "The condition to evaluate."
+        }
+      },
+      "required": [
+        "actions",
+        "when"
+      ],
+      "additionalProperties": false    }
+  },
+  "doFinally": {
+    "kind": "testContainer",
+    "version": "4.10.1",
+    "name": "doFinally",
+    "title": "DoFinally",
+    "description": "Runs test actions after the test.",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "actions": {
+          "title": "Actions",
+          "description": "Test actions to execute after the test.",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "title": "Actions",
+            "description": "Test actions to execute after the test."
+          }
+        },
+        "description": {
+          "type": "string",
+          "title": "Description",
+          "description": "Test action description printed when the action is executed.",
+          "$comment": "group:advanced"
+        }
+      },
+      "required": [
+        "actions"
+      ],
+      "additionalProperties": false    }
+  },
+  "iterate": {
+    "kind": "testContainer",
+    "version": "4.10.1",
+    "name": "iterate",
+    "title": "Iterate",
+    "description": "Iterate test action.",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "actions": {
+          "title": "Actions",
+          "description": "Sequence of test actions to execute.",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "title": "Actions",
+            "description": "Sequence of test actions to execute."
+          }
+        },
+        "condition": {
+          "type": "string",
+          "title": "Condition",
+          "description": "Condition that keeps the iteration running."
+        },
+        "description": {
+          "type": "string",
+          "title": "Description",
+          "description": "Test action description printed when the action is executed.",
+          "$comment": "group:advanced"
+        },
+        "index": {
+          "type": "string",
+          "title": "Index",
+          "description": "Test variable holding the current iteration index.",
+          "$comment": "group:advanced"
+        },
+        "startsWith": {
+          "type": "integer",
+          "title": "StartsWith",
+          "description": "Index starts with this value.",
+          "default": "1",
+          "$comment": "group:advanced"
+        },
+        "step": {
+          "type": "integer",
+          "title": "Step",
+          "description": "The step added to the index for each iteration.",
+          "default": "1",
+          "$comment": "group:advanced"
+        }
+      },
+      "required": [
+        "actions",
+        "condition"
+      ],
+      "additionalProperties": false    }
+  },
+  "parallel": {
+    "kind": "testContainer",
+    "version": "4.10.1",
+    "name": "parallel",
+    "title": "Parallel",
+    "description": "Parallel test action.",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "actions": {
+          "title": "Actions",
+          "description": "Test actions to execute.",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "title": "Actions",
+            "description": "Test actions to execute."
+          }
+        },
+        "description": {
+          "type": "string",
+          "title": "Description",
+          "description": "Test action description printed when the action is executed.",
+          "$comment": "group:advanced"
+        }
+      },
+      "required": [
+        "actions"
+      ],
+      "additionalProperties": false    }
+  },
+  "repeat": {
+    "kind": "testContainer",
+    "version": "4.10.1",
+    "name": "repeat",
+    "title": "Repeat",
+    "description": "Repeat test action.",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "actions": {
+          "title": "Actions",
+          "description": "Sequence of test actions to execute.",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "title": "Actions",
+            "description": "Sequence of test actions to execute."
+          }
+        },
+        "description": {
+          "type": "string",
+          "title": "Description",
+          "description": "Test action description printed when the action is executed.",
+          "$comment": "group:advanced"
+        },
+        "index": {
+          "type": "string",
+          "title": "Index",
+          "description": "Test variable holding the current iteration index.",
+          "$comment": "group:advanced"
+        },
+        "startsWith": {
+          "type": "integer",
+          "title": "StartsWith",
+          "description": "Index starts with this value.",
+          "default": "1",
+          "$comment": "group:advanced"
+        },
+        "until": {
+          "type": "string",
+          "title": "Until",
+          "description": "Condition that ends the iteration."
+        }
+      },
+      "required": [
+        "actions"
+      ],
+      "additionalProperties": false    }
+  },
+  "repeatOnError": {
+    "kind": "testContainer",
+    "version": "4.10.1",
+    "name": "repeatOnError",
+    "title": "RepeatOnError",
+    "description": "Repeat on error test action.",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "actions": {
+          "title": "Actions",
+          "description": "Sequence of test actions to execute.",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "title": "Actions",
+            "description": "Sequence of test actions to execute."
+          }
+        },
+        "autoSleep": {
+          "type": "integer",
+          "title": "AutoSleep",
+          "description": "Automatically sleep the time in milliseconds with each attempt."
+        },
+        "description": {
+          "type": "string",
+          "title": "Description",
+          "description": "Test action description printed when the action is executed.",
+          "$comment": "group:advanced"
+        },
+        "index": {
+          "type": "string",
+          "title": "Index",
+          "description": "Test variable holding the current iteration index.",
+          "$comment": "group:advanced"
+        },
+        "startsWith": {
+          "type": "integer",
+          "title": "StartsWith",
+          "description": "Index starts with this value.",
+          "default": "1",
+          "$comment": "group:advanced"
+        },
+        "until": {
+          "type": "string",
+          "title": "Until",
+          "description": "Condition that ends the iteration."
+        }
+      },
+      "required": [
+        "actions"
+      ],
+      "additionalProperties": false    }
+  },
+  "sequential": {
+    "kind": "testContainer",
+    "version": "4.10.1",
+    "name": "sequential",
+    "title": "Sequential",
+    "description": "Sequential test action.",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "actions": {
+          "title": "Actions",
+          "description": "Sequence of test actions to execute.",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "title": "Actions",
+            "description": "Sequence of test actions to execute."
+          }
+        },
+        "description": {
+          "type": "string",
+          "title": "Description",
+          "description": "Test action description printed when the action is executed.",
+          "$comment": "group:advanced"
+        }
+      },
+      "required": [
+        "actions"
+      ],
+      "additionalProperties": false    }
+  },
+  "soap-assertFault": {
+    "kind": "testContainer",
+    "version": "4.10.1",
+    "name": "soap-assertFault",
+    "group": "soap",
+    "module": "citrus-ws",
+    "title": "AssertFault",
+    "description": "Expects a SOAP fault response as a client.",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "faultActor": {
+          "type": "string",
+          "title": "FaultActor",
+          "description": "The SOAP fault actor.",
+          "$comment": "group:advanced"
+        },
+        "faultCode": {
+          "type": "string",
+          "title": "FaultCode",
+          "description": "The SOAP fault code."
+        },
+        "faultDetails": {
+          "title": "FaultDetails",
+          "description": "The SOAP fault details.",
+          "$comment": "group:advanced",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "content": {
+                "type": "string",
+                "title": "Content",
+                "description": "The SOAP fault detail content."
+              },
+              "resource": {
+                "type": "string",
+                "title": "Resource",
+                "description": "The SOAP fault detail loaded from a file resource."
+              }
+            },
+            "additionalProperties": false,
+            "title": "FaultDetails",
+            "description": "The SOAP fault details.",
+            "$comment": "group:advanced"
+          }
+        },
+        "faultString": {
+          "type": "string",
+          "title": "FaultString",
+          "description": "The SOAP fault string."
+        },
+        "validator": {
+          "type": "string",
+          "title": "Validator",
+          "description": "Explicit message validator.",
+          "$comment": "group:advanced"
+        },
+        "when": {
+          "type": "object",
+          "title": "When",
+          "description": "The test action raising the SOAP fault response message."
+        }
+      },
+      "required": [
+        "when"
+      ],
+      "additionalProperties": false    }
+  },
+  "timer": {
+    "kind": "testContainer",
+    "version": "4.10.1",
+    "name": "timer",
+    "title": "Timer",
+    "description": "Timer test action.",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "actions": {
+          "title": "Actions",
+          "description": "Sequence of test actions to execute.",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "title": "Actions",
+            "description": "Sequence of test actions to execute."
+          }
+        },
+        "autoStop": {
+          "type": "boolean",
+          "title": "AutoStop",
+          "description": "Automatically stop the timer when the test is finished.",
+          "default": "true",
+          "$comment": "group:advanced"
+        },
+        "delay": {
+          "type": "integer",
+          "title": "Delay",
+          "description": "Initial delay to wait before starting the timer.",
+          "$comment": "group:advanced"
+        },
+        "description": {
+          "type": "string",
+          "title": "Description",
+          "description": "Test action description printed when the action is executed.",
+          "$comment": "group:advanced"
+        },
+        "fork": {
+          "type": "boolean",
+          "title": "Fork",
+          "description": "Do not block the test while the timer is running.",
+          "default": "false",
+          "$comment": "group:advanced"
+        },
+        "id": {
+          "type": "string",
+          "title": "Id",
+          "description": "The id of the timer."
+        },
+        "interval": {
+          "type": "integer",
+          "title": "Interval",
+          "description": "Timer interval in milliseconds.",
+          "default": "1000"
+        },
+        "repeatCount": {
+          "type": "integer",
+          "title": "RepeatCount",
+          "description": "Number of timer executions.",
+          "$comment": "group:advanced"
+        }
+      },
+      "required": [
+        "actions"
+      ],
+      "additionalProperties": false    }
+  }
+}

--- a/catalog/citrus/4.10.1/citrus-catalog-aggregate-validation-matcher.json
+++ b/catalog/citrus/4.10.1/citrus-catalog-aggregate-validation-matcher.json
@@ -1,0 +1,514 @@
+{
+  "isUUIDv4": {
+    "kind": "testValidationMatcher",
+    "version": "4.10.1",
+    "name": "isUUIDv4",
+    "group": "citrus",
+    "module": "citrus-base",
+    "title": "IsUUIDv4",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "additionalProperties": false    }
+  },
+  "dateRange": {
+    "kind": "testValidationMatcher",
+    "version": "4.10.1",
+    "name": "dateRange",
+    "group": "citrus",
+    "module": "citrus-base",
+    "title": "DateRange",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "dateFormat": {
+          "type": "string",
+          "title": "DateFormat",
+          "description": "The date format string.",
+          "default": "yyyy-MM-dd"
+        },
+        "dateFrom": {
+          "type": "string",
+          "title": "DateFrom",
+          "description": "The expected data range start value."
+        },
+        "dateTo": {
+          "type": "string",
+          "title": "DateTo",
+          "description": "The expected data range end value."
+        }
+      },
+      "required": [
+        "dateFrom",
+        "dateTo"
+      ],
+      "additionalProperties": false    }
+  },
+  "lowerThan": {
+    "kind": "testValidationMatcher",
+    "version": "4.10.1",
+    "name": "lowerThan",
+    "group": "citrus",
+    "module": "citrus-base",
+    "title": "LowerThan",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "value": {
+          "type": "number",
+          "title": "Value",
+          "description": "The numeric value to evaluate."
+        }
+      },
+      "required": [
+        "value"
+      ],
+      "additionalProperties": false    }
+  },
+  "matchesDatePattern": {
+    "kind": "testValidationMatcher",
+    "version": "4.10.1",
+    "name": "matchesDatePattern",
+    "group": "citrus",
+    "module": "citrus-base",
+    "title": "MatchesDatePattern",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "value": {
+          "type": "string",
+          "title": "Value",
+          "description": "The expected control value."
+        }
+      },
+      "required": [
+        "value"
+      ],
+      "additionalProperties": false    }
+  },
+  "isWeekday": {
+    "kind": "testValidationMatcher",
+    "version": "4.10.1",
+    "name": "isWeekday",
+    "group": "citrus",
+    "module": "citrus-base",
+    "title": "IsWeekday",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "dateFormat": {
+          "type": "string",
+          "title": "DateFormat",
+          "description": "The date format string.",
+          "default": "dd.MM.yyyy"
+        },
+        "weekday": {
+          "type": "string",
+          "enum": [
+            "MONDAY",
+            "TUESDAY",
+            "WEDNESDAY",
+            "THURSDAY",
+            "FRIDAY",
+            "SATURDAY",
+            "SUNDAY"
+          ],
+          "title": "Weekday",
+          "description": "The expected weekday."
+        }
+      },
+      "required": [
+        "weekday"
+      ],
+      "additionalProperties": false    }
+  },
+  "empty": {
+    "kind": "testValidationMatcher",
+    "version": "4.10.1",
+    "name": "empty",
+    "group": "citrus",
+    "module": "citrus-base",
+    "title": "Empty",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "additionalProperties": false    }
+  },
+  "trim": {
+    "kind": "testValidationMatcher",
+    "version": "4.10.1",
+    "name": "trim",
+    "group": "citrus",
+    "module": "citrus-base",
+    "title": "Trim",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "value": {
+          "type": "string",
+          "title": "Value",
+          "description": "The expected control value."
+        }
+      },
+      "required": [
+        "value"
+      ],
+      "additionalProperties": false    }
+  },
+  "ignoreNewLine": {
+    "kind": "testValidationMatcher",
+    "version": "4.10.1",
+    "name": "ignoreNewLine",
+    "group": "citrus",
+    "module": "citrus-base",
+    "title": "IgnoreNewLine",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "value": {
+          "type": "string",
+          "title": "Value",
+          "description": "The expected control value."
+        }
+      },
+      "required": [
+        "value"
+      ],
+      "additionalProperties": false    }
+  },
+  "isNumber": {
+    "kind": "testValidationMatcher",
+    "version": "4.10.1",
+    "name": "isNumber",
+    "group": "citrus",
+    "module": "citrus-base",
+    "title": "IsNumber",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "additionalProperties": false    }
+  },
+  "ignore": {
+    "kind": "testValidationMatcher",
+    "version": "4.10.1",
+    "name": "ignore",
+    "group": "citrus",
+    "module": "citrus-base",
+    "title": "Ignore",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "additionalProperties": false    }
+  },
+  "equalsIgnoreCase": {
+    "kind": "testValidationMatcher",
+    "version": "4.10.1",
+    "name": "equalsIgnoreCase",
+    "group": "citrus",
+    "module": "citrus-base",
+    "title": "EqualsIgnoreCase",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "value": {
+          "type": "string",
+          "title": "Value",
+          "description": "The expected control value."
+        }
+      },
+      "required": [
+        "value"
+      ],
+      "additionalProperties": false    }
+  },
+  "hasLength": {
+    "kind": "testValidationMatcher",
+    "version": "4.10.1",
+    "name": "hasLength",
+    "group": "citrus",
+    "module": "citrus-base",
+    "title": "HasLength",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "value": {
+          "type": "string",
+          "title": "Value",
+          "description": "The expected control value."
+        }
+      },
+      "required": [
+        "value"
+      ],
+      "additionalProperties": false    }
+  },
+  "greaterThan": {
+    "kind": "testValidationMatcher",
+    "version": "4.10.1",
+    "name": "greaterThan",
+    "group": "citrus",
+    "module": "citrus-base",
+    "title": "GreaterThan",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "value": {
+          "type": "number",
+          "title": "Value",
+          "description": "The numeric value to evaluate."
+        }
+      },
+      "required": [
+        "value"
+      ],
+      "additionalProperties": false    }
+  },
+  "notNull": {
+    "kind": "testValidationMatcher",
+    "version": "4.10.1",
+    "name": "notNull",
+    "group": "citrus",
+    "module": "citrus-base",
+    "title": "NotNull",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "additionalProperties": false    }
+  },
+  "matchesXml": {
+    "kind": "testValidationMatcher",
+    "version": "4.10.1",
+    "name": "matchesXml",
+    "group": "citrus",
+    "module": "citrus-validation-xml",
+    "title": "MatchesXml",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "value": {
+          "type": "string",
+          "title": "Value",
+          "description": "The expected control value."
+        }
+      },
+      "required": [
+        "value"
+      ],
+      "additionalProperties": false    }
+  },
+  "containsIgnoreCase": {
+    "kind": "testValidationMatcher",
+    "version": "4.10.1",
+    "name": "containsIgnoreCase",
+    "group": "citrus",
+    "module": "citrus-base",
+    "title": "ContainsIgnoreCase",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "value": {
+          "type": "string",
+          "title": "Value",
+          "description": "The expected control value."
+        }
+      },
+      "required": [
+        "value"
+      ],
+      "additionalProperties": false    }
+  },
+  "trimAllWhitespaces": {
+    "kind": "testValidationMatcher",
+    "version": "4.10.1",
+    "name": "trimAllWhitespaces",
+    "group": "citrus",
+    "module": "citrus-base",
+    "title": "TrimAllWhitespaces",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "value": {
+          "type": "string",
+          "title": "Value",
+          "description": "The expected control value."
+        }
+      },
+      "required": [
+        "value"
+      ],
+      "additionalProperties": false    }
+  },
+  "assertThat": {
+    "kind": "testValidationMatcher",
+    "version": "4.10.1",
+    "name": "assertThat",
+    "group": "citrus",
+    "module": "citrus-validation-hamcrest",
+    "title": "AssertThat",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "expression": {
+          "type": "string",
+          "title": "Expression",
+          "description": "The Hamcrest expression to evaluate."
+        },
+        "value": {
+          "type": "string",
+          "title": "Value",
+          "description": "The value to verify."
+        }
+      },
+      "required": [
+        "expression"
+      ],
+      "additionalProperties": false    }
+  },
+  "matches": {
+    "kind": "testValidationMatcher",
+    "version": "4.10.1",
+    "name": "matches",
+    "group": "citrus",
+    "module": "citrus-base",
+    "title": "Matches",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "value": {
+          "type": "string",
+          "title": "Value",
+          "description": "The expected control value."
+        }
+      },
+      "required": [
+        "value"
+      ],
+      "additionalProperties": false    }
+  },
+  "contains": {
+    "kind": "testValidationMatcher",
+    "version": "4.10.1",
+    "name": "contains",
+    "group": "citrus",
+    "module": "citrus-base",
+    "title": "Contains",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "value": {
+          "type": "string",
+          "title": "Value",
+          "description": "The expected control value."
+        }
+      },
+      "required": [
+        "value"
+      ],
+      "additionalProperties": false    }
+  },
+  "null": {
+    "kind": "testValidationMatcher",
+    "version": "4.10.1",
+    "name": "null",
+    "group": "citrus",
+    "module": "citrus-base",
+    "title": "Null",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "additionalProperties": false    }
+  },
+  "endsWith": {
+    "kind": "testValidationMatcher",
+    "version": "4.10.1",
+    "name": "endsWith",
+    "group": "citrus",
+    "module": "citrus-base",
+    "title": "EndsWith",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "value": {
+          "type": "string",
+          "title": "Value",
+          "description": "The expected control value."
+        }
+      },
+      "required": [
+        "value"
+      ],
+      "additionalProperties": false    }
+  },
+  "variable": {
+    "kind": "testValidationMatcher",
+    "version": "4.10.1",
+    "name": "variable",
+    "group": "citrus",
+    "module": "citrus-base",
+    "title": "Variable",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "value": {
+          "type": "string",
+          "title": "Value",
+          "description": "The expected control value."
+        }
+      },
+      "required": [
+        "value"
+      ],
+      "additionalProperties": false    }
+  },
+  "notEmpty": {
+    "kind": "testValidationMatcher",
+    "version": "4.10.1",
+    "name": "notEmpty",
+    "group": "citrus",
+    "module": "citrus-base",
+    "title": "NotEmpty",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "additionalProperties": false    }
+  },
+  "startsWith": {
+    "kind": "testValidationMatcher",
+    "version": "4.10.1",
+    "name": "startsWith",
+    "group": "citrus",
+    "module": "citrus-base",
+    "title": "StartsWith",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "value": {
+          "type": "string",
+          "title": "Value",
+          "description": "The expected control value."
+        }
+      },
+      "required": [
+        "value"
+      ],
+      "additionalProperties": false    }
+  }
+}

--- a/catalog/citrus/4.10.1/citrus-testcase.json
+++ b/catalog/citrus/4.10.1/citrus-testcase.json
@@ -1,0 +1,14254 @@
+{
+  "$schema" : "http://json-schema.org/draft-07/schema#",
+  "definitions" : {
+    "Attachment" : {
+      "type" : "object",
+      "properties" : {
+        "charset" : {
+          "type" : "string",
+          "title" : "Charset",
+          "description" : "The SOAP attachment charset.",
+          "$comment" : "group:advanced"
+        },
+        "content" : {
+          "type" : "string",
+          "title" : "Content",
+          "description" : "The SOAP attachment content."
+        },
+        "contentId" : {
+          "type" : "string",
+          "title" : "ContentId",
+          "description" : "The SOAP attachment content id."
+        },
+        "contentType" : {
+          "type" : "string",
+          "title" : "ContentType",
+          "description" : "The SOAP attachment content type"
+        },
+        "resource" : {
+          "type" : "string",
+          "title" : "Resource",
+          "description" : "The SOAP attachment content loaded from a file resource."
+        }
+      },
+      "additionalProperties" : false
+    },
+    "AutoFillType" : {
+      "type" : "string",
+      "enum" : [ "NONE", "REQUIRED", "ALL" ]
+    },
+    "Body" : {
+      "type" : "object",
+      "properties" : {
+        "data" : { },
+        "resource" : { },
+        "script" : { }
+      },
+      "additionalProperties" : false,
+      "anyOf" : [ {
+        "oneOf" : [ {
+          "type" : "object",
+          "properties" : {
+            "data" : {
+              "type" : "string",
+              "title" : "Data",
+              "description" : "The message body content as inline data."
+            }
+          },
+          "required" : [ "data" ]
+        }, {
+          "type" : "object",
+          "properties" : {
+            "resource" : {
+              "type" : "object",
+              "properties" : {
+                "charset" : {
+                  "type" : "string",
+                  "title" : "Charset",
+                  "$comment" : "group:advanced"
+                },
+                "file" : {
+                  "type" : "string",
+                  "title" : "File"
+                }
+              },
+              "additionalProperties" : false,
+              "title" : "Resource",
+              "description" : "The message body loaded from a file resource."
+            }
+          },
+          "required" : [ "resource" ]
+        }, {
+          "type" : "object",
+          "properties" : {
+            "script" : {
+              "type" : "object",
+              "properties" : {
+                "charset" : {
+                  "type" : "string",
+                  "title" : "Charset",
+                  "description" : "The charset used to load the file resource.",
+                  "$comment" : "group:advanced"
+                },
+                "content" : {
+                  "type" : "string",
+                  "title" : "Content",
+                  "description" : "The script content as inline data."
+                },
+                "file" : {
+                  "type" : "string",
+                  "title" : "File",
+                  "description" : "The script content loaded as a file resource."
+                },
+                "type" : {
+                  "type" : "string",
+                  "title" : "Type",
+                  "description" : "The script type.",
+                  "default" : "groovy"
+                }
+              },
+              "additionalProperties" : false,
+              "title" : "Script",
+              "description" : "The message body set via script."
+            }
+          },
+          "required" : [ "script" ]
+        } ]
+      } ]
+    },
+    "Element" : {
+      "type" : "object",
+      "properties" : {
+        "className" : {
+          "type" : "string",
+          "title" : "ClassName"
+        },
+        "cssSelector" : {
+          "type" : "string",
+          "title" : "CssSelector"
+        },
+        "id" : {
+          "type" : "string",
+          "title" : "Id"
+        },
+        "linkText" : {
+          "type" : "string",
+          "title" : "LinkText"
+        },
+        "name" : {
+          "type" : "string",
+          "title" : "Name"
+        },
+        "partialLinkText" : {
+          "type" : "string",
+          "title" : "PartialLinkText"
+        },
+        "property" : {
+          "type" : "object",
+          "properties" : {
+            "name" : {
+              "type" : "string",
+              "title" : "Name"
+            },
+            "value" : {
+              "type" : "string",
+              "title" : "Value"
+            }
+          },
+          "additionalProperties" : false,
+          "title" : "Property"
+        },
+        "tagName" : {
+          "type" : "string",
+          "title" : "TagName"
+        },
+        "xpath" : {
+          "type" : "string",
+          "title" : "Xpath"
+        }
+      },
+      "additionalProperties" : false
+    },
+    "ErrorHandlingStrategy" : {
+      "type" : "string",
+      "enum" : [ "THROWS_EXCEPTION", "PROPAGATE" ]
+    },
+    "Expression" : {
+      "type" : "object",
+      "properties" : {
+        "path" : {
+          "type" : "string",
+          "title" : "Path",
+          "description" : "The path expression to evaluate."
+        },
+        "value" : {
+          "type" : "string",
+          "title" : "Value",
+          "description" : "The expected expression result value."
+        }
+      },
+      "required" : [ "path", "value" ],
+      "additionalProperties" : false
+    },
+    "Extract" : {
+      "type" : "object",
+      "properties" : {
+        "body" : {
+          "title" : "Body",
+          "description" : "Extract elements from the message body into test variables.",
+          "type" : "array",
+          "items" : {
+            "type" : "object",
+            "properties" : {
+              "path" : {
+                "type" : "string",
+                "title" : "Path",
+                "description" : "The path expression to evaluate."
+              },
+              "resultType" : {
+                "type" : "string",
+                "title" : "ResultType",
+                "description" : "The expression result type. By default the path expression evaluate to String values.With this setting you can force another expression result type.",
+                "$comment" : "group:advanced"
+              },
+              "variable" : {
+                "type" : "string",
+                "title" : "Variable",
+                "description" : "The test variable name."
+              }
+            },
+            "required" : [ "variable" ],
+            "additionalProperties" : false,
+            "title" : "Body",
+            "description" : "Extract elements from the message body into test variables."
+          }
+        },
+        "header" : {
+          "title" : "Header",
+          "description" : "Extract elements from the message header into test variables.",
+          "type" : "array",
+          "items" : {
+            "type" : "object",
+            "properties" : {
+              "name" : {
+                "type" : "string",
+                "title" : "Name",
+                "description" : "The name of the message header."
+              },
+              "variable" : {
+                "type" : "string",
+                "title" : "Variable",
+                "description" : "The test variable name."
+              }
+            },
+            "required" : [ "name", "variable" ],
+            "additionalProperties" : false,
+            "title" : "Header",
+            "description" : "Extract elements from the message header into test variables."
+          }
+        }
+      },
+      "additionalProperties" : false
+    },
+    "Header" : {
+      "type" : "object",
+      "properties" : {
+        "data" : { },
+        "name" : {
+          "type" : "string",
+          "title" : "Name",
+          "description" : "The message header name."
+        },
+        "resource" : { },
+        "type" : {
+          "type" : "string",
+          "title" : "Type",
+          "description" : "The message header type to create typed message headers.",
+          "$comment" : "group:advanced"
+        },
+        "value" : { }
+      },
+      "additionalProperties" : false,
+      "anyOf" : [ {
+        "oneOf" : [ {
+          "type" : "object",
+          "properties" : {
+            "value" : {
+              "type" : "string",
+              "title" : "Value",
+              "description" : "The message header value."
+            }
+          },
+          "required" : [ "value" ]
+        }, {
+          "type" : "object",
+          "properties" : {
+            "resource" : {
+              "type" : "object",
+              "properties" : {
+                "charset" : {
+                  "type" : "string",
+                  "title" : "Charset",
+                  "description" : "Optional file resource charset used to read the file content.",
+                  "$comment" : "group:advanced"
+                },
+                "file" : {
+                  "type" : "string",
+                  "title" : "File",
+                  "description" : "The file resource path."
+                }
+              },
+              "required" : [ "file" ],
+              "additionalProperties" : false,
+              "title" : "Resource",
+              "description" : "The header data loaded from a file resource."
+            }
+          },
+          "required" : [ "resource" ]
+        }, {
+          "type" : "object",
+          "properties" : {
+            "data" : {
+              "type" : "string",
+              "title" : "Data",
+              "description" : "The message header value as inline data."
+            }
+          },
+          "required" : [ "data" ]
+        } ]
+      } ]
+    },
+    "HttpRequest" : {
+      "type" : "object",
+      "properties" : {
+        "accept" : {
+          "type" : "string",
+          "title" : "Accept",
+          "description" : "Http accept header.",
+          "$comment" : "group:advanced"
+        },
+        "body" : {
+          "allOf" : [ {
+            "$ref" : "#/definitions/Body"
+          }, {
+            "title" : "Body",
+            "description" : "The message body."
+          } ]
+        },
+        "contentType" : {
+          "type" : "string",
+          "title" : "ContentType",
+          "description" : "Http content type."
+        },
+        "dataDictionary" : {
+          "type" : "string",
+          "title" : "DataDictionary",
+          "description" : "Sets a data dictionary that transforms message content before it is being processed.",
+          "$comment" : "group:dictionary"
+        },
+        "expression" : {
+          "title" : "Expression",
+          "description" : "List of path expressions to evaluate on the message content before processing the message.",
+          "$comment" : "group:advanced",
+          "type" : "array",
+          "items" : {
+            "allOf" : [ {
+              "$ref" : "#/definitions/Expression"
+            }, {
+              "title" : "Expression",
+              "description" : "List of path expressions to evaluate on the message content before processing the message.",
+              "$comment" : "group:advanced"
+            } ]
+          }
+        },
+        "headerIgnoreCase" : {
+          "type" : "string",
+          "title" : "HeaderIgnoreCase",
+          "description" : "When enabled the header case is not verified.",
+          "$comment" : "group:advanced"
+        },
+        "headers" : {
+          "title" : "Headers",
+          "description" : "The message headers.",
+          "type" : "array",
+          "items" : {
+            "allOf" : [ {
+              "$ref" : "#/definitions/Header"
+            }, {
+              "title" : "Headers",
+              "description" : "The message headers."
+            } ]
+          }
+        },
+        "name" : {
+          "type" : "string",
+          "title" : "Name",
+          "description" : "The message name. Named messages may be referenced in subsequent test steps."
+        },
+        "parameters" : {
+          "title" : "Parameters",
+          "description" : "List of Http query parameters.",
+          "$comment" : "group:advanced",
+          "type" : "array",
+          "items" : {
+            "type" : "object",
+            "properties" : {
+              "name" : {
+                "type" : "string",
+                "title" : "Name",
+                "description" : "Http query parameter name."
+              },
+              "value" : {
+                "type" : "string",
+                "title" : "Value",
+                "description" : "Http query parameter value."
+              }
+            },
+            "required" : [ "name", "value" ],
+            "additionalProperties" : false,
+            "title" : "Parameters",
+            "description" : "List of Http query parameters.",
+            "$comment" : "group:advanced"
+          }
+        },
+        "path" : {
+          "type" : "string",
+          "title" : "Path",
+          "description" : "Http request path."
+        },
+        "schema" : {
+          "type" : "string",
+          "title" : "Schema",
+          "description" : "The reference to a schema in the bean registry that should be used for validation.",
+          "$comment" : "group:schema"
+        },
+        "schemaRepository" : {
+          "type" : "string",
+          "title" : "SchemaRepository",
+          "description" : "The schema repository holding the schema.",
+          "$comment" : "group:schema"
+        },
+        "schemaValidation" : {
+          "type" : "boolean",
+          "title" : "SchemaValidation",
+          "description" : "Enables the schema validation.",
+          "$comment" : "group:schema"
+        },
+        "type" : {
+          "type" : "string",
+          "title" : "Type",
+          "description" : "The message type. Gives the validator a hint which validatory are capable of performing proper message validation.",
+          "$comment" : "group:advanced"
+        },
+        "version" : {
+          "type" : "string",
+          "title" : "Version",
+          "description" : "Http version.",
+          "$comment" : "group:advanced"
+        }
+      },
+      "additionalProperties" : false
+    },
+    "HttpResponse" : {
+      "type" : "object",
+      "properties" : {
+        "body" : {
+          "allOf" : [ {
+            "$ref" : "#/definitions/Body"
+          }, {
+            "title" : "Body",
+            "description" : "The message body."
+          } ]
+        },
+        "contentType" : {
+          "type" : "string",
+          "title" : "ContentType",
+          "description" : "Http content type."
+        },
+        "dataDictionary" : {
+          "type" : "string",
+          "title" : "DataDictionary",
+          "description" : "Sets a data dictionary that transforms message content before it is being processed.",
+          "$comment" : "group:dictionary"
+        },
+        "expression" : {
+          "title" : "Expression",
+          "description" : "List of path expressions to evaluate on the message content before processing the message.",
+          "$comment" : "group:advanced",
+          "type" : "array",
+          "items" : {
+            "allOf" : [ {
+              "$ref" : "#/definitions/Expression"
+            }, {
+              "title" : "Expression",
+              "description" : "List of path expressions to evaluate on the message content before processing the message.",
+              "$comment" : "group:advanced"
+            } ]
+          }
+        },
+        "headerIgnoreCase" : {
+          "type" : "string",
+          "title" : "HeaderIgnoreCase",
+          "description" : "When enabled the header case is not verified.",
+          "$comment" : "group:advanced"
+        },
+        "headers" : {
+          "title" : "Headers",
+          "description" : "The message headers.",
+          "type" : "array",
+          "items" : {
+            "allOf" : [ {
+              "$ref" : "#/definitions/Header"
+            }, {
+              "title" : "Headers",
+              "description" : "The message headers."
+            } ]
+          }
+        },
+        "name" : {
+          "type" : "string",
+          "title" : "Name",
+          "description" : "The message name. Named messages may be referenced in subsequent test steps."
+        },
+        "reasonPhrase" : {
+          "type" : "string",
+          "title" : "ReasonPhrase",
+          "description" : "Http reason phrase.",
+          "$comment" : "group:advanced"
+        },
+        "schema" : {
+          "type" : "string",
+          "title" : "Schema",
+          "description" : "The reference to a schema in the bean registry that should be used for validation.",
+          "$comment" : "group:schema"
+        },
+        "schemaRepository" : {
+          "type" : "string",
+          "title" : "SchemaRepository",
+          "description" : "The schema repository holding the schema.",
+          "$comment" : "group:schema"
+        },
+        "schemaValidation" : {
+          "type" : "boolean",
+          "title" : "SchemaValidation",
+          "description" : "Enables the schema validation.",
+          "$comment" : "group:schema"
+        },
+        "status" : {
+          "type" : "string",
+          "title" : "Status",
+          "description" : "The Http status code."
+        },
+        "type" : {
+          "type" : "string",
+          "title" : "Type",
+          "description" : "The message type. Gives the validator a hint which validatory are capable of performing proper message validation.",
+          "$comment" : "group:advanced"
+        },
+        "version" : {
+          "type" : "string",
+          "title" : "Version",
+          "description" : "Http version.",
+          "$comment" : "group:advanced"
+        }
+      },
+      "additionalProperties" : false
+    },
+    "HttpStatus" : {
+      "type" : "string",
+      "enum" : [ "CONTINUE", "SWITCHING_PROTOCOLS", "PROCESSING", "EARLY_HINTS", "CHECKPOINT", "OK", "CREATED", "ACCEPTED", "NON_AUTHORITATIVE_INFORMATION", "NO_CONTENT", "RESET_CONTENT", "PARTIAL_CONTENT", "MULTI_STATUS", "ALREADY_REPORTED", "IM_USED", "MULTIPLE_CHOICES", "MOVED_PERMANENTLY", "FOUND", "MOVED_TEMPORARILY", "SEE_OTHER", "NOT_MODIFIED", "USE_PROXY", "TEMPORARY_REDIRECT", "PERMANENT_REDIRECT", "BAD_REQUEST", "UNAUTHORIZED", "PAYMENT_REQUIRED", "FORBIDDEN", "NOT_FOUND", "METHOD_NOT_ALLOWED", "NOT_ACCEPTABLE", "PROXY_AUTHENTICATION_REQUIRED", "REQUEST_TIMEOUT", "CONFLICT", "GONE", "LENGTH_REQUIRED", "PRECONDITION_FAILED", "PAYLOAD_TOO_LARGE", "REQUEST_ENTITY_TOO_LARGE", "URI_TOO_LONG", "REQUEST_URI_TOO_LONG", "UNSUPPORTED_MEDIA_TYPE", "REQUESTED_RANGE_NOT_SATISFIABLE", "EXPECTATION_FAILED", "I_AM_A_TEAPOT", "INSUFFICIENT_SPACE_ON_RESOURCE", "METHOD_FAILURE", "DESTINATION_LOCKED", "UNPROCESSABLE_ENTITY", "LOCKED", "FAILED_DEPENDENCY", "TOO_EARLY", "UPGRADE_REQUIRED", "PRECONDITION_REQUIRED", "TOO_MANY_REQUESTS", "REQUEST_HEADER_FIELDS_TOO_LARGE", "UNAVAILABLE_FOR_LEGAL_REASONS", "INTERNAL_SERVER_ERROR", "NOT_IMPLEMENTED", "BAD_GATEWAY", "SERVICE_UNAVAILABLE", "GATEWAY_TIMEOUT", "HTTP_VERSION_NOT_SUPPORTED", "VARIANT_ALSO_NEGOTIATES", "INSUFFICIENT_STORAGE", "LOOP_DETECTED", "BANDWIDTH_LIMIT_EXCEEDED", "NOT_EXTENDED", "NETWORK_AUTHENTICATION_REQUIRED" ]
+    },
+    "Label" : {
+      "type" : "object",
+      "properties" : {
+        "name" : {
+          "type" : "string",
+          "title" : "Name"
+        },
+        "value" : {
+          "type" : "string",
+          "title" : "Value"
+        }
+      },
+      "additionalProperties" : false
+    },
+    "Message" : {
+      "type" : "object",
+      "properties" : {
+        "body" : {
+          "allOf" : [ {
+            "$ref" : "#/definitions/Body"
+          }, {
+            "title" : "Body",
+            "description" : "The message body."
+          } ]
+        },
+        "dataDictionary" : {
+          "type" : "string",
+          "title" : "DataDictionary",
+          "description" : "Sets a data dictionary that transforms message content before it is being processed.",
+          "$comment" : "group:dictionary"
+        },
+        "expression" : {
+          "title" : "Expression",
+          "description" : "List of path expressions to evaluate on the message content before processing the message.",
+          "$comment" : "group:advanced",
+          "type" : "array",
+          "items" : {
+            "allOf" : [ {
+              "$ref" : "#/definitions/Expression"
+            }, {
+              "title" : "Expression",
+              "description" : "List of path expressions to evaluate on the message content before processing the message.",
+              "$comment" : "group:advanced"
+            } ]
+          }
+        },
+        "headerIgnoreCase" : {
+          "type" : "string",
+          "title" : "HeaderIgnoreCase",
+          "description" : "When enabled the header case is not verified.",
+          "$comment" : "group:advanced"
+        },
+        "headers" : {
+          "title" : "Headers",
+          "description" : "The message headers.",
+          "type" : "array",
+          "items" : {
+            "allOf" : [ {
+              "$ref" : "#/definitions/Header"
+            }, {
+              "title" : "Headers",
+              "description" : "The message headers."
+            } ]
+          }
+        },
+        "name" : {
+          "type" : "string",
+          "title" : "Name",
+          "description" : "The message name. Named messages may be referenced in subsequent test steps."
+        },
+        "schema" : {
+          "type" : "string",
+          "title" : "Schema",
+          "description" : "The reference to a schema in the bean registry that should be used for validation.",
+          "$comment" : "group:schema"
+        },
+        "schemaRepository" : {
+          "type" : "string",
+          "title" : "SchemaRepository",
+          "description" : "The schema repository holding the schema.",
+          "$comment" : "group:schema"
+        },
+        "schemaValidation" : {
+          "type" : "boolean",
+          "title" : "SchemaValidation",
+          "description" : "Enables the schema validation.",
+          "$comment" : "group:schema"
+        },
+        "type" : {
+          "type" : "string",
+          "title" : "Type",
+          "description" : "The message type. Gives the validator a hint which validatory are capable of performing proper message validation.",
+          "$comment" : "group:advanced"
+        }
+      },
+      "additionalProperties" : false
+    },
+    "RequestMethod" : {
+      "type" : "string",
+      "enum" : [ "GET", "HEAD", "POST", "PUT", "PATCH", "DELETE", "OPTIONS", "TRACE" ]
+    },
+    "Script" : {
+      "type" : "object",
+      "properties" : {
+        "file" : {
+          "type" : "string",
+          "title" : "File"
+        },
+        "script" : {
+          "type" : "string",
+          "title" : "Script"
+        },
+        "template" : {
+          "type" : "string",
+          "title" : "Template"
+        },
+        "useScriptTemplate" : {
+          "type" : "boolean",
+          "title" : "UseScriptTemplate"
+        },
+        "value" : {
+          "type" : "string",
+          "title" : "Value"
+        }
+      },
+      "additionalProperties" : false
+    },
+    "Selector" : {
+      "type" : "object",
+      "properties" : {
+        "element" : {
+          "title" : "Element",
+          "description" : "List of elements to build the selector expression.",
+          "$comment" : "group:advanced",
+          "type" : "array",
+          "items" : {
+            "type" : "object",
+            "properties" : {
+              "name" : {
+                "type" : "string",
+                "title" : "Name",
+                "description" : "Select element key name."
+              },
+              "value" : {
+                "type" : "string",
+                "title" : "Value",
+                "description" : "Select expression value."
+              }
+            },
+            "required" : [ "name", "value" ],
+            "additionalProperties" : false,
+            "title" : "Element",
+            "description" : "List of elements to build the selector expression.",
+            "$comment" : "group:advanced"
+          }
+        },
+        "value" : {
+          "type" : "string",
+          "title" : "Value",
+          "description" : "Selector expression value."
+        }
+      },
+      "additionalProperties" : false
+    },
+    "SoapFaultDetail" : {
+      "type" : "object",
+      "properties" : {
+        "content" : {
+          "type" : "string",
+          "title" : "Content",
+          "description" : "The SOAP fault detail content."
+        },
+        "resource" : {
+          "type" : "string",
+          "title" : "Resource",
+          "description" : "The SOAP fault detail loaded from a file resource."
+        }
+      },
+      "additionalProperties" : false
+    },
+    "SoapRequest" : {
+      "type" : "object",
+      "properties" : {
+        "accept" : {
+          "type" : "string",
+          "title" : "Accept",
+          "description" : "The SOAP request accept header.",
+          "$comment" : "group:advanced"
+        },
+        "attachments" : {
+          "title" : "Attachments",
+          "description" : "List of SOAP attachments for this message.",
+          "$comment" : "group:advanced",
+          "type" : "array",
+          "items" : {
+            "allOf" : [ {
+              "$ref" : "#/definitions/Attachment"
+            }, {
+              "title" : "Attachments",
+              "description" : "List of SOAP attachments for this message.",
+              "$comment" : "group:advanced"
+            } ]
+          }
+        },
+        "body" : {
+          "allOf" : [ {
+            "$ref" : "#/definitions/Body"
+          }, {
+            "title" : "Body",
+            "description" : "The message body."
+          } ]
+        },
+        "contentType" : {
+          "type" : "string",
+          "title" : "ContentType",
+          "description" : "The SOAP request content type."
+        },
+        "dataDictionary" : {
+          "type" : "string",
+          "title" : "DataDictionary",
+          "description" : "Sets a data dictionary that transforms message content before it is being processed.",
+          "$comment" : "group:dictionary"
+        },
+        "expression" : {
+          "title" : "Expression",
+          "description" : "List of path expressions to evaluate on the message content before processing the message.",
+          "$comment" : "group:advanced",
+          "type" : "array",
+          "items" : {
+            "allOf" : [ {
+              "$ref" : "#/definitions/Expression"
+            }, {
+              "title" : "Expression",
+              "description" : "List of path expressions to evaluate on the message content before processing the message.",
+              "$comment" : "group:advanced"
+            } ]
+          }
+        },
+        "headerIgnoreCase" : {
+          "type" : "string",
+          "title" : "HeaderIgnoreCase",
+          "description" : "When enabled the header case is not verified.",
+          "$comment" : "group:advanced"
+        },
+        "headers" : {
+          "title" : "Headers",
+          "description" : "The message headers.",
+          "type" : "array",
+          "items" : {
+            "allOf" : [ {
+              "$ref" : "#/definitions/Header"
+            }, {
+              "title" : "Headers",
+              "description" : "The message headers."
+            } ]
+          }
+        },
+        "mtomEnabled" : {
+          "type" : "boolean",
+          "title" : "MtomEnabled",
+          "description" : "Enables SOAP MTOM.",
+          "$comment" : "group:advanced"
+        },
+        "name" : {
+          "type" : "string",
+          "title" : "Name",
+          "description" : "The message name. Named messages may be referenced in subsequent test steps."
+        },
+        "path" : {
+          "type" : "string",
+          "title" : "Path",
+          "description" : "The SOAP request path."
+        },
+        "schema" : {
+          "type" : "string",
+          "title" : "Schema",
+          "description" : "The reference to a schema in the bean registry that should be used for validation.",
+          "$comment" : "group:schema"
+        },
+        "schemaRepository" : {
+          "type" : "string",
+          "title" : "SchemaRepository",
+          "description" : "The schema repository holding the schema.",
+          "$comment" : "group:schema"
+        },
+        "schemaValidation" : {
+          "type" : "boolean",
+          "title" : "SchemaValidation",
+          "description" : "Enables the schema validation.",
+          "$comment" : "group:schema"
+        },
+        "soapAction" : {
+          "type" : "string",
+          "title" : "SoapAction",
+          "description" : "The SOAP action."
+        },
+        "type" : {
+          "type" : "string",
+          "title" : "Type",
+          "description" : "The message type. Gives the validator a hint which validatory are capable of performing proper message validation.",
+          "$comment" : "group:advanced"
+        },
+        "version" : {
+          "type" : "string",
+          "title" : "Version",
+          "description" : "The SOAP version.",
+          "$comment" : "group:advanced"
+        }
+      },
+      "additionalProperties" : false
+    },
+    "SoapResponse" : {
+      "type" : "object",
+      "properties" : {
+        "attachments" : {
+          "title" : "Attachments",
+          "description" : "List of SOAP attachments for this message.",
+          "$comment" : "group:advanced",
+          "type" : "array",
+          "items" : {
+            "allOf" : [ {
+              "$ref" : "#/definitions/Attachment"
+            }, {
+              "title" : "Attachments",
+              "description" : "List of SOAP attachments for this message.",
+              "$comment" : "group:advanced"
+            } ]
+          }
+        },
+        "body" : {
+          "allOf" : [ {
+            "$ref" : "#/definitions/Body"
+          }, {
+            "title" : "Body",
+            "description" : "The message body."
+          } ]
+        },
+        "contentType" : {
+          "type" : "string",
+          "title" : "ContentType",
+          "description" : "The SOAP response content type."
+        },
+        "dataDictionary" : {
+          "type" : "string",
+          "title" : "DataDictionary",
+          "description" : "Sets a data dictionary that transforms message content before it is being processed.",
+          "$comment" : "group:dictionary"
+        },
+        "expression" : {
+          "title" : "Expression",
+          "description" : "List of path expressions to evaluate on the message content before processing the message.",
+          "$comment" : "group:advanced",
+          "type" : "array",
+          "items" : {
+            "allOf" : [ {
+              "$ref" : "#/definitions/Expression"
+            }, {
+              "title" : "Expression",
+              "description" : "List of path expressions to evaluate on the message content before processing the message.",
+              "$comment" : "group:advanced"
+            } ]
+          }
+        },
+        "headerIgnoreCase" : {
+          "type" : "string",
+          "title" : "HeaderIgnoreCase",
+          "description" : "When enabled the header case is not verified.",
+          "$comment" : "group:advanced"
+        },
+        "headers" : {
+          "title" : "Headers",
+          "description" : "The message headers.",
+          "type" : "array",
+          "items" : {
+            "allOf" : [ {
+              "$ref" : "#/definitions/Header"
+            }, {
+              "title" : "Headers",
+              "description" : "The message headers."
+            } ]
+          }
+        },
+        "name" : {
+          "type" : "string",
+          "title" : "Name",
+          "description" : "The message name. Named messages may be referenced in subsequent test steps."
+        },
+        "reasonPhrase" : {
+          "type" : "string",
+          "title" : "ReasonPhrase",
+          "description" : "The SOAP response reason phrase.",
+          "$comment" : "group:advanced"
+        },
+        "schema" : {
+          "type" : "string",
+          "title" : "Schema",
+          "description" : "The reference to a schema in the bean registry that should be used for validation.",
+          "$comment" : "group:schema"
+        },
+        "schemaRepository" : {
+          "type" : "string",
+          "title" : "SchemaRepository",
+          "description" : "The schema repository holding the schema.",
+          "$comment" : "group:schema"
+        },
+        "schemaValidation" : {
+          "type" : "boolean",
+          "title" : "SchemaValidation",
+          "description" : "Enables the schema validation.",
+          "$comment" : "group:schema"
+        },
+        "status" : {
+          "type" : "string",
+          "title" : "Status",
+          "description" : "The SOAP response status."
+        },
+        "type" : {
+          "type" : "string",
+          "title" : "Type",
+          "description" : "The message type. Gives the validator a hint which validatory are capable of performing proper message validation.",
+          "$comment" : "group:advanced"
+        },
+        "version" : {
+          "type" : "string",
+          "title" : "Version",
+          "description" : "The SOAP version.",
+          "$comment" : "group:advanced"
+        }
+      },
+      "additionalProperties" : false
+    },
+    "SwitchWindow" : {
+      "type" : "object",
+      "properties" : {
+        "name" : {
+          "type" : "string",
+          "title" : "Name"
+        },
+        "window" : {
+          "type" : "string",
+          "title" : "Window"
+        }
+      },
+      "additionalProperties" : false
+    },
+    "TestActionBuilder_Object_" : {
+      "type" : "object"
+    },
+    "TestActions" : {
+      "type" : "object",
+      "properties" : {
+        "action" : {
+          "type" : "object",
+          "properties" : {
+            "ref" : {
+              "type" : "string",
+              "title" : "Ref",
+              "description" : "The reference to the test action in the bean registry."
+            },
+            "reference" : {
+              "type" : "string",
+              "title" : "Reference",
+              "description" : "The reference to the test action in the bean registry."
+            }
+          },
+          "additionalProperties" : false,
+          "title" : "Action",
+          "description" : "Generic test action."
+        },
+        "agent" : {
+          "type" : "object",
+          "properties" : {
+            "connect" : {
+              "type" : "object",
+              "properties" : {
+                "port" : {
+                  "type" : "integer",
+                  "title" : "Port"
+                },
+                "url" : {
+                  "type" : "string",
+                  "title" : "Url"
+                }
+              },
+              "additionalProperties" : false,
+              "title" : "Connect"
+            },
+            "name" : {
+              "type" : "string",
+              "title" : "Name"
+            },
+            "run" : {
+              "type" : "object",
+              "properties" : {
+                "actions" : {
+                  "title" : "Actions",
+                  "description" : "Sequence of test actions to execute.",
+                  "type" : "array",
+                  "items" : {
+                    "allOf" : [ {
+                      "$ref" : "#/definitions/TestActionBuilder_Object_"
+                    }, {
+                      "title" : "Actions",
+                      "description" : "Sequence of test actions to execute."
+                    } ]
+                  }
+                },
+                "source" : {
+                  "type" : "object",
+                  "properties" : {
+                    "code" : {
+                      "type" : "string",
+                      "title" : "Code"
+                    },
+                    "file" : {
+                      "type" : "string",
+                      "title" : "File"
+                    }
+                  },
+                  "additionalProperties" : false,
+                  "title" : "Source"
+                }
+              },
+              "additionalProperties" : false,
+              "title" : "Run"
+            }
+          },
+          "additionalProperties" : false,
+          "title" : "Agent",
+          "description" : "Agent service test actions."
+        },
+        "ant" : {
+          "type" : "object",
+          "properties" : {
+            "buildFile" : {
+              "type" : "string",
+              "title" : "BuildFile",
+              "description" : "Path to the Ant build file."
+            },
+            "buildListener" : {
+              "type" : "string",
+              "title" : "BuildListener",
+              "description" : "Optional reference to a build listener.",
+              "$comment" : "group:advanced"
+            },
+            "description" : {
+              "type" : "string",
+              "title" : "Description",
+              "description" : "Test action description printed when the action is executed.",
+              "$comment" : "group:advanced"
+            },
+            "execute" : {
+              "type" : "object",
+              "properties" : {
+                "target" : {
+                  "type" : "string",
+                  "title" : "Target"
+                },
+                "targets" : {
+                  "type" : "string",
+                  "title" : "Targets"
+                }
+              },
+              "additionalProperties" : false,
+              "title" : "Execute",
+              "description" : "The build target to call."
+            },
+            "properties" : {
+              "title" : "Properties",
+              "description" : "Ant build properties.",
+              "type" : "array",
+              "items" : {
+                "type" : "object",
+                "properties" : {
+                  "name" : {
+                    "type" : "string",
+                    "title" : "Name"
+                  },
+                  "value" : {
+                    "type" : "string",
+                    "title" : "Value"
+                  }
+                },
+                "additionalProperties" : false,
+                "title" : "Properties",
+                "description" : "Ant build properties."
+              }
+            },
+            "propertyFile" : {
+              "type" : "string",
+              "title" : "PropertyFile",
+              "description" : "Adds a build property file."
+            }
+          },
+          "additionalProperties" : false,
+          "title" : "Ant",
+          "description" : "Ant run test action."
+        },
+        "applyTemplate" : {
+          "type" : "object",
+          "properties" : {
+            "file" : {
+              "type" : "string",
+              "title" : "File",
+              "description" : "Load the template from given file resource."
+            },
+            "name" : {
+              "type" : "string",
+              "title" : "Name",
+              "description" : "The name of the template."
+            },
+            "parameters" : {
+              "title" : "Parameters",
+              "description" : "Template parameters, passed to the template as test variables.",
+              "type" : "array",
+              "items" : {
+                "type" : "object",
+                "properties" : {
+                  "name" : {
+                    "type" : "string",
+                    "title" : "Name",
+                    "description" : "The name of the parameter."
+                  },
+                  "value" : {
+                    "type" : "string",
+                    "title" : "Value",
+                    "description" : "The parameter value."
+                  }
+                },
+                "required" : [ "name", "value" ],
+                "additionalProperties" : false,
+                "title" : "Parameters",
+                "description" : "Template parameters, passed to the template as test variables."
+              }
+            }
+          },
+          "required" : [ "name" ],
+          "additionalProperties" : false,
+          "title" : "ApplyTemplate",
+          "description" : "Apply template test action."
+        },
+        "assert" : {
+          "type" : "object",
+          "properties" : {
+            "description" : {
+              "type" : "string",
+              "title" : "Description",
+              "description" : "Test action description printed when the action is executed.",
+              "$comment" : "group:advanced"
+            },
+            "exception" : {
+              "type" : "string",
+              "title" : "Exception",
+              "description" : "The type of the Java exception."
+            },
+            "message" : {
+              "type" : "string",
+              "title" : "Message",
+              "description" : "The expected exception message."
+            },
+            "when" : {
+              "title" : "When",
+              "description" : "Nested test actions that raise the exception.",
+              "type" : "array",
+              "items" : {
+                "allOf" : [ {
+                  "$ref" : "#/definitions/TestActionBuilder_Object_"
+                }, {
+                  "title" : "When",
+                  "description" : "Nested test actions that raise the exception."
+                } ]
+              }
+            }
+          },
+          "required" : [ "when" ],
+          "additionalProperties" : false,
+          "title" : "Assert",
+          "description" : "Assert exception test action."
+        },
+        "async" : {
+          "type" : "object",
+          "properties" : {
+            "actions" : {
+              "title" : "Actions",
+              "description" : "Sequence of test actions to execute.",
+              "type" : "array",
+              "items" : {
+                "allOf" : [ {
+                  "$ref" : "#/definitions/TestActionBuilder_Object_"
+                }, {
+                  "title" : "Actions",
+                  "description" : "Sequence of test actions to execute."
+                } ]
+              }
+            },
+            "description" : {
+              "type" : "string",
+              "title" : "Description",
+              "description" : "Test action description printed when the action is executed.",
+              "$comment" : "group:advanced"
+            },
+            "error" : {
+              "title" : "Error",
+              "description" : "Test actions executed when async container has failed.",
+              "$comment" : "group:advanced",
+              "type" : "array",
+              "items" : {
+                "allOf" : [ {
+                  "$ref" : "#/definitions/TestActionBuilder_Object_"
+                }, {
+                  "title" : "Error",
+                  "description" : "Test actions executed when async container has failed.",
+                  "$comment" : "group:advanced"
+                } ]
+              }
+            },
+            "success" : {
+              "title" : "Success",
+              "description" : "Test actions executed when async container is successful.",
+              "$comment" : "group:advanced",
+              "type" : "array",
+              "items" : {
+                "allOf" : [ {
+                  "$ref" : "#/definitions/TestActionBuilder_Object_"
+                }, {
+                  "title" : "Success",
+                  "description" : "Test actions executed when async container is successful.",
+                  "$comment" : "group:advanced"
+                } ]
+              }
+            }
+          },
+          "required" : [ "actions" ],
+          "additionalProperties" : false,
+          "title" : "Async",
+          "description" : "Async test action."
+        },
+        "camel" : {
+          "type" : "object",
+          "properties" : {
+            "actor" : {
+              "type" : "string",
+              "title" : "Actor",
+              "$comment" : "group:advanced"
+            },
+            "camelContext" : {
+              "type" : "string",
+              "title" : "CamelContext",
+              "description" : "Name of the Camel context."
+            },
+            "controlBus" : {
+              "type" : "object",
+              "properties" : {
+                "action" : {
+                  "type" : "string",
+                  "title" : "Action",
+                  "description" : "The control bus action to execute."
+                },
+                "description" : {
+                  "type" : "string",
+                  "title" : "Description",
+                  "description" : "Test action description printed when the action is executed.",
+                  "$comment" : "group:advanced"
+                },
+                "language" : {
+                  "type" : "object",
+                  "properties" : {
+                    "expression" : {
+                      "type" : "string",
+                      "title" : "Expression",
+                      "description" : "The language expression."
+                    },
+                    "name" : {
+                      "type" : "string",
+                      "title" : "Name",
+                      "description" : "The language name."
+                    }
+                  },
+                  "additionalProperties" : false,
+                  "title" : "Language",
+                  "description" : "Runs another Camel language expression."
+                },
+                "result" : {
+                  "type" : "string",
+                  "title" : "Result",
+                  "description" : "The expected action result."
+                },
+                "route" : {
+                  "type" : "string",
+                  "title" : "Route",
+                  "description" : "The route id"
+                },
+                "simple" : {
+                  "type" : "string",
+                  "title" : "Simple",
+                  "description" : "Runs a simple expression"
+                }
+              },
+              "additionalProperties" : false,
+              "title" : "ControlBus",
+              "description" : "Connects with the Camel control bus to run operations."
+            },
+            "createComponent" : {
+              "type" : "object",
+              "properties" : {
+                "file" : {
+                  "type" : "string",
+                  "title" : "File",
+                  "description" : "The Camel component script loaded from a file resource."
+                },
+                "name" : {
+                  "type" : "string",
+                  "title" : "Name",
+                  "description" : "The Camel component name."
+                },
+                "script" : {
+                  "type" : "string",
+                  "title" : "Script",
+                  "description" : "The script that defines the Camel component."
+                }
+              },
+              "additionalProperties" : false,
+              "title" : "CreateComponent",
+              "description" : "Create components in the Camel registry."
+            },
+            "createContext" : {
+              "type" : "object",
+              "properties" : {
+                "autoStart" : {
+                  "type" : "boolean",
+                  "title" : "AutoStart",
+                  "description" : "When enabled the context is automatically started after creation.",
+                  "$comment" : "group:advanced"
+                },
+                "name" : {
+                  "type" : "string",
+                  "title" : "Name",
+                  "description" : "The name of the Camel context."
+                }
+              },
+              "additionalProperties" : false,
+              "title" : "CreateContext",
+              "description" : "Create a new Camel context."
+            },
+            "createRoutes" : {
+              "type" : "object",
+              "properties" : {
+                "file" : {
+                  "type" : "string",
+                  "title" : "File",
+                  "description" : "Route definitions loaded from a file resource",
+                  "$comment" : "group:advanced"
+                },
+                "id" : {
+                  "type" : "string",
+                  "title" : "Id",
+                  "description" : "The route id."
+                },
+                "route" : {
+                  "type" : "string",
+                  "title" : "Route",
+                  "description" : "Inline route definition."
+                },
+                "routeContext" : {
+                  "type" : "string",
+                  "title" : "RouteContext",
+                  "description" : "Camel route context to load multiple routes.",
+                  "$comment" : "group:advanced"
+                }
+              },
+              "additionalProperties" : false,
+              "title" : "CreateRoutes",
+              "description" : "Create a new Camel route in the context."
+            },
+            "description" : {
+              "type" : "string",
+              "title" : "Description",
+              "description" : "Test action description printed when the action is executed.",
+              "$comment" : "group:advanced"
+            },
+            "infra" : {
+              "type" : "object",
+              "properties" : {
+                "run" : {
+                  "type" : "object",
+                  "properties" : {
+                    "autoRemove" : {
+                      "type" : "boolean",
+                      "title" : "AutoRemove",
+                      "description" : "When enabled the infra service is automatically stopped after the test."
+                    },
+                    "catalog" : {
+                      "type" : "string",
+                      "title" : "Catalog",
+                      "description" : "The Camel catalog that holds the infra service definitions.",
+                      "$comment" : "group:advanced"
+                    },
+                    "dumpServiceOutput" : {
+                      "type" : "boolean",
+                      "title" : "DumpServiceOutput",
+                      "description" : "When enabled the service output is saved into a log file.",
+                      "$comment" : "group:advanced"
+                    },
+                    "implementation" : {
+                      "type" : "string",
+                      "title" : "Implementation",
+                      "description" : "Optional service implementation detail."
+                    },
+                    "service" : {
+                      "type" : "string",
+                      "title" : "Service",
+                      "description" : "The Camel infra service name."
+                    }
+                  },
+                  "additionalProperties" : false,
+                  "title" : "Run",
+                  "description" : "Runs a Camel infra service."
+                },
+                "stop" : {
+                  "type" : "object",
+                  "properties" : {
+                    "implementation" : {
+                      "type" : "string",
+                      "title" : "Implementation",
+                      "description" : "Optional service implementation detail."
+                    },
+                    "service" : {
+                      "type" : "string",
+                      "title" : "Service",
+                      "description" : "The Camel infra service name."
+                    }
+                  },
+                  "additionalProperties" : false,
+                  "title" : "Stop",
+                  "description" : "Stops a Camel infra service."
+                }
+              },
+              "additionalProperties" : false,
+              "title" : "Infra",
+              "description" : "Manage Camel infra services."
+            },
+            "jbang" : {
+              "type" : "object",
+              "properties" : {
+                "camelVersion" : {
+                  "type" : "string",
+                  "title" : "CamelVersion",
+                  "description" : "The Apache Camel version."
+                },
+                "cmd" : {
+                  "type" : "object",
+                  "properties" : {
+                    "receive" : {
+                      "type" : "object",
+                      "properties" : {
+                        "args" : {
+                          "title" : "Args",
+                          "description" : "Command arguments.",
+                          "$comment" : "group:advanced",
+                          "type" : "array",
+                          "items" : {
+                            "type" : "string",
+                            "title" : "Args",
+                            "description" : "Command arguments.",
+                            "$comment" : "group:advanced"
+                          }
+                        },
+                        "delayBetweenAttempts" : {
+                          "type" : "integer",
+                          "title" : "DelayBetweenAttempts",
+                          "description" : "The delay in milliseconds to wait between validation attempts.",
+                          "default" : "1000",
+                          "$comment" : "group:advanced"
+                        },
+                        "endpoint" : {
+                          "type" : "string",
+                          "title" : "Endpoint",
+                          "description" : "Optional endpoint in the Camel integration.",
+                          "$comment" : "group:advanced"
+                        },
+                        "grep" : {
+                          "type" : "string",
+                          "title" : "Grep",
+                          "description" : "Filter messages based on this expression."
+                        },
+                        "integration" : {
+                          "type" : "string",
+                          "title" : "Integration",
+                          "description" : "The Camel integration to send the message to."
+                        },
+                        "jsonOutput" : {
+                          "type" : "boolean",
+                          "title" : "JsonOutput",
+                          "description" : "When enabled action stores messages from json output.",
+                          "default" : "false",
+                          "$comment" : "group:advanced"
+                        },
+                        "loggingColor" : {
+                          "type" : "boolean",
+                          "title" : "LoggingColor",
+                          "description" : "When enabled the output uses logging color.",
+                          "default" : "false",
+                          "$comment" : "group:advanced"
+                        },
+                        "maxAttempts" : {
+                          "type" : "integer",
+                          "title" : "MaxAttempts",
+                          "description" : "Maximum number of validation attempts.",
+                          "default" : "60",
+                          "$comment" : "group:advanced"
+                        },
+                        "printLogs" : {
+                          "type" : "boolean",
+                          "title" : "PrintLogs",
+                          "description" : "When enabled the Camel integration log output is added to the test log output.",
+                          "$comment" : "group:advanced"
+                        },
+                        "since" : {
+                          "type" : "string",
+                          "title" : "Since",
+                          "description" : "Return messages newer than a relative duration.",
+                          "$comment" : "group:advanced"
+                        },
+                        "stopOnErrorStatus" : {
+                          "type" : "boolean",
+                          "title" : "StopOnErrorStatus",
+                          "description" : "When enabled the validation attempts stop when error state is reported.",
+                          "default" : "true",
+                          "$comment" : "group:advanced"
+                        },
+                        "tail" : {
+                          "type" : "string",
+                          "title" : "Tail",
+                          "description" : "The number of messages from the end to show.",
+                          "default" : "0",
+                          "$comment" : "group:advanced"
+                        },
+                        "uri" : {
+                          "type" : "string",
+                          "title" : "Uri",
+                          "description" : "Camel endpoint URI to send message to.",
+                          "$comment" : "group:advanced"
+                        }
+                      },
+                      "additionalProperties" : false,
+                      "title" : "Receive",
+                      "description" : "Receives a message from a Camel JBang integration."
+                    },
+                    "send" : {
+                      "type" : "object",
+                      "properties" : {
+                        "args" : {
+                          "title" : "Args",
+                          "description" : "Command arguments.",
+                          "$comment" : "group:advanced",
+                          "type" : "array",
+                          "items" : {
+                            "type" : "string",
+                            "title" : "Args",
+                            "description" : "Command arguments.",
+                            "$comment" : "group:advanced"
+                          }
+                        },
+                        "body" : {
+                          "type" : "object",
+                          "properties" : {
+                            "data" : {
+                              "type" : "string",
+                              "title" : "Data",
+                              "description" : "The message body as inline data."
+                            },
+                            "file" : {
+                              "type" : "string",
+                              "title" : "File",
+                              "description" : "The message body content loaded from a file resource."
+                            }
+                          },
+                          "additionalProperties" : false,
+                          "title" : "Body",
+                          "description" : "The message body."
+                        },
+                        "endpoint" : {
+                          "type" : "string",
+                          "title" : "Endpoint",
+                          "description" : "Optional endpoint in the Camel integration.",
+                          "$comment" : "group:advanced"
+                        },
+                        "headers" : {
+                          "type" : "object",
+                          "title" : "Headers",
+                          "description" : "The message headers.",
+                          "additionalProperties" : {
+                            "type" : "string",
+                            "title" : "Headers",
+                            "description" : "The message headers."
+                          }
+                        },
+                        "infra" : {
+                          "type" : "string",
+                          "title" : "Infra",
+                          "description" : "Optional Camel infrastructure service to connect to.",
+                          "$comment" : "group:advanced"
+                        },
+                        "integration" : {
+                          "type" : "string",
+                          "title" : "Integration",
+                          "description" : "The Camel integration to send the message to."
+                        },
+                        "reply" : {
+                          "type" : "boolean",
+                          "title" : "Reply",
+                          "description" : "When enabled the operation waits for a reply message from the integration.",
+                          "$comment" : "group:advanced"
+                        },
+                        "timeout" : {
+                          "type" : "string",
+                          "title" : "Timeout",
+                          "description" : "The send timeout."
+                        },
+                        "uri" : {
+                          "type" : "string",
+                          "title" : "Uri",
+                          "description" : "Camel endpoint URI to send message to.",
+                          "$comment" : "group:advanced"
+                        }
+                      },
+                      "additionalProperties" : false,
+                      "title" : "Send",
+                      "description" : "Sends a message to Camel JBang integration."
+                    }
+                  },
+                  "additionalProperties" : false,
+                  "title" : "Cmd",
+                  "description" : "Camel JBang cmd operations."
+                },
+                "custom" : {
+                  "type" : "object",
+                  "properties" : {
+                    "args" : {
+                      "title" : "Args",
+                      "description" : "Optional command arguments.",
+                      "$comment" : "group:advanced",
+                      "type" : "array",
+                      "items" : {
+                        "type" : "string",
+                        "title" : "Args",
+                        "description" : "Optional command arguments.",
+                        "$comment" : "group:advanced"
+                      }
+                    },
+                    "autoRemove" : {
+                      "type" : "boolean",
+                      "title" : "AutoRemove",
+                      "description" : "When enabled the Camel integration is automatically stopped after the test.",
+                      "default" : "true",
+                      "$comment" : "group:advanced"
+                    },
+                    "commands" : {
+                      "title" : "Commands",
+                      "description" : "Customized Camel JBang commands.",
+                      "type" : "array",
+                      "items" : {
+                        "type" : "string",
+                        "title" : "Commands",
+                        "description" : "Customized Camel JBang commands."
+                      }
+                    },
+                    "dumpIntegrationOutput" : {
+                      "type" : "boolean",
+                      "title" : "DumpIntegrationOutput",
+                      "description" : "When enabled the integration output is saved to a log file.",
+                      "default" : "false",
+                      "$comment" : "group:advanced"
+                    },
+                    "integration" : {
+                      "type" : "object",
+                      "properties" : {
+                        "environment" : {
+                          "type" : "object",
+                          "properties" : {
+                            "file" : {
+                              "type" : "string",
+                              "title" : "File",
+                              "description" : "Environment variables loaded from a file resource."
+                            },
+                            "variables" : {
+                              "title" : "Variables",
+                              "description" : "List of environment variables.",
+                              "type" : "array",
+                              "items" : {
+                                "type" : "object",
+                                "properties" : {
+                                  "name" : {
+                                    "type" : "string",
+                                    "title" : "Name",
+                                    "description" : "The environment variable name."
+                                  },
+                                  "value" : {
+                                    "type" : "string",
+                                    "title" : "Value",
+                                    "description" : "The environment variable value."
+                                  }
+                                },
+                                "required" : [ "name", "value" ],
+                                "additionalProperties" : false,
+                                "title" : "Variables",
+                                "description" : "List of environment variables."
+                              }
+                            }
+                          },
+                          "additionalProperties" : false,
+                          "title" : "Environment",
+                          "description" : "Environment variables set for the Camel JBang process.",
+                          "$comment" : "group:advanced"
+                        },
+                        "file" : {
+                          "type" : "string",
+                          "title" : "File",
+                          "description" : "Camel integration source code loaded from a file resource."
+                        },
+                        "name" : {
+                          "type" : "string",
+                          "title" : "Name",
+                          "description" : "The Camel integration name."
+                        },
+                        "systemProperties" : {
+                          "type" : "object",
+                          "properties" : {
+                            "file" : {
+                              "type" : "string",
+                              "title" : "File",
+                              "description" : "System properties loaded from a file resource."
+                            },
+                            "properties" : {
+                              "title" : "Properties",
+                              "description" : "List of system properties.",
+                              "type" : "array",
+                              "items" : {
+                                "type" : "object",
+                                "properties" : {
+                                  "name" : {
+                                    "type" : "string",
+                                    "title" : "Name",
+                                    "description" : "The system property name."
+                                  },
+                                  "value" : {
+                                    "type" : "string",
+                                    "title" : "Value",
+                                    "description" : "The system property value."
+                                  }
+                                },
+                                "required" : [ "name", "value" ],
+                                "additionalProperties" : false,
+                                "title" : "Properties",
+                                "description" : "List of system properties."
+                              }
+                            }
+                          },
+                          "additionalProperties" : false,
+                          "title" : "SystemProperties",
+                          "description" : "System properties set for the Camel JBang process.",
+                          "$comment" : "group:advanced"
+                        }
+                      },
+                      "additionalProperties" : false,
+                      "title" : "Integration",
+                      "description" : "The Camel integration."
+                    },
+                    "processName" : {
+                      "type" : "string",
+                      "title" : "ProcessName",
+                      "description" : "Custom Camel JBang process name.",
+                      "$comment" : "group:advanced"
+                    },
+                    "resources" : {
+                      "title" : "Resources",
+                      "description" : "Optional list of resources added to the Camel JBang process.",
+                      "$comment" : "group:advanced",
+                      "type" : "array",
+                      "items" : {
+                        "type" : "string",
+                        "title" : "Resources",
+                        "description" : "Optional list of resources added to the Camel JBang process.",
+                        "$comment" : "group:advanced"
+                      }
+                    },
+                    "waitForRunningState" : {
+                      "type" : "boolean",
+                      "title" : "WaitForRunningState",
+                      "description" : "Wait for the integration to report running state.",
+                      "default" : "true",
+                      "$comment" : "group:advanced"
+                    },
+                    "workDir" : {
+                      "type" : "string",
+                      "title" : "WorkDir",
+                      "description" : "Custom working directory for the Camel JBang process.",
+                      "$comment" : "group:advanced"
+                    }
+                  },
+                  "additionalProperties" : false,
+                  "title" : "Custom",
+                  "description" : "Runs a Camel integration with customized parameters."
+                },
+                "kameletsVersion" : {
+                  "type" : "string",
+                  "title" : "KameletsVersion",
+                  "description" : "The Kamelets version."
+                },
+                "kubernetes" : {
+                  "type" : "object",
+                  "properties" : {
+                    "delete" : {
+                      "type" : "object",
+                      "properties" : {
+                        "clusterType" : {
+                          "type" : "string",
+                          "title" : "ClusterType",
+                          "description" : "The Kubernetes cluster type.",
+                          "$comment" : "group:advanced"
+                        },
+                        "integration" : {
+                          "type" : "object",
+                          "properties" : {
+                            "file" : {
+                              "type" : "string",
+                              "title" : "File",
+                              "description" : "The Camel integration source code loaded from a file resource."
+                            },
+                            "name" : {
+                              "type" : "string",
+                              "title" : "Name",
+                              "description" : "The Camel integration name."
+                            }
+                          },
+                          "additionalProperties" : false,
+                          "title" : "Integration",
+                          "description" : "The Camel integration to delete."
+                        },
+                        "namespace" : {
+                          "type" : "string",
+                          "title" : "Namespace",
+                          "description" : "The Kubernetes namespace.",
+                          "$comment" : "group:advanced"
+                        },
+                        "workingDir" : {
+                          "type" : "string",
+                          "title" : "WorkingDir",
+                          "description" : "The working directory that contains the Kubernetes manifest.",
+                          "$comment" : "group:advanced"
+                        }
+                      },
+                      "additionalProperties" : false,
+                      "title" : "Delete",
+                      "description" : "Deletes a Camel integration from Kubernetes."
+                    },
+                    "run" : {
+                      "type" : "object",
+                      "properties" : {
+                        "argLine" : {
+                          "type" : "string",
+                          "title" : "ArgLine",
+                          "description" : "Camel JBang command arguments.",
+                          "$comment" : "group:advanced"
+                        },
+                        "args" : {
+                          "title" : "Args",
+                          "description" : "Camel JBang command arguments.",
+                          "$comment" : "group:advanced",
+                          "type" : "array",
+                          "items" : {
+                            "type" : "string",
+                            "title" : "Args",
+                            "description" : "Camel JBang command arguments.",
+                            "$comment" : "group:advanced"
+                          }
+                        },
+                        "autoRemove" : {
+                          "type" : "boolean",
+                          "title" : "AutoRemove",
+                          "description" : "When enabled the Camel integration is automatically removed from Kubernetes after the test.",
+                          "default" : "true"
+                        },
+                        "buildProperties" : {
+                          "title" : "BuildProperties",
+                          "description" : "List of build properties passed to the Camel JBang project build.",
+                          "$comment" : "group:advanced",
+                          "type" : "array",
+                          "items" : {
+                            "type" : "string",
+                            "title" : "BuildProperties",
+                            "description" : "List of build properties passed to the Camel JBang project build.",
+                            "$comment" : "group:advanced"
+                          }
+                        },
+                        "clusterType" : {
+                          "type" : "string",
+                          "title" : "ClusterType",
+                          "description" : "The Kubernetes cluster type.",
+                          "$comment" : "group:advanced"
+                        },
+                        "imageBuilder" : {
+                          "type" : "string",
+                          "title" : "ImageBuilder",
+                          "description" : "The Docker image builder.",
+                          "$comment" : "group:advanced"
+                        },
+                        "imageRegistry" : {
+                          "type" : "string",
+                          "title" : "ImageRegistry",
+                          "description" : "The Docker image registry.",
+                          "$comment" : "group:advanced"
+                        },
+                        "integration" : {
+                          "type" : "object",
+                          "properties" : {
+                            "file" : {
+                              "type" : "string",
+                              "title" : "File",
+                              "description" : "The integration source code loaded as a file resource."
+                            },
+                            "name" : {
+                              "type" : "string",
+                              "title" : "Name",
+                              "description" : "The Camel integration name."
+                            },
+                            "source" : {
+                              "type" : "string",
+                              "title" : "Source",
+                              "description" : "The integration source code as inline data."
+                            }
+                          },
+                          "additionalProperties" : false,
+                          "title" : "Integration",
+                          "description" : "The Camel integration name."
+                        },
+                        "properties" : {
+                          "title" : "Properties",
+                          "description" : "Properties set on the Camel JBang project export.",
+                          "type" : "array",
+                          "items" : {
+                            "type" : "string",
+                            "title" : "Properties",
+                            "description" : "Properties set on the Camel JBang project export."
+                          }
+                        },
+                        "runtime" : {
+                          "type" : "string",
+                          "title" : "Runtime",
+                          "description" : "The runtime to use.",
+                          "default" : "quarkus",
+                          "$comment" : "group:advanced"
+                        },
+                        "traits" : {
+                          "title" : "Traits",
+                          "description" : "List of traits to set for the project export.",
+                          "type" : "array",
+                          "items" : {
+                            "type" : "string",
+                            "title" : "Traits",
+                            "description" : "List of traits to set for the project export."
+                          }
+                        },
+                        "verbose" : {
+                          "type" : "boolean",
+                          "title" : "Verbose",
+                          "description" : "When enabled the Camel JBang command print verbose log messages.",
+                          "default" : "false",
+                          "$comment" : "group:advanced"
+                        },
+                        "waitForRunningState" : {
+                          "type" : "boolean",
+                          "title" : "WaitForRunningState",
+                          "description" : "When enabled the test waits for the Camel integration Kubernetes deployment to report proper running state.",
+                          "default" : "true",
+                          "$comment" : "group:advanced"
+                        }
+                      },
+                      "additionalProperties" : false,
+                      "title" : "Run",
+                      "description" : "Runs a Camel integration on Kubernetes."
+                    },
+                    "verify" : {
+                      "type" : "object",
+                      "properties" : {
+                        "args" : {
+                          "title" : "Args",
+                          "description" : "Camel JBang command arguments.",
+                          "$comment" : "group:advanced",
+                          "type" : "array",
+                          "items" : {
+                            "type" : "string",
+                            "title" : "Args",
+                            "description" : "Camel JBang command arguments.",
+                            "$comment" : "group:advanced"
+                          }
+                        },
+                        "delayBetweenAttempts" : {
+                          "type" : "integer",
+                          "title" : "DelayBetweenAttempts",
+                          "description" : "The delay in milliseconds to wait between validation attempts.",
+                          "default" : "1000",
+                          "$comment" : "group:advanced"
+                        },
+                        "integration" : {
+                          "type" : "string",
+                          "title" : "Integration",
+                          "description" : "The Camel integration name."
+                        },
+                        "label" : {
+                          "type" : "string",
+                          "title" : "Label",
+                          "description" : "Identify the Camel integration via a Kubernetes label."
+                        },
+                        "logMessage" : {
+                          "type" : "string",
+                          "title" : "LogMessage",
+                          "description" : "The expected log message to verify."
+                        },
+                        "maxAttempts" : {
+                          "type" : "integer",
+                          "title" : "MaxAttempts",
+                          "description" : "Maximum number of validation attempts.",
+                          "default" : "60",
+                          "$comment" : "group:advanced"
+                        },
+                        "namespace" : {
+                          "type" : "string",
+                          "title" : "Namespace",
+                          "description" : "The Kubernetes namespace.",
+                          "$comment" : "group:advanced"
+                        },
+                        "printLogs" : {
+                          "type" : "boolean",
+                          "title" : "PrintLogs",
+                          "description" : "When enabled the Camel integration log output is added to the test log output.",
+                          "$comment" : "group:advanced"
+                        }
+                      },
+                      "additionalProperties" : false,
+                      "title" : "Verify",
+                      "description" : "Verify the status and log messages for a Camel integration run on Kubernetes."
+                    }
+                  },
+                  "additionalProperties" : false,
+                  "title" : "Kubernetes",
+                  "description" : "Camel Kubernetes plugin related operations."
+                },
+                "plugin" : {
+                  "type" : "object",
+                  "properties" : {
+                    "add" : {
+                      "type" : "object",
+                      "properties" : {
+                        "args" : {
+                          "title" : "Args",
+                          "description" : "Plugin arguments.",
+                          "$comment" : "group:advanced",
+                          "type" : "array",
+                          "items" : {
+                            "type" : "string",
+                            "title" : "Args",
+                            "description" : "Plugin arguments.",
+                            "$comment" : "group:advanced"
+                          }
+                        },
+                        "name" : {
+                          "type" : "string",
+                          "title" : "Name",
+                          "description" : "The plugin name."
+                        }
+                      },
+                      "required" : [ "name" ],
+                      "additionalProperties" : false,
+                      "title" : "Add",
+                      "description" : "Adds a plugin to the Camel Jbang installation."
+                    }
+                  },
+                  "additionalProperties" : false,
+                  "title" : "Plugin",
+                  "description" : "Manage Camel JBang plugins."
+                },
+                "run" : {
+                  "type" : "object",
+                  "properties" : {
+                    "args" : {
+                      "title" : "Args",
+                      "description" : "Optional command arguments.",
+                      "$comment" : "group:advanced",
+                      "type" : "array",
+                      "items" : {
+                        "type" : "string",
+                        "title" : "Args",
+                        "description" : "Optional command arguments.",
+                        "$comment" : "group:advanced"
+                      }
+                    },
+                    "autoRemove" : {
+                      "type" : "boolean",
+                      "title" : "AutoRemove",
+                      "description" : "When enabled the Camel integration is automatically stopped after the test.",
+                      "default" : "true",
+                      "$comment" : "group:advanced"
+                    },
+                    "dumpIntegrationOutput" : {
+                      "type" : "boolean",
+                      "title" : "DumpIntegrationOutput",
+                      "description" : "When enabled the integration output is saved to a log file.",
+                      "default" : "false",
+                      "$comment" : "group:advanced"
+                    },
+                    "integration" : {
+                      "type" : "object",
+                      "properties" : {
+                        "environment" : {
+                          "type" : "object",
+                          "properties" : {
+                            "file" : {
+                              "type" : "string",
+                              "title" : "File",
+                              "description" : "Environment variables loaded from a file resource."
+                            },
+                            "variables" : {
+                              "title" : "Variables",
+                              "description" : "List of environment variables.",
+                              "type" : "array",
+                              "items" : {
+                                "type" : "object",
+                                "properties" : {
+                                  "name" : {
+                                    "type" : "string",
+                                    "title" : "Name",
+                                    "description" : "The environment variable name."
+                                  },
+                                  "value" : {
+                                    "type" : "string",
+                                    "title" : "Value",
+                                    "description" : "The environment variable value."
+                                  }
+                                },
+                                "required" : [ "name", "value" ],
+                                "additionalProperties" : false,
+                                "title" : "Variables",
+                                "description" : "List of environment variables."
+                              }
+                            }
+                          },
+                          "additionalProperties" : false,
+                          "title" : "Environment",
+                          "description" : "Environment variables set for the Camel JBang process.",
+                          "$comment" : "group:advanced"
+                        },
+                        "file" : {
+                          "type" : "string",
+                          "title" : "File",
+                          "description" : "Camel integration source code loaded from a file resource."
+                        },
+                        "name" : {
+                          "type" : "string",
+                          "title" : "Name",
+                          "description" : "The Camel integration name."
+                        },
+                        "source" : {
+                          "type" : "string",
+                          "title" : "Source",
+                          "description" : "Camel integration source code as inline data."
+                        },
+                        "systemProperties" : {
+                          "type" : "object",
+                          "properties" : {
+                            "file" : {
+                              "type" : "string",
+                              "title" : "File",
+                              "description" : "System properties loaded from a file resource."
+                            },
+                            "properties" : {
+                              "title" : "Properties",
+                              "description" : "List of system properties.",
+                              "type" : "array",
+                              "items" : {
+                                "type" : "object",
+                                "properties" : {
+                                  "name" : {
+                                    "type" : "string",
+                                    "title" : "Name",
+                                    "description" : "The system property name."
+                                  },
+                                  "value" : {
+                                    "type" : "string",
+                                    "title" : "Value",
+                                    "description" : "The system property value."
+                                  }
+                                },
+                                "required" : [ "name", "value" ],
+                                "additionalProperties" : false,
+                                "title" : "Properties",
+                                "description" : "List of system properties."
+                              }
+                            }
+                          },
+                          "additionalProperties" : false,
+                          "title" : "SystemProperties",
+                          "description" : "System properties set for the Camel JBang process.",
+                          "$comment" : "group:advanced"
+                        }
+                      },
+                      "additionalProperties" : false,
+                      "title" : "Integration",
+                      "description" : "The Camel integration."
+                    },
+                    "resources" : {
+                      "title" : "Resources",
+                      "description" : "Optional list of resources added to the Camel JBang process.",
+                      "$comment" : "group:advanced",
+                      "type" : "array",
+                      "items" : {
+                        "type" : "string",
+                        "title" : "Resources",
+                        "description" : "Optional list of resources added to the Camel JBang process.",
+                        "$comment" : "group:advanced"
+                      }
+                    },
+                    "stub" : {
+                      "title" : "Stub",
+                      "description" : "Optional stubbed components.",
+                      "$comment" : "group:advanced",
+                      "type" : "array",
+                      "items" : {
+                        "type" : "string",
+                        "title" : "Stub",
+                        "description" : "Optional stubbed components.",
+                        "$comment" : "group:advanced"
+                      }
+                    },
+                    "waitForRunningState" : {
+                      "type" : "boolean",
+                      "title" : "WaitForRunningState",
+                      "description" : "Wait for the integration to report running state.",
+                      "default" : "true",
+                      "$comment" : "group:advanced"
+                    }
+                  },
+                  "additionalProperties" : false,
+                  "title" : "Run",
+                  "description" : "Runs a Camel integration."
+                },
+                "stop" : {
+                  "type" : "object",
+                  "properties" : {
+                    "integration" : {
+                      "type" : "string",
+                      "title" : "Integration",
+                      "description" : "Camel integration name"
+                    }
+                  },
+                  "additionalProperties" : false,
+                  "title" : "Stop",
+                  "description" : "Stops a Camel integration."
+                },
+                "verify" : {
+                  "type" : "object",
+                  "properties" : {
+                    "delayBetweenAttempts" : {
+                      "type" : "integer",
+                      "title" : "DelayBetweenAttempts",
+                      "description" : "The delay in milliseconds to wait between validation attempts.",
+                      "default" : "1000",
+                      "$comment" : "group:advanced"
+                    },
+                    "integration" : {
+                      "type" : "string",
+                      "title" : "Integration",
+                      "description" : "The Camel integration name."
+                    },
+                    "logMessage" : {
+                      "type" : "string",
+                      "title" : "LogMessage",
+                      "description" : "The expected log message to verify."
+                    },
+                    "maxAttempts" : {
+                      "type" : "integer",
+                      "title" : "MaxAttempts",
+                      "description" : "Maximum attempts to validate the integration.",
+                      "default" : "60",
+                      "$comment" : "group:advanced"
+                    },
+                    "phase" : {
+                      "type" : "string",
+                      "title" : "Phase",
+                      "description" : "The expected integration status",
+                      "default" : "Running",
+                      "$comment" : "group:advanced"
+                    },
+                    "printLogs" : {
+                      "type" : "boolean",
+                      "title" : "PrintLogs",
+                      "description" : "When enabled the Camel integration log output is added to the test log output.",
+                      "$comment" : "group:advanced"
+                    },
+                    "stopOnErrorStatus" : {
+                      "type" : "boolean",
+                      "title" : "StopOnErrorStatus",
+                      "description" : "When enabled the validation attempts stop when error state is reported.",
+                      "default" : "true",
+                      "$comment" : "group:advanced"
+                    }
+                  },
+                  "additionalProperties" : false,
+                  "title" : "Verify",
+                  "description" : "Verify the Camel integration status and log messages."
+                }
+              },
+              "additionalProperties" : false,
+              "title" : "Jbang",
+              "description" : "Connect with Camel JBang to run commands."
+            },
+            "removeRoutes" : {
+              "type" : "object",
+              "properties" : {
+                "routes" : {
+                  "title" : "Routes",
+                  "description" : "The Camel route ids to remove.",
+                  "type" : "array",
+                  "items" : {
+                    "type" : "string",
+                    "title" : "Routes",
+                    "description" : "The Camel route ids to remove."
+                  }
+                }
+              },
+              "additionalProperties" : false,
+              "title" : "RemoveRoutes",
+              "description" : "Remove given Camel routes."
+            },
+            "startContext" : {
+              "type" : "object",
+              "properties" : {
+                "name" : {
+                  "type" : "string",
+                  "title" : "Name",
+                  "description" : "The Camel context name."
+                }
+              },
+              "additionalProperties" : false,
+              "title" : "StartContext",
+              "description" : "Starts the given Camel context."
+            },
+            "startRoutes" : {
+              "type" : "object",
+              "properties" : {
+                "routes" : {
+                  "title" : "Routes",
+                  "description" : "The Camel route ids to start.",
+                  "type" : "array",
+                  "items" : {
+                    "type" : "string",
+                    "title" : "Routes",
+                    "description" : "The Camel route ids to start."
+                  }
+                }
+              },
+              "additionalProperties" : false,
+              "title" : "StartRoutes",
+              "description" : "Start existing Camel routes in the context."
+            },
+            "stopContext" : {
+              "type" : "object",
+              "properties" : {
+                "name" : {
+                  "type" : "string",
+                  "title" : "Name",
+                  "description" : "The Camel context name."
+                }
+              },
+              "additionalProperties" : false,
+              "title" : "StopContext",
+              "description" : "Stops the given Camel context."
+            },
+            "stopRoutes" : {
+              "type" : "object",
+              "properties" : {
+                "routes" : {
+                  "title" : "Routes",
+                  "description" : "The Camel route ids to stop.",
+                  "type" : "array",
+                  "items" : {
+                    "type" : "string",
+                    "title" : "Routes",
+                    "description" : "The Camel route ids to stop."
+                  }
+                }
+              },
+              "additionalProperties" : false,
+              "title" : "StopRoutes",
+              "description" : "Stop given Camel routes."
+            }
+          },
+          "additionalProperties" : false,
+          "title" : "Camel",
+          "description" : "Test actions related to Apache Camel."
+        },
+        "catch" : {
+          "type" : "object",
+          "properties" : {
+            "description" : {
+              "type" : "string",
+              "title" : "Description",
+              "description" : "Test action description printed when the action is executed.",
+              "$comment" : "group:advanced"
+            },
+            "exception" : {
+              "type" : "string",
+              "title" : "Exception",
+              "description" : "The exception type to catch."
+            },
+            "when" : {
+              "title" : "When",
+              "description" : "Nested test actions that may raise an exception.",
+              "type" : "array",
+              "items" : {
+                "allOf" : [ {
+                  "$ref" : "#/definitions/TestActionBuilder_Object_"
+                }, {
+                  "title" : "When",
+                  "description" : "Nested test actions that may raise an exception."
+                } ]
+              }
+            }
+          },
+          "required" : [ "when" ],
+          "additionalProperties" : false,
+          "title" : "Catch",
+          "description" : "Catch exception test action."
+        },
+        "conditional" : {
+          "type" : "object",
+          "properties" : {
+            "actions" : {
+              "title" : "Actions",
+              "description" : "Test actions that get executed when the condition matches.",
+              "type" : "array",
+              "items" : {
+                "allOf" : [ {
+                  "$ref" : "#/definitions/TestActionBuilder_Object_"
+                }, {
+                  "title" : "Actions",
+                  "description" : "Test actions that get executed when the condition matches."
+                } ]
+              }
+            },
+            "description" : {
+              "type" : "string",
+              "title" : "Description",
+              "description" : "Test action description printed when the action is executed.",
+              "$comment" : "group:advanced"
+            },
+            "when" : {
+              "type" : "string",
+              "title" : "When",
+              "description" : "The condition to evaluate."
+            }
+          },
+          "required" : [ "actions", "when" ],
+          "additionalProperties" : false,
+          "title" : "Conditional",
+          "description" : "Conditional test action."
+        },
+        "createEndpoint" : {
+          "type" : "object",
+          "properties" : {
+            "camel" : { },
+            "channel" : { },
+            "context" : { },
+            "description" : {
+              "type" : "string",
+              "title" : "Description",
+              "description" : "Test action description printed when the action is executed.",
+              "$comment" : "group:advanced"
+            },
+            "direct" : { },
+            "docker" : { },
+            "ftp" : { },
+            "http" : { },
+            "jms" : { },
+            "kafka" : { },
+            "kubernetes" : { },
+            "mail" : { },
+            "name" : {
+              "type" : "string",
+              "title" : "Name",
+              "description" : "The endpoint name. When set this endpoint is retrievable via this name in the bean registry.",
+              "$comment" : "group:generic"
+            },
+            "properties" : {
+              "type" : "object",
+              "title" : "Properties",
+              "description" : "List of properties for this endpoint.",
+              "additionalProperties" : {
+                "type" : "string",
+                "title" : "Properties",
+                "description" : "List of properties for this endpoint.",
+                "$comment" : "group:generic"
+              },
+              "$comment" : "group:generic"
+            },
+            "scp" : { },
+            "selenium" : { },
+            "sftp" : { },
+            "soap" : { },
+            "type" : {
+              "type" : "string",
+              "title" : "Type",
+              "description" : "The endpoint type.",
+              "$comment" : "group:generic"
+            },
+            "uri" : {
+              "type" : "string",
+              "title" : "Uri",
+              "description" : "The URI with properties defining the endpoint.",
+              "$comment" : "group:generic"
+            },
+            "vertx" : { },
+            "webSocket" : { }
+          },
+          "additionalProperties" : false,
+          "anyOf" : [ {
+            "oneOf" : [ {
+              "type" : "object",
+              "properties" : {
+                "http" : {
+                  "type" : "object",
+                  "properties" : {
+                    "client" : { },
+                    "server" : { }
+                  },
+                  "additionalProperties" : false,
+                  "anyOf" : [ {
+                    "oneOf" : [ {
+                      "type" : "object",
+                      "properties" : {
+                        "client" : {
+                          "type" : "object",
+                          "properties" : {
+                            "authentication" : {
+                              "type" : "string",
+                              "title" : "Authentication",
+                              "description" : "Use given authentication mechanism.",
+                              "$comment" : "group:security"
+                            },
+                            "binaryMediaTypes" : {
+                              "title" : "BinaryMediaTypes",
+                              "description" : "Sets the list of binary media types.",
+                              "$comment" : "group:advanced",
+                              "type" : "array",
+                              "items" : {
+                                "type" : "string",
+                                "title" : "BinaryMediaTypes",
+                                "description" : "Sets the list of binary media types.",
+                                "$comment" : "group:advanced"
+                              }
+                            },
+                            "charset" : {
+                              "type" : "string",
+                              "title" : "Charset",
+                              "description" : "The default charset.",
+                              "$comment" : "group:advanced"
+                            },
+                            "contentType" : {
+                              "type" : "string",
+                              "title" : "ContentType",
+                              "description" : "Sets the default content type header set for each request.",
+                              "$comment" : "group:advanced"
+                            },
+                            "correlator" : {
+                              "type" : "string",
+                              "title" : "Correlator",
+                              "description" : "Sets the message correlator.",
+                              "$comment" : "group:advanced"
+                            },
+                            "defaultAcceptHeader" : {
+                              "type" : "boolean",
+                              "title" : "DefaultAcceptHeader",
+                              "description" : "When enabled the client adds the default accept header to requests.",
+                              "$comment" : "group:advanced"
+                            },
+                            "disableRedirectHandling" : {
+                              "type" : "boolean",
+                              "title" : "DisableRedirectHandling",
+                              "description" : "Disables the redirect handling for this client.",
+                              "$comment" : "group:advanced"
+                            },
+                            "endpointResolver" : {
+                              "type" : "string",
+                              "title" : "EndpointResolver",
+                              "description" : "Sets the endpoint URI resolver.",
+                              "$comment" : "group:advanced"
+                            },
+                            "errorHandler" : {
+                              "type" : "string",
+                              "title" : "ErrorHandler",
+                              "description" : "Sets a custom error handler.",
+                              "$comment" : "group:errorHandling"
+                            },
+                            "errorHandlingStrategy" : {
+                              "allOf" : [ {
+                                "$ref" : "#/definitions/ErrorHandlingStrategy"
+                              }, {
+                                "title" : "ErrorHandlingStrategy",
+                                "description" : "Sets the error handling strategy.",
+                                "$comment" : "group:errorHandling"
+                              } ]
+                            },
+                            "handleCookies" : {
+                              "type" : "boolean",
+                              "title" : "HandleCookies",
+                              "description" : "When enabled the client handles cookies.",
+                              "$comment" : "group:advanced"
+                            },
+                            "headerMapper" : {
+                              "type" : "string",
+                              "title" : "HeaderMapper",
+                              "description" : "Sets a custom header mapper bean reference.",
+                              "$comment" : "group:advanced"
+                            },
+                            "interceptor" : {
+                              "type" : "string",
+                              "title" : "Interceptor",
+                              "description" : "Sets a client interceptor.",
+                              "$comment" : "group:intercept"
+                            },
+                            "interceptors" : {
+                              "title" : "Interceptors",
+                              "description" : "Sets the list of client interceptor bean references.",
+                              "$comment" : "group:intercept",
+                              "type" : "array",
+                              "items" : {
+                                "type" : "string",
+                                "title" : "Interceptors",
+                                "description" : "Sets the list of client interceptor bean references.",
+                                "$comment" : "group:intercept"
+                              }
+                            },
+                            "messageConverter" : {
+                              "type" : "string",
+                              "title" : "MessageConverter",
+                              "description" : "Bean reference to a message converter.",
+                              "$comment" : "group:advanced"
+                            },
+                            "name" : {
+                              "type" : "string",
+                              "title" : "Name",
+                              "description" : "The name of the endpoint"
+                            },
+                            "pollingInterval" : {
+                              "type" : "integer",
+                              "title" : "PollingInterval",
+                              "description" : "Sets the polling interval when consuming messages.",
+                              "$comment" : "group:advanced"
+                            },
+                            "requestFactory" : {
+                              "type" : "string",
+                              "title" : "RequestFactory",
+                              "description" : "Reference to a request factory.",
+                              "$comment" : "group:advanced"
+                            },
+                            "requestMethod" : {
+                              "allOf" : [ {
+                                "$ref" : "#/definitions/RequestMethod"
+                              }, {
+                                "title" : "RequestMethod",
+                                "description" : "The default request method to use"
+                              } ]
+                            },
+                            "requestUrl" : {
+                              "type" : "string",
+                              "title" : "RequestUrl",
+                              "description" : "Sets the Http client request URL."
+                            },
+                            "restTemplate" : {
+                              "type" : "string",
+                              "title" : "RestTemplate",
+                              "description" : "The reference to a REST template bean.",
+                              "$comment" : "group:advanced"
+                            },
+                            "securedConnection" : {
+                              "type" : "string",
+                              "title" : "SecuredConnection",
+                              "description" : "Secure the connection with given security mechanism.",
+                              "$comment" : "group:security"
+                            },
+                            "timeout" : {
+                              "type" : "integer",
+                              "title" : "Timeout",
+                              "description" : "The Http request timeout while waiting for a response",
+                              "default" : "5000"
+                            }
+                          },
+                          "additionalProperties" : false,
+                          "title" : "Client",
+                          "description" : "Sets the Http client endpoint."
+                        }
+                      },
+                      "required" : [ "client" ]
+                    }, {
+                      "type" : "object",
+                      "properties" : {
+                        "server" : {
+                          "type" : "object",
+                          "properties" : {
+                            "authentication" : {
+                              "type" : "string",
+                              "title" : "Authentication",
+                              "description" : "Use given authentication mechanism for all request paths.",
+                              "$comment" : "group:security"
+                            },
+                            "autoStart" : {
+                              "type" : "boolean",
+                              "title" : "AutoStart",
+                              "description" : "When enabled the server is automatically started after creation."
+                            },
+                            "binaryMediaTypes" : {
+                              "title" : "BinaryMediaTypes",
+                              "description" : "List of supported media types on this server.",
+                              "$comment" : "group:advanced",
+                              "type" : "array",
+                              "items" : {
+                                "type" : "string",
+                                "title" : "BinaryMediaTypes",
+                                "description" : "List of supported media types on this server.",
+                                "$comment" : "group:advanced"
+                              }
+                            },
+                            "connector" : {
+                              "type" : "string",
+                              "title" : "Connector",
+                              "description" : "Add a connector to this server.",
+                              "$comment" : "group:servlet"
+                            },
+                            "connectors" : {
+                              "title" : "Connectors",
+                              "description" : "Sets a list of connectors for this server.",
+                              "$comment" : "group:servlet",
+                              "type" : "array",
+                              "items" : {
+                                "type" : "string",
+                                "title" : "Connectors",
+                                "description" : "Sets a list of connectors for this server.",
+                                "$comment" : "group:servlet"
+                              }
+                            },
+                            "contextConfigLocation" : {
+                              "type" : "string",
+                              "title" : "ContextConfigLocation",
+                              "description" : "Sets the Spring context configuration loaded for this Http server.",
+                              "$comment" : "group:advanced"
+                            },
+                            "contextPath" : {
+                              "type" : "string",
+                              "title" : "ContextPath",
+                              "description" : "Sets the context path on this server.",
+                              "$comment" : "group:servlet"
+                            },
+                            "debugLogging" : {
+                              "type" : "boolean",
+                              "title" : "DebugLogging",
+                              "description" : "When enabled the server prints debug logging output.",
+                              "$comment" : "group:advanced"
+                            },
+                            "defaultStatus" : {
+                              "allOf" : [ {
+                                "$ref" : "#/definitions/HttpStatus"
+                              }, {
+                                "title" : "DefaultStatus",
+                                "description" : "Sets the default status returned by the server.",
+                                "$comment" : "group:advanced"
+                              } ]
+                            },
+                            "endpointAdapter" : {
+                              "type" : "string",
+                              "title" : "EndpointAdapter",
+                              "description" : "Sets a custom endpoint adapter to handle requests.",
+                              "$comment" : "group:advanced"
+                            },
+                            "filterMappings" : {
+                              "type" : "object",
+                              "title" : "FilterMappings",
+                              "description" : "Filter mapping used on this server.",
+                              "additionalProperties" : {
+                                "type" : "string",
+                                "title" : "FilterMappings",
+                                "description" : "Filter mapping used on this server.",
+                                "$comment" : "group:filter"
+                              },
+                              "$comment" : "group:filter"
+                            },
+                            "filters" : {
+                              "type" : "object",
+                              "title" : "Filters",
+                              "description" : "Map of Http filters used on this server.",
+                              "additionalProperties" : {
+                                "type" : "string",
+                                "title" : "Filters",
+                                "description" : "Map of Http filters used on this server.",
+                                "$comment" : "group:filter"
+                              },
+                              "$comment" : "group:filter"
+                            },
+                            "handleAttributeHeaders" : {
+                              "type" : "boolean",
+                              "title" : "HandleAttributeHeaders",
+                              "description" : "When enabled the server handles attribute headers.",
+                              "$comment" : "group:advanced"
+                            },
+                            "handleCookies" : {
+                              "type" : "boolean",
+                              "title" : "HandleCookies",
+                              "description" : "When enabled the server handles cookies.",
+                              "$comment" : "group:advanced"
+                            },
+                            "interceptor" : {
+                              "type" : "string",
+                              "title" : "Interceptor",
+                              "description" : "Sets a handler interceptor.",
+                              "$comment" : "group:intercept"
+                            },
+                            "interceptors" : {
+                              "title" : "Interceptors",
+                              "description" : "Sets the list of handler interceptor bean references.",
+                              "$comment" : "group:intercept",
+                              "type" : "array",
+                              "items" : {
+                                "type" : "string",
+                                "title" : "Interceptors",
+                                "description" : "Sets the list of handler interceptor bean references.",
+                                "$comment" : "group:intercept"
+                              }
+                            },
+                            "messageConverter" : {
+                              "type" : "string",
+                              "title" : "MessageConverter",
+                              "description" : "Sets the Http message converter bean reference.",
+                              "$comment" : "group:advanced"
+                            },
+                            "name" : {
+                              "type" : "string",
+                              "title" : "Name",
+                              "description" : "The name of the endpoint"
+                            },
+                            "port" : {
+                              "type" : "integer",
+                              "title" : "Port",
+                              "description" : "The Http server port."
+                            },
+                            "removeSemicolonPathContent" : {
+                              "type" : "boolean",
+                              "title" : "RemoveSemicolonPathContent",
+                              "description" : "When enabled the server removes semicolon path content from headers.",
+                              "$comment" : "group:advanced"
+                            },
+                            "resourceBase" : {
+                              "type" : "string",
+                              "title" : "ResourceBase",
+                              "description" : "The server resource base path where resources get loaded from.",
+                              "$comment" : "group:advanced"
+                            },
+                            "responseCacheSize" : {
+                              "type" : "integer",
+                              "title" : "ResponseCacheSize",
+                              "description" : "Sets the response cache size.",
+                              "$comment" : "group:advanced"
+                            },
+                            "rootParentContext" : {
+                              "type" : "boolean",
+                              "title" : "RootParentContext",
+                              "description" : "When enabled the server uses the root Spring application context.",
+                              "$comment" : "group:advanced"
+                            },
+                            "securePort" : {
+                              "type" : "integer",
+                              "title" : "SecurePort",
+                              "description" : "The secured port.",
+                              "$comment" : "group:security"
+                            },
+                            "securedConnection" : {
+                              "type" : "string",
+                              "title" : "SecuredConnection",
+                              "description" : "Secure the connections on given secured port with given security mechanism.",
+                              "$comment" : "group:security"
+                            },
+                            "securityHandler" : {
+                              "type" : "string",
+                              "title" : "SecurityHandler",
+                              "description" : "Sets the security handler as a bean reference.",
+                              "$comment" : "group:security"
+                            },
+                            "serServletHandler" : {
+                              "type" : "string",
+                              "title" : "SerServletHandler",
+                              "description" : "Sets a custom servlet handler as a bean reference.",
+                              "$comment" : "group:servlet"
+                            },
+                            "servletMappingPath" : {
+                              "type" : "string",
+                              "title" : "ServletMappingPath",
+                              "description" : "Sets the servlet mapping path.",
+                              "$comment" : "group:servlet"
+                            },
+                            "servletName" : {
+                              "type" : "string",
+                              "title" : "ServletName",
+                              "description" : "Sets the servlet name.",
+                              "$comment" : "group:servlet"
+                            },
+                            "timeout" : {
+                              "type" : "integer",
+                              "title" : "Timeout",
+                              "description" : "Sets the server timeout while waiting for incoming requests.",
+                              "default" : "5000"
+                            },
+                            "useDefaultFilters" : {
+                              "type" : "boolean",
+                              "title" : "UseDefaultFilters",
+                              "description" : "When enabled the server uses the default set of Http servlet filters.",
+                              "$comment" : "group:filter"
+                            }
+                          },
+                          "additionalProperties" : false,
+                          "title" : "Server",
+                          "description" : "Sets the Http server endpoint."
+                        }
+                      },
+                      "required" : [ "server" ]
+                    } ]
+                  } ],
+                  "title" : "Http",
+                  "description" : "Http client and server endpoints"
+                }
+              },
+              "required" : [ "http" ]
+            }, {
+              "type" : "object",
+              "properties" : {
+                "soap" : {
+                  "type" : "object",
+                  "properties" : {
+                    "client" : { },
+                    "server" : { }
+                  },
+                  "additionalProperties" : false,
+                  "anyOf" : [ {
+                    "oneOf" : [ {
+                      "type" : "object",
+                      "properties" : {
+                        "client" : {
+                          "type" : "object",
+                          "properties" : {
+                            "correlator" : {
+                              "type" : "string",
+                              "title" : "Correlator",
+                              "description" : "Sets the message correlator.",
+                              "$comment" : "group:advanced"
+                            },
+                            "defaultUri" : {
+                              "type" : "string",
+                              "title" : "DefaultUri",
+                              "description" : "Sets the SOAP Web Service server url."
+                            },
+                            "endpointResolver" : {
+                              "type" : "string",
+                              "title" : "EndpointResolver",
+                              "description" : "Sets the endpoint resolver.",
+                              "$comment" : "group:advanced"
+                            },
+                            "faultStrategy" : {
+                              "allOf" : [ {
+                                "$ref" : "#/definitions/ErrorHandlingStrategy"
+                              }, {
+                                "title" : "FaultStrategy",
+                                "description" : "Sets the error handling strategy.",
+                                "$comment" : "group:errorHandler"
+                              } ]
+                            },
+                            "interceptor" : {
+                              "type" : "string",
+                              "title" : "Interceptor",
+                              "description" : "Sets a custom client interceptor.",
+                              "$comment" : "group:intercept"
+                            },
+                            "interceptors" : {
+                              "title" : "Interceptors",
+                              "description" : "Sets client interceptors.",
+                              "$comment" : "group:intercept",
+                              "type" : "array",
+                              "items" : {
+                                "type" : "string",
+                                "title" : "Interceptors",
+                                "description" : "Sets client interceptors.",
+                                "$comment" : "group:intercept"
+                              }
+                            },
+                            "keepSoapEnvelope" : {
+                              "type" : "boolean",
+                              "title" : "KeepSoapEnvelope",
+                              "description" : "When enabled the client does not remove the SOAP envelope before processing the message.",
+                              "$comment" : "group:advanced"
+                            },
+                            "messageConverter" : {
+                              "type" : "string",
+                              "title" : "MessageConverter",
+                              "description" : "Sets a custom message converter implementation.",
+                              "$comment" : "group:advanced"
+                            },
+                            "messageFactory" : {
+                              "type" : "string",
+                              "title" : "MessageFactory",
+                              "description" : "Sets a custom message factory.",
+                              "$comment" : "group:advanced"
+                            },
+                            "messageSender" : {
+                              "type" : "string",
+                              "title" : "MessageSender",
+                              "description" : "Sets a custom message sender implementation.",
+                              "$comment" : "group:advanced"
+                            },
+                            "name" : {
+                              "type" : "string",
+                              "title" : "Name",
+                              "description" : "The name of the endpoint"
+                            },
+                            "pollingInterval" : {
+                              "type" : "integer",
+                              "title" : "PollingInterval",
+                              "description" : "Sets the polling interval when consuming messages."
+                            },
+                            "timeout" : {
+                              "type" : "integer",
+                              "title" : "Timeout",
+                              "description" : "Sets the receive timeout when the client waits for response messages.",
+                              "default" : "5000"
+                            },
+                            "webServiceTemplate" : {
+                              "type" : "string",
+                              "title" : "WebServiceTemplate",
+                              "description" : "Sets custom web service template reference.",
+                              "$comment" : "group:advanced"
+                            }
+                          },
+                          "additionalProperties" : false,
+                          "title" : "Client",
+                          "description" : "Sets the SOAP WebService client endpoint."
+                        }
+                      },
+                      "required" : [ "client" ]
+                    }, {
+                      "type" : "object",
+                      "properties" : {
+                        "server" : {
+                          "type" : "object",
+                          "properties" : {
+                            "autoStart" : {
+                              "type" : "boolean",
+                              "title" : "AutoStart",
+                              "description" : "When enabled the server is automatically started after creation."
+                            },
+                            "connector" : {
+                              "type" : "string",
+                              "title" : "Connector",
+                              "description" : "Add a connector to this server.",
+                              "$comment" : "group:servlet"
+                            },
+                            "connectors" : {
+                              "title" : "Connectors",
+                              "description" : "Sets a list of connectors for this server.",
+                              "$comment" : "group:servlet",
+                              "type" : "array",
+                              "items" : {
+                                "type" : "string",
+                                "title" : "Connectors",
+                                "description" : "Sets a list of connectors for this server.",
+                                "$comment" : "group:servlet"
+                              }
+                            },
+                            "contextConfigLocation" : {
+                              "type" : "string",
+                              "title" : "ContextConfigLocation",
+                              "description" : "Sets the path to the Spring context configuration for this server.",
+                              "$comment" : "group:advanced"
+                            },
+                            "contextPath" : {
+                              "type" : "string",
+                              "title" : "ContextPath",
+                              "description" : "Sets the context path on this server.",
+                              "$comment" : "group:servlet"
+                            },
+                            "debugLogging" : {
+                              "type" : "boolean",
+                              "title" : "DebugLogging",
+                              "description" : "When enabled the server prints debug logging output.",
+                              "$comment" : "group:advanced"
+                            },
+                            "endpointAdapter" : {
+                              "type" : "string",
+                              "title" : "EndpointAdapter",
+                              "description" : "Sets a custom endpoint adapter to handle requests.",
+                              "$comment" : "group:advanced"
+                            },
+                            "handleAttributeHeaders" : {
+                              "type" : "boolean",
+                              "title" : "HandleAttributeHeaders",
+                              "description" : "When enabled the server handles attribute headers.",
+                              "$comment" : "group:advanced"
+                            },
+                            "handleMimeHeaders" : {
+                              "type" : "boolean",
+                              "title" : "HandleMimeHeaders",
+                              "description" : "When enabled the server handles mime headers.",
+                              "$comment" : "group:advanced"
+                            },
+                            "interceptor" : {
+                              "type" : "string",
+                              "title" : "Interceptor",
+                              "description" : "Sets a endpoint interceptor.",
+                              "$comment" : "group:intercept"
+                            },
+                            "interceptors" : {
+                              "title" : "Interceptors",
+                              "description" : "Sets the list of endpoint interceptor bean references.",
+                              "$comment" : "group:intercept",
+                              "type" : "array",
+                              "items" : {
+                                "type" : "string",
+                                "title" : "Interceptors",
+                                "description" : "Sets the list of endpoint interceptor bean references.",
+                                "$comment" : "group:intercept"
+                              }
+                            },
+                            "keepSoapEnvelope" : {
+                              "type" : "boolean",
+                              "title" : "KeepSoapEnvelope",
+                              "description" : "When enabled the server does not remove the SOAP envelope before processing messages.",
+                              "$comment" : "group:advanced"
+                            },
+                            "messageConverter" : {
+                              "type" : "string",
+                              "title" : "MessageConverter",
+                              "description" : "Sets the Http message converter bean reference.",
+                              "$comment" : "group:advanced"
+                            },
+                            "messageFactory" : {
+                              "type" : "string",
+                              "title" : "MessageFactory",
+                              "description" : "Sets a custom message factory.",
+                              "$comment" : "group:advanced"
+                            },
+                            "name" : {
+                              "type" : "string",
+                              "title" : "Name",
+                              "description" : "The name of the endpoint"
+                            },
+                            "port" : {
+                              "type" : "integer",
+                              "title" : "Port",
+                              "description" : "The SOAP WebService server port."
+                            },
+                            "resourceBase" : {
+                              "type" : "string",
+                              "title" : "ResourceBase",
+                              "description" : "Sets the resource base path where the server reads resources from.",
+                              "$comment" : "group:advanced"
+                            },
+                            "rootParentContext" : {
+                              "type" : "boolean",
+                              "title" : "RootParentContext",
+                              "description" : "When enabled the server uses the root Spring application context.",
+                              "$comment" : "group:advanced"
+                            },
+                            "securityHandler" : {
+                              "type" : "string",
+                              "title" : "SecurityHandler",
+                              "description" : "Sets the security handler as a bean reference.",
+                              "$comment" : "group:security"
+                            },
+                            "serServletHandler" : {
+                              "type" : "string",
+                              "title" : "SerServletHandler",
+                              "description" : "Sets a custom servlet handler as a bean reference.",
+                              "$comment" : "group:servlet"
+                            },
+                            "servletMappingPath" : {
+                              "type" : "string",
+                              "title" : "ServletMappingPath",
+                              "description" : "Sets the servlet mapping path.",
+                              "$comment" : "group:servlet"
+                            },
+                            "servletName" : {
+                              "type" : "string",
+                              "title" : "ServletName",
+                              "description" : "Sets the servlet name.",
+                              "$comment" : "group:servlet"
+                            },
+                            "soapHeaderNamespace" : {
+                              "type" : "string",
+                              "title" : "SoapHeaderNamespace",
+                              "description" : "Sets the SOAP header namespace.",
+                              "$comment" : "group:advanced"
+                            },
+                            "soapHeaderPrefix" : {
+                              "type" : "string",
+                              "title" : "SoapHeaderPrefix",
+                              "description" : "Sets the SOAP header namespace prefix.",
+                              "$comment" : "group:advanced"
+                            },
+                            "timeout" : {
+                              "type" : "integer",
+                              "title" : "Timeout",
+                              "description" : "Sets the server timeout while waiting for incoming requests.",
+                              "default" : "5000"
+                            }
+                          },
+                          "additionalProperties" : false,
+                          "title" : "Server",
+                          "description" : "Sets the SOAP WebService server endpoint."
+                        }
+                      },
+                      "required" : [ "server" ]
+                    } ]
+                  } ],
+                  "title" : "Soap",
+                  "description" : "SOAP WebService client and server endpoints"
+                }
+              },
+              "required" : [ "soap" ]
+            }, {
+              "type" : "object",
+              "properties" : {
+                "webSocket" : {
+                  "type" : "object",
+                  "properties" : {
+                    "client" : { },
+                    "server" : { }
+                  },
+                  "additionalProperties" : false,
+                  "anyOf" : [ {
+                    "oneOf" : [ {
+                      "type" : "object",
+                      "properties" : {
+                        "client" : {
+                          "type" : "object",
+                          "properties" : {
+                            "endpointResolver" : {
+                              "type" : "string",
+                              "title" : "EndpointResolver",
+                              "description" : "Sets the endpoint URI resolver.",
+                              "$comment" : "group:advanced"
+                            },
+                            "messageConverter" : {
+                              "type" : "string",
+                              "title" : "MessageConverter",
+                              "description" : "Bean reference to a message converter.",
+                              "$comment" : "group:advanced"
+                            },
+                            "name" : {
+                              "type" : "string",
+                              "title" : "Name",
+                              "description" : "The name of the endpoint"
+                            },
+                            "pollingInterval" : {
+                              "type" : "integer",
+                              "title" : "PollingInterval",
+                              "description" : "Sets the polling interval when consuming messages.",
+                              "$comment" : "group:advanced"
+                            },
+                            "requestUrl" : {
+                              "type" : "string",
+                              "title" : "RequestUrl",
+                              "description" : "Sets the client request URL."
+                            },
+                            "timeout" : {
+                              "type" : "integer",
+                              "title" : "Timeout",
+                              "description" : "The Http request timeout while waiting for a response",
+                              "default" : "5000"
+                            }
+                          },
+                          "additionalProperties" : false,
+                          "title" : "Client",
+                          "description" : "Sets the WebSocket client endpoint."
+                        }
+                      },
+                      "required" : [ "client" ]
+                    }, {
+                      "type" : "object",
+                      "properties" : {
+                        "server" : {
+                          "type" : "object",
+                          "properties" : {
+                            "authentication" : {
+                              "type" : "string",
+                              "title" : "Authentication",
+                              "description" : "Use given authentication mechanism for all request paths.",
+                              "$comment" : "group:security"
+                            },
+                            "autoStart" : {
+                              "type" : "boolean",
+                              "title" : "AutoStart",
+                              "description" : "When enabled the server is automatically started after creation."
+                            },
+                            "binaryMediaTypes" : {
+                              "title" : "BinaryMediaTypes",
+                              "description" : "List of supported media types on this server.",
+                              "$comment" : "group:advanced",
+                              "type" : "array",
+                              "items" : {
+                                "type" : "string",
+                                "title" : "BinaryMediaTypes",
+                                "description" : "List of supported media types on this server.",
+                                "$comment" : "group:advanced"
+                              }
+                            },
+                            "connector" : {
+                              "type" : "string",
+                              "title" : "Connector",
+                              "description" : "Add a connector to this server.",
+                              "$comment" : "group:servlet"
+                            },
+                            "connectors" : {
+                              "title" : "Connectors",
+                              "description" : "Sets a list of connectors for this server.",
+                              "$comment" : "group:servlet",
+                              "type" : "array",
+                              "items" : {
+                                "type" : "string",
+                                "title" : "Connectors",
+                                "description" : "Sets a list of connectors for this server.",
+                                "$comment" : "group:servlet"
+                              }
+                            },
+                            "contextConfigLocation" : {
+                              "type" : "string",
+                              "title" : "ContextConfigLocation",
+                              "description" : "Sets the Spring context configuration loaded for this Http server.",
+                              "$comment" : "group:advanced"
+                            },
+                            "contextPath" : {
+                              "type" : "string",
+                              "title" : "ContextPath",
+                              "description" : "Sets the context path on this server.",
+                              "$comment" : "group:servlet"
+                            },
+                            "debugLogging" : {
+                              "type" : "boolean",
+                              "title" : "DebugLogging",
+                              "description" : "When enabled the server prints debug logging output.",
+                              "$comment" : "group:advanced"
+                            },
+                            "defaultStatus" : {
+                              "allOf" : [ {
+                                "$ref" : "#/definitions/HttpStatus"
+                              }, {
+                                "title" : "DefaultStatus",
+                                "description" : "Sets the default status returned by the server.",
+                                "$comment" : "group:advanced"
+                              } ]
+                            },
+                            "endpointAdapter" : {
+                              "type" : "string",
+                              "title" : "EndpointAdapter",
+                              "description" : "Sets a custom endpoint adapter to handle requests.",
+                              "$comment" : "group:advanced"
+                            },
+                            "filterMappings" : {
+                              "type" : "object",
+                              "title" : "FilterMappings",
+                              "description" : "Filter mapping used on this server.",
+                              "additionalProperties" : {
+                                "type" : "string",
+                                "title" : "FilterMappings",
+                                "description" : "Filter mapping used on this server.",
+                                "$comment" : "group:filter"
+                              },
+                              "$comment" : "group:filter"
+                            },
+                            "filters" : {
+                              "type" : "object",
+                              "title" : "Filters",
+                              "description" : "Map of Http filters used on this server.",
+                              "additionalProperties" : {
+                                "type" : "string",
+                                "title" : "Filters",
+                                "description" : "Map of Http filters used on this server.",
+                                "$comment" : "group:filter"
+                              },
+                              "$comment" : "group:filter"
+                            },
+                            "handleAttributeHeaders" : {
+                              "type" : "boolean",
+                              "title" : "HandleAttributeHeaders",
+                              "description" : "When enabled the server handles attribute headers.",
+                              "$comment" : "group:advanced"
+                            },
+                            "handleCookies" : {
+                              "type" : "boolean",
+                              "title" : "HandleCookies",
+                              "description" : "When enabled the server handles cookies.",
+                              "$comment" : "group:advanced"
+                            },
+                            "interceptor" : {
+                              "type" : "string",
+                              "title" : "Interceptor",
+                              "description" : "Sets a handler interceptor.",
+                              "$comment" : "group:intercept"
+                            },
+                            "interceptors" : {
+                              "title" : "Interceptors",
+                              "description" : "Sets the list of handler interceptor bean references.",
+                              "$comment" : "group:intercept",
+                              "type" : "array",
+                              "items" : {
+                                "type" : "string",
+                                "title" : "Interceptors",
+                                "description" : "Sets the list of handler interceptor bean references.",
+                                "$comment" : "group:intercept"
+                              }
+                            },
+                            "messageConverter" : {
+                              "type" : "string",
+                              "title" : "MessageConverter",
+                              "description" : "Sets the Http message converter bean reference.",
+                              "$comment" : "group:advanced"
+                            },
+                            "name" : {
+                              "type" : "string",
+                              "title" : "Name",
+                              "description" : "The name of the endpoint"
+                            },
+                            "port" : {
+                              "type" : "integer",
+                              "title" : "Port",
+                              "description" : "The Http server port."
+                            },
+                            "removeSemicolonPathContent" : {
+                              "type" : "boolean",
+                              "title" : "RemoveSemicolonPathContent",
+                              "description" : "When enabled the server removes semicolon path content from headers.",
+                              "$comment" : "group:advanced"
+                            },
+                            "resourceBase" : {
+                              "type" : "string",
+                              "title" : "ResourceBase",
+                              "description" : "The server resource base path where resources get loaded from.",
+                              "$comment" : "group:advanced"
+                            },
+                            "responseCacheSize" : {
+                              "type" : "integer",
+                              "title" : "ResponseCacheSize",
+                              "description" : "Sets the response cache size.",
+                              "$comment" : "group:advanced"
+                            },
+                            "rootParentContext" : {
+                              "type" : "boolean",
+                              "title" : "RootParentContext",
+                              "description" : "When enabled the server uses the root Spring application context.",
+                              "$comment" : "group:advanced"
+                            },
+                            "securePort" : {
+                              "type" : "integer",
+                              "title" : "SecurePort",
+                              "description" : "The secured port.",
+                              "$comment" : "group:security"
+                            },
+                            "securedConnection" : {
+                              "type" : "string",
+                              "title" : "SecuredConnection",
+                              "description" : "Secure the connections on given secured port with given security mechanism.",
+                              "$comment" : "group:security"
+                            },
+                            "securityHandler" : {
+                              "type" : "string",
+                              "title" : "SecurityHandler",
+                              "description" : "Sets the security handler as a bean reference.",
+                              "$comment" : "group:security"
+                            },
+                            "serServletHandler" : {
+                              "type" : "string",
+                              "title" : "SerServletHandler",
+                              "description" : "Sets a custom servlet handler as a bean reference.",
+                              "$comment" : "group:servlet"
+                            },
+                            "servletMappingPath" : {
+                              "type" : "string",
+                              "title" : "ServletMappingPath",
+                              "description" : "Sets the servlet mapping path.",
+                              "$comment" : "group:servlet"
+                            },
+                            "servletName" : {
+                              "type" : "string",
+                              "title" : "ServletName",
+                              "description" : "Sets the servlet name.",
+                              "$comment" : "group:servlet"
+                            },
+                            "timeout" : {
+                              "type" : "integer",
+                              "title" : "Timeout",
+                              "description" : "Sets the server timeout while waiting for incoming requests.",
+                              "default" : "5000"
+                            },
+                            "useDefaultFilters" : {
+                              "type" : "boolean",
+                              "title" : "UseDefaultFilters",
+                              "description" : "When enabled the server uses the default set of Http servlet filters.",
+                              "$comment" : "group:filter"
+                            },
+                            "webSockets" : {
+                              "title" : "WebSockets",
+                              "description" : "Sets the list of web sockets for this server.",
+                              "type" : "array",
+                              "items" : {
+                                "type" : "string",
+                                "title" : "WebSockets",
+                                "description" : "Sets the list of web sockets for this server."
+                              }
+                            }
+                          },
+                          "additionalProperties" : false,
+                          "title" : "Server",
+                          "description" : "Sets the WebSocket server endpoint."
+                        }
+                      },
+                      "required" : [ "server" ]
+                    } ]
+                  } ],
+                  "title" : "WebSocket",
+                  "description" : "WebSocket client and server endpoints"
+                }
+              },
+              "required" : [ "webSocket" ]
+            }, {
+              "type" : "object",
+              "properties" : {
+                "context" : {
+                  "type" : "object",
+                  "properties" : {
+                    "messageStore" : {
+                      "type" : "object",
+                      "properties" : {
+                        "messageName" : {
+                          "type" : "string",
+                          "title" : "MessageName",
+                          "description" : "The message name."
+                        },
+                        "name" : {
+                          "type" : "string",
+                          "title" : "Name",
+                          "description" : "The name of the endpoint"
+                        },
+                        "timeout" : {
+                          "type" : "integer",
+                          "title" : "Timeout",
+                          "description" : "The timeout when receiving messages from the message store."
+                        }
+                      },
+                      "additionalProperties" : false,
+                      "title" : "MessageStore",
+                      "description" : "Sets a message store endpoint ."
+                    }
+                  },
+                  "additionalProperties" : false,
+                  "title" : "Context",
+                  "description" : "Context endpoint."
+                }
+              },
+              "required" : [ "context" ]
+            }, {
+              "type" : "object",
+              "properties" : {
+                "mail" : {
+                  "type" : "object",
+                  "properties" : {
+                    "client" : { },
+                    "server" : { }
+                  },
+                  "additionalProperties" : false,
+                  "anyOf" : [ {
+                    "oneOf" : [ {
+                      "type" : "object",
+                      "properties" : {
+                        "client" : {
+                          "type" : "object",
+                          "properties" : {
+                            "host" : {
+                              "type" : "string",
+                              "title" : "Host",
+                              "description" : "The mail server host to connect to."
+                            },
+                            "javaMailProperties" : {
+                              "type" : "object",
+                              "title" : "JavaMailProperties",
+                              "description" : "Custom properties passed to the java mail implementation.",
+                              "$comment" : "group:advanced"
+                            },
+                            "marshaller" : {
+                              "type" : "string",
+                              "title" : "Marshaller",
+                              "description" : "Sets a custom mail message marshaller.",
+                              "$comment" : "group:advanced"
+                            },
+                            "messageConverter" : {
+                              "type" : "string",
+                              "title" : "MessageConverter",
+                              "description" : "Sets custom message converter.",
+                              "$comment" : "group:advanced"
+                            },
+                            "name" : {
+                              "type" : "string",
+                              "title" : "Name",
+                              "description" : "The name of the endpoint"
+                            },
+                            "password" : {
+                              "type" : "string",
+                              "title" : "Password",
+                              "description" : "The client user password.",
+                              "$comment" : "group:security"
+                            },
+                            "port" : {
+                              "type" : "integer",
+                              "title" : "Port",
+                              "description" : "The mail server port."
+                            },
+                            "protocol" : {
+                              "type" : "string",
+                              "title" : "Protocol",
+                              "description" : "The mail protocol."
+                            },
+                            "timeout" : {
+                              "type" : "integer",
+                              "title" : "Timeout",
+                              "description" : "Mail client timeout when waiting for a response."
+                            },
+                            "username" : {
+                              "type" : "string",
+                              "title" : "Username",
+                              "description" : "The client user name.",
+                              "$comment" : "group:security"
+                            }
+                          },
+                          "additionalProperties" : false,
+                          "title" : "Client",
+                          "description" : "Sets the mail client endpoint."
+                        }
+                      },
+                      "required" : [ "client" ]
+                    }, {
+                      "type" : "object",
+                      "properties" : {
+                        "server" : {
+                          "type" : "object",
+                          "properties" : {
+                            "authRequired" : {
+                              "type" : "boolean",
+                              "title" : "AuthRequired",
+                              "description" : "When enabled users must authenticate with the server.",
+                              "$comment" : "group:security"
+                            },
+                            "autoAccept" : {
+                              "type" : "boolean",
+                              "title" : "AutoAccept",
+                              "description" : "When enabled server will auto accept client connections.",
+                              "$comment" : "group:security"
+                            },
+                            "autoStart" : {
+                              "type" : "boolean",
+                              "title" : "AutoStart",
+                              "description" : "When enabled the server is automatically started after creation."
+                            },
+                            "debugLogging" : {
+                              "type" : "boolean",
+                              "title" : "DebugLogging",
+                              "description" : "When enabled the server prints debug logging output.",
+                              "$comment" : "group:advanced"
+                            },
+                            "endpointAdapter" : {
+                              "type" : "string",
+                              "title" : "EndpointAdapter",
+                              "description" : "Sets a custom endpoint adapter to handle requests.",
+                              "$comment" : "group:advanced"
+                            },
+                            "javaMailProperties" : {
+                              "type" : "object",
+                              "title" : "JavaMailProperties",
+                              "description" : "Custom properties passed to the java mail implementation.",
+                              "$comment" : "group:advanced"
+                            },
+                            "knownUsers" : {
+                              "title" : "KnownUsers",
+                              "description" : "Sets a list of known users that will be accepted when establishing a connection.",
+                              "$comment" : "group:security",
+                              "type" : "array",
+                              "items" : {
+                                "type" : "string",
+                                "title" : "KnownUsers",
+                                "description" : "Sets a list of known users that will be accepted when establishing a connection.",
+                                "$comment" : "group:security"
+                              }
+                            },
+                            "marshaller" : {
+                              "type" : "string",
+                              "title" : "Marshaller",
+                              "description" : "Sets a custom mail message marshaller.",
+                              "$comment" : "group:advanced"
+                            },
+                            "messageConverter" : {
+                              "type" : "string",
+                              "title" : "MessageConverter",
+                              "description" : "Sets custom message converter.",
+                              "$comment" : "group:advanced"
+                            },
+                            "name" : {
+                              "type" : "string",
+                              "title" : "Name",
+                              "description" : "The name of the endpoint"
+                            },
+                            "port" : {
+                              "type" : "integer",
+                              "title" : "Port",
+                              "description" : "The mail server port."
+                            },
+                            "smtp" : {
+                              "type" : "string",
+                              "title" : "Smtp",
+                              "description" : "Sets the SMTP implementation.",
+                              "$comment" : "group:advanced"
+                            },
+                            "splitMultipart" : {
+                              "type" : "boolean",
+                              "title" : "SplitMultipart",
+                              "description" : "When enabled the server splits multipart messages into individual parts.",
+                              "$comment" : "group:advanced"
+                            },
+                            "timeout" : {
+                              "type" : "integer",
+                              "title" : "Timeout",
+                              "description" : "The server timeout.",
+                              "default" : "5000"
+                            }
+                          },
+                          "additionalProperties" : false,
+                          "title" : "Server",
+                          "description" : "Sets the mail server endpoint."
+                        }
+                      },
+                      "required" : [ "server" ]
+                    } ]
+                  } ],
+                  "title" : "Mail",
+                  "description" : "Mail client and server endpoints"
+                }
+              },
+              "required" : [ "mail" ]
+            }, {
+              "type" : "object",
+              "properties" : {
+                "ftp" : {
+                  "type" : "object",
+                  "properties" : {
+                    "client" : { },
+                    "server" : { }
+                  },
+                  "additionalProperties" : false,
+                  "anyOf" : [ {
+                    "oneOf" : [ {
+                      "type" : "object",
+                      "properties" : {
+                        "client" : {
+                          "type" : "object",
+                          "properties" : {
+                            "autoReadFiles" : {
+                              "type" : "boolean",
+                              "title" : "AutoReadFiles",
+                              "description" : "When enabled the client automatically reads new files."
+                            },
+                            "correlator" : {
+                              "type" : "string",
+                              "title" : "Correlator",
+                              "description" : "Sets the message correlator.",
+                              "$comment" : "group:advanced"
+                            },
+                            "errorHandlingStrategy" : {
+                              "allOf" : [ {
+                                "$ref" : "#/definitions/ErrorHandlingStrategy"
+                              }, {
+                                "title" : "ErrorHandlingStrategy",
+                                "description" : "Sets the error handling strategy.",
+                                "$comment" : "group:errorHandler"
+                              } ]
+                            },
+                            "host" : {
+                              "type" : "string",
+                              "title" : "Host",
+                              "description" : "The Ftp server host."
+                            },
+                            "localPassiveMode" : {
+                              "type" : "boolean",
+                              "title" : "LocalPassiveMode",
+                              "description" : "SEnables the local passive mode."
+                            },
+                            "name" : {
+                              "type" : "string",
+                              "title" : "Name",
+                              "description" : "The name of the endpoint"
+                            },
+                            "password" : {
+                              "type" : "string",
+                              "title" : "Password",
+                              "description" : "Sets the user password.",
+                              "$comment" : "group:security"
+                            },
+                            "pollingInterval" : {
+                              "type" : "integer",
+                              "title" : "PollingInterval",
+                              "description" : "Sets the polling interval when consuming messages."
+                            },
+                            "port" : {
+                              "type" : "integer",
+                              "title" : "Port",
+                              "description" : "The Ftp server port."
+                            },
+                            "timeout" : {
+                              "type" : "integer",
+                              "title" : "Timeout",
+                              "description" : "The endpoint timeout when waiting for messages."
+                            },
+                            "username" : {
+                              "type" : "string",
+                              "title" : "Username",
+                              "description" : "Sets the user name.",
+                              "$comment" : "group:security"
+                            }
+                          },
+                          "additionalProperties" : false,
+                          "title" : "Client",
+                          "description" : "Sets the ftp client endpoint."
+                        }
+                      },
+                      "required" : [ "client" ]
+                    }, {
+                      "type" : "object",
+                      "properties" : {
+                        "server" : {
+                          "type" : "object",
+                          "properties" : {
+                            "autoConnect" : {
+                              "type" : "boolean",
+                              "title" : "AutoConnect",
+                              "description" : "When enabled the server uses automatic connect mode."
+                            },
+                            "autoHandleCommands" : {
+                              "type" : "string",
+                              "title" : "AutoHandleCommands",
+                              "description" : "Enables the auto handle commands mode."
+                            },
+                            "autoLogin" : {
+                              "type" : "boolean",
+                              "title" : "AutoLogin",
+                              "description" : "When enabled the server uses automatic login mode."
+                            },
+                            "autoReadFiles" : {
+                              "type" : "boolean",
+                              "title" : "AutoReadFiles",
+                              "description" : "When enabled the client automatically reads new files."
+                            },
+                            "autoStart" : {
+                              "type" : "boolean",
+                              "title" : "AutoStart",
+                              "description" : "When enabled the server is automatically started after creation."
+                            },
+                            "correlator" : {
+                              "type" : "string",
+                              "title" : "Correlator",
+                              "description" : "Sets the message correlator.",
+                              "$comment" : "group:advanced"
+                            },
+                            "debugLogging" : {
+                              "type" : "boolean",
+                              "title" : "DebugLogging",
+                              "description" : "When enabled the server prints debug logging output.",
+                              "$comment" : "group:advanced"
+                            },
+                            "endpointAdapter" : {
+                              "type" : "string",
+                              "title" : "EndpointAdapter",
+                              "description" : "Sets a custom endpoint adapter to handle requests.",
+                              "$comment" : "group:advanced"
+                            },
+                            "errorHandlingStrategy" : {
+                              "allOf" : [ {
+                                "$ref" : "#/definitions/ErrorHandlingStrategy"
+                              }, {
+                                "title" : "ErrorHandlingStrategy",
+                                "description" : "Sets the error handling strategy.",
+                                "$comment" : "group:errorHandler"
+                              } ]
+                            },
+                            "host" : {
+                              "type" : "string",
+                              "title" : "Host",
+                              "description" : "The Ftp server host."
+                            },
+                            "listenerFactory" : {
+                              "type" : "string",
+                              "title" : "ListenerFactory",
+                              "description" : "Sets a custom listener factory implementation.",
+                              "$comment" : "group:advanced"
+                            },
+                            "localPassiveMode" : {
+                              "type" : "boolean",
+                              "title" : "LocalPassiveMode",
+                              "description" : "Enables the local passive mode."
+                            },
+                            "marshaller" : {
+                              "type" : "string",
+                              "title" : "Marshaller",
+                              "description" : "Sets a custom Ftp message marshaller.",
+                              "$comment" : "group:advanced"
+                            },
+                            "name" : {
+                              "type" : "string",
+                              "title" : "Name",
+                              "description" : "The name of the endpoint"
+                            },
+                            "password" : {
+                              "type" : "string",
+                              "title" : "Password",
+                              "description" : "Sets the allowed user password.",
+                              "$comment" : "group:security"
+                            },
+                            "port" : {
+                              "type" : "integer",
+                              "title" : "Port",
+                              "description" : "The Ftp server port."
+                            },
+                            "server" : {
+                              "type" : "string",
+                              "title" : "Server",
+                              "description" : "Sets the Ftp server implementation.",
+                              "$comment" : "group:advanced"
+                            },
+                            "timeout" : {
+                              "type" : "integer",
+                              "title" : "Timeout",
+                              "description" : "The server timeout.",
+                              "default" : "5000"
+                            },
+                            "user" : {
+                              "type" : "string",
+                              "title" : "User",
+                              "description" : "Sets the allowed user name."
+                            },
+                            "userManager" : {
+                              "type" : "string",
+                              "title" : "UserManager",
+                              "description" : "Sets a custom user manager implementation.",
+                              "$comment" : "group:advanced"
+                            },
+                            "userManagerProperties" : {
+                              "type" : "string",
+                              "title" : "UserManagerProperties",
+                              "description" : "Loads user manage properties from a file resource.",
+                              "$comment" : "group:advanced"
+                            }
+                          },
+                          "additionalProperties" : false,
+                          "title" : "Server",
+                          "description" : "Sets the ftp server endpoint."
+                        }
+                      },
+                      "required" : [ "server" ]
+                    } ]
+                  } ],
+                  "title" : "Ftp",
+                  "description" : "Ftp client and server endpoints"
+                }
+              },
+              "required" : [ "ftp" ]
+            }, {
+              "type" : "object",
+              "properties" : {
+                "sftp" : {
+                  "type" : "object",
+                  "properties" : {
+                    "client" : { },
+                    "server" : { }
+                  },
+                  "additionalProperties" : false,
+                  "anyOf" : [ {
+                    "oneOf" : [ {
+                      "type" : "object",
+                      "properties" : {
+                        "client" : {
+                          "type" : "object",
+                          "properties" : {
+                            "autoReadFiles" : {
+                              "type" : "boolean",
+                              "title" : "AutoReadFiles",
+                              "description" : "When enabled the client automatically reads new files."
+                            },
+                            "correlator" : {
+                              "type" : "string",
+                              "title" : "Correlator",
+                              "description" : "Sets the message correlator.",
+                              "$comment" : "group:advanced"
+                            },
+                            "errorHandlingStrategy" : {
+                              "allOf" : [ {
+                                "$ref" : "#/definitions/ErrorHandlingStrategy"
+                              }, {
+                                "title" : "ErrorHandlingStrategy",
+                                "description" : "Sets the error handling strategy.",
+                                "$comment" : "group:errorHandler"
+                              } ]
+                            },
+                            "host" : {
+                              "type" : "string",
+                              "title" : "Host",
+                              "description" : "The Ftp server host."
+                            },
+                            "knownHosts" : {
+                              "type" : "string",
+                              "title" : "KnownHosts",
+                              "description" : "List of known hosts.",
+                              "$comment" : "group:security"
+                            },
+                            "localPassiveMode" : {
+                              "type" : "boolean",
+                              "title" : "LocalPassiveMode",
+                              "description" : "SEnables the local passive mode."
+                            },
+                            "name" : {
+                              "type" : "string",
+                              "title" : "Name",
+                              "description" : "The name of the endpoint"
+                            },
+                            "password" : {
+                              "type" : "string",
+                              "title" : "Password",
+                              "description" : "Sets the user password.",
+                              "$comment" : "group:security"
+                            },
+                            "pollingInterval" : {
+                              "type" : "integer",
+                              "title" : "PollingInterval",
+                              "description" : "Sets the polling interval when consuming messages."
+                            },
+                            "port" : {
+                              "type" : "integer",
+                              "title" : "Port",
+                              "description" : "The Ftp server port."
+                            },
+                            "preferredAuthentications" : {
+                              "type" : "string",
+                              "title" : "PreferredAuthentications",
+                              "description" : "Sets the preferred authentication mechanism.",
+                              "$comment" : "group:security"
+                            },
+                            "privateKeyPassword" : {
+                              "type" : "string",
+                              "title" : "PrivateKeyPassword",
+                              "description" : "Sets the private key password.",
+                              "$comment" : "group:security"
+                            },
+                            "privateKeyPath" : {
+                              "type" : "string",
+                              "title" : "PrivateKeyPath",
+                              "description" : "Sets the private key path.",
+                              "$comment" : "group:security"
+                            },
+                            "sessionConfigs" : {
+                              "type" : "object",
+                              "title" : "SessionConfigs",
+                              "description" : "The session configuration.",
+                              "additionalProperties" : {
+                                "type" : "string",
+                                "title" : "SessionConfigs",
+                                "description" : "The session configuration."
+                              }
+                            },
+                            "strictHostChecking" : {
+                              "type" : "boolean",
+                              "title" : "StrictHostChecking",
+                              "description" : "Enable strict host checking.",
+                              "$comment" : "group:security"
+                            },
+                            "timeout" : {
+                              "type" : "integer",
+                              "title" : "Timeout",
+                              "description" : "The endpoint timeout when waiting for messages."
+                            },
+                            "username" : {
+                              "type" : "string",
+                              "title" : "Username",
+                              "description" : "Sets the user name.",
+                              "$comment" : "group:security"
+                            }
+                          },
+                          "additionalProperties" : false,
+                          "title" : "Client",
+                          "description" : "Sets the sftp client endpoint."
+                        }
+                      },
+                      "required" : [ "client" ]
+                    }, {
+                      "type" : "object",
+                      "properties" : {
+                        "server" : {
+                          "type" : "object",
+                          "properties" : {
+                            "allowedKeyPath" : {
+                              "type" : "string",
+                              "title" : "AllowedKeyPath",
+                              "description" : "Sets the allowed key certificate path.",
+                              "$comment" : "group:security"
+                            },
+                            "autoConnect" : {
+                              "type" : "boolean",
+                              "title" : "AutoConnect",
+                              "description" : "When enabled the server uses automatic connect mode."
+                            },
+                            "autoLogin" : {
+                              "type" : "boolean",
+                              "title" : "AutoLogin",
+                              "description" : "When enabled the server uses automatic login mode."
+                            },
+                            "autoStart" : {
+                              "type" : "boolean",
+                              "title" : "AutoStart",
+                              "description" : "When enabled the server is automatically started after creation."
+                            },
+                            "debugLogging" : {
+                              "type" : "boolean",
+                              "title" : "DebugLogging",
+                              "description" : "When enabled the server prints debug logging output.",
+                              "$comment" : "group:advanced"
+                            },
+                            "endpointAdapter" : {
+                              "type" : "string",
+                              "title" : "EndpointAdapter",
+                              "description" : "Sets a custom endpoint adapter to handle requests.",
+                              "$comment" : "group:advanced"
+                            },
+                            "hostKeyPath" : {
+                              "type" : "string",
+                              "title" : "HostKeyPath",
+                              "description" : "Sets the host key certificate path.",
+                              "$comment" : "group:security"
+                            },
+                            "knownHosts" : {
+                              "type" : "string",
+                              "title" : "KnownHosts",
+                              "description" : "List of known hosts.",
+                              "$comment" : "group:security"
+                            },
+                            "name" : {
+                              "type" : "string",
+                              "title" : "Name",
+                              "description" : "The name of the endpoint"
+                            },
+                            "password" : {
+                              "type" : "string",
+                              "title" : "Password",
+                              "description" : "Sets the allowed user password.",
+                              "$comment" : "group:security"
+                            },
+                            "pollingInterval" : {
+                              "type" : "integer",
+                              "title" : "PollingInterval",
+                              "description" : "Sets the polling interval when consuming messages."
+                            },
+                            "port" : {
+                              "type" : "integer",
+                              "title" : "Port",
+                              "description" : "The Ftp server port."
+                            },
+                            "preferredAuthentications" : {
+                              "type" : "string",
+                              "title" : "PreferredAuthentications",
+                              "description" : "Sets the preferred authentication mechanism.",
+                              "$comment" : "group:security"
+                            },
+                            "privateKeyPassword" : {
+                              "type" : "string",
+                              "title" : "PrivateKeyPassword",
+                              "description" : "Sets the private key password.",
+                              "$comment" : "group:security"
+                            },
+                            "privateKeyPath" : {
+                              "type" : "string",
+                              "title" : "PrivateKeyPath",
+                              "description" : "Sets the private key certificate path.",
+                              "$comment" : "group:security"
+                            },
+                            "sessionConfigs" : {
+                              "type" : "object",
+                              "title" : "SessionConfigs",
+                              "description" : "The session configuration.",
+                              "additionalProperties" : {
+                                "type" : "string",
+                                "title" : "SessionConfigs",
+                                "description" : "The session configuration."
+                              }
+                            },
+                            "strictHostChecking" : {
+                              "type" : "boolean",
+                              "title" : "StrictHostChecking",
+                              "description" : "Enable strict host checking.",
+                              "$comment" : "group:security"
+                            },
+                            "timeout" : {
+                              "type" : "integer",
+                              "title" : "Timeout",
+                              "description" : "The server timeout.",
+                              "default" : "5000"
+                            },
+                            "user" : {
+                              "type" : "string",
+                              "title" : "User",
+                              "description" : "Sets the allowed user name."
+                            },
+                            "userHomePath" : {
+                              "type" : "string",
+                              "title" : "UserHomePath",
+                              "description" : "Sets the user home path directory."
+                            }
+                          },
+                          "additionalProperties" : false,
+                          "title" : "Server",
+                          "description" : "Sets the sftp server endpoint."
+                        }
+                      },
+                      "required" : [ "server" ]
+                    } ]
+                  } ],
+                  "title" : "Sftp",
+                  "description" : "Sftp client and server endpoints"
+                }
+              },
+              "required" : [ "sftp" ]
+            }, {
+              "type" : "object",
+              "properties" : {
+                "scp" : {
+                  "type" : "object",
+                  "properties" : {
+                    "client" : { },
+                    "server" : { }
+                  },
+                  "additionalProperties" : false,
+                  "anyOf" : [ {
+                    "oneOf" : [ {
+                      "type" : "object",
+                      "properties" : {
+                        "client" : {
+                          "type" : "object",
+                          "properties" : {
+                            "autoReadFiles" : {
+                              "type" : "boolean",
+                              "title" : "AutoReadFiles",
+                              "description" : "When enabled the client automatically reads new files."
+                            },
+                            "correlator" : {
+                              "type" : "string",
+                              "title" : "Correlator",
+                              "description" : "Sets the message correlator.",
+                              "$comment" : "group:advanced"
+                            },
+                            "errorHandlingStrategy" : {
+                              "allOf" : [ {
+                                "$ref" : "#/definitions/ErrorHandlingStrategy"
+                              }, {
+                                "title" : "ErrorHandlingStrategy",
+                                "description" : "Sets the error handling strategy.",
+                                "$comment" : "group:errorHandler"
+                              } ]
+                            },
+                            "host" : {
+                              "type" : "string",
+                              "title" : "Host",
+                              "description" : "The Ftp server host."
+                            },
+                            "knownHosts" : {
+                              "type" : "string",
+                              "title" : "KnownHosts",
+                              "description" : "List of known hosts.",
+                              "$comment" : "group:security"
+                            },
+                            "name" : {
+                              "type" : "string",
+                              "title" : "Name",
+                              "description" : "The name of the endpoint"
+                            },
+                            "password" : {
+                              "type" : "string",
+                              "title" : "Password",
+                              "description" : "Sets the user password.",
+                              "$comment" : "group:security"
+                            },
+                            "pollingInterval" : {
+                              "type" : "integer",
+                              "title" : "PollingInterval",
+                              "description" : "Sets the polling interval when consuming messages."
+                            },
+                            "port" : {
+                              "type" : "integer",
+                              "title" : "Port",
+                              "description" : "The Ftp server port."
+                            },
+                            "portOption" : {
+                              "type" : "string",
+                              "title" : "PortOption",
+                              "description" : "Sets the port option.",
+                              "$comment" : "group:advanced"
+                            },
+                            "privateKeyPassword" : {
+                              "type" : "string",
+                              "title" : "PrivateKeyPassword",
+                              "description" : "Sets the private key password.",
+                              "$comment" : "group:security"
+                            },
+                            "privateKeyPath" : {
+                              "type" : "string",
+                              "title" : "PrivateKeyPath",
+                              "description" : "Sets the private key path.",
+                              "$comment" : "group:security"
+                            },
+                            "strictHostChecking" : {
+                              "type" : "boolean",
+                              "title" : "StrictHostChecking",
+                              "description" : "Enable strict host checking.",
+                              "$comment" : "group:security"
+                            },
+                            "timeout" : {
+                              "type" : "integer",
+                              "title" : "Timeout",
+                              "description" : "The endpoint timeout when waiting for messages."
+                            },
+                            "username" : {
+                              "type" : "string",
+                              "title" : "Username",
+                              "description" : "Sets the user name.",
+                              "$comment" : "group:security"
+                            }
+                          },
+                          "additionalProperties" : false,
+                          "title" : "Client",
+                          "description" : "Sets the scp client endpoint."
+                        }
+                      },
+                      "required" : [ "client" ]
+                    }, {
+                      "type" : "object",
+                      "properties" : {
+                        "server" : {
+                          "type" : "object",
+                          "properties" : {
+                            "allowedKeyPath" : {
+                              "type" : "string",
+                              "title" : "AllowedKeyPath",
+                              "description" : "Sets the allowed key certificate path.",
+                              "$comment" : "group:security"
+                            },
+                            "autoConnect" : {
+                              "type" : "boolean",
+                              "title" : "AutoConnect",
+                              "description" : "When enabled the server uses automatic connect mode."
+                            },
+                            "autoLogin" : {
+                              "type" : "boolean",
+                              "title" : "AutoLogin",
+                              "description" : "When enabled the server uses automatic login mode."
+                            },
+                            "autoStart" : {
+                              "type" : "boolean",
+                              "title" : "AutoStart",
+                              "description" : "When enabled the server is automatically started after creation."
+                            },
+                            "debugLogging" : {
+                              "type" : "boolean",
+                              "title" : "DebugLogging",
+                              "description" : "When enabled the server prints debug logging output.",
+                              "$comment" : "group:advanced"
+                            },
+                            "endpointAdapter" : {
+                              "type" : "string",
+                              "title" : "EndpointAdapter",
+                              "description" : "Sets a custom endpoint adapter to handle requests.",
+                              "$comment" : "group:advanced"
+                            },
+                            "hostKeyPath" : {
+                              "type" : "string",
+                              "title" : "HostKeyPath",
+                              "description" : "Sets the host key certificate path.",
+                              "$comment" : "group:security"
+                            },
+                            "knownHosts" : {
+                              "type" : "string",
+                              "title" : "KnownHosts",
+                              "description" : "List of known hosts.",
+                              "$comment" : "group:security"
+                            },
+                            "name" : {
+                              "type" : "string",
+                              "title" : "Name",
+                              "description" : "The name of the endpoint"
+                            },
+                            "password" : {
+                              "type" : "string",
+                              "title" : "Password",
+                              "description" : "Sets the allowed user password.",
+                              "$comment" : "group:security"
+                            },
+                            "pollingInterval" : {
+                              "type" : "integer",
+                              "title" : "PollingInterval",
+                              "description" : "Sets the polling interval when consuming messages."
+                            },
+                            "port" : {
+                              "type" : "integer",
+                              "title" : "Port",
+                              "description" : "The Ftp server port."
+                            },
+                            "preferredAuthentications" : {
+                              "type" : "string",
+                              "title" : "PreferredAuthentications",
+                              "description" : "Sets the preferred authentication mechanism.",
+                              "$comment" : "group:security"
+                            },
+                            "privateKeyPassword" : {
+                              "type" : "string",
+                              "title" : "PrivateKeyPassword",
+                              "description" : "Sets the private key password.",
+                              "$comment" : "group:security"
+                            },
+                            "privateKeyPath" : {
+                              "type" : "string",
+                              "title" : "PrivateKeyPath",
+                              "description" : "Sets the private key certificate path.",
+                              "$comment" : "group:security"
+                            },
+                            "sessionConfigs" : {
+                              "type" : "object",
+                              "title" : "SessionConfigs",
+                              "description" : "The session configuration.",
+                              "additionalProperties" : {
+                                "type" : "string",
+                                "title" : "SessionConfigs",
+                                "description" : "The session configuration."
+                              }
+                            },
+                            "strictHostChecking" : {
+                              "type" : "boolean",
+                              "title" : "StrictHostChecking",
+                              "description" : "Enable strict host checking.",
+                              "$comment" : "group:security"
+                            },
+                            "timeout" : {
+                              "type" : "integer",
+                              "title" : "Timeout",
+                              "description" : "The server timeout.",
+                              "default" : "5000"
+                            },
+                            "user" : {
+                              "type" : "string",
+                              "title" : "User",
+                              "description" : "Sets the allowed user name."
+                            },
+                            "userHomePath" : {
+                              "type" : "string",
+                              "title" : "UserHomePath",
+                              "description" : "Sets the user home path directory."
+                            }
+                          },
+                          "additionalProperties" : false,
+                          "title" : "Server",
+                          "description" : "Sets the sftp server endpoint."
+                        }
+                      },
+                      "required" : [ "server" ]
+                    } ]
+                  } ],
+                  "title" : "Scp",
+                  "description" : "Scp client and server endpoint"
+                }
+              },
+              "required" : [ "scp" ]
+            }, {
+              "type" : "object",
+              "properties" : {
+                "docker" : {
+                  "type" : "object",
+                  "properties" : {
+                    "client" : {
+                      "type" : "object",
+                      "properties" : {
+                        "certPath" : {
+                          "type" : "string",
+                          "title" : "CertPath",
+                          "description" : "Sets the path to the client certificate.",
+                          "$comment" : "group:security"
+                        },
+                        "configPath" : {
+                          "type" : "string",
+                          "title" : "ConfigPath",
+                          "description" : "Sets the path to the client configuration file.",
+                          "$comment" : "group:advanced"
+                        },
+                        "email" : {
+                          "type" : "string",
+                          "title" : "Email",
+                          "description" : "The Docker client email.",
+                          "$comment" : "group:security"
+                        },
+                        "name" : {
+                          "type" : "string",
+                          "title" : "Name",
+                          "description" : "The name of the endpoint"
+                        },
+                        "password" : {
+                          "type" : "string",
+                          "title" : "Password",
+                          "description" : "The Docker client password.",
+                          "$comment" : "group:security"
+                        },
+                        "registry" : {
+                          "type" : "string",
+                          "title" : "Registry",
+                          "description" : "The Docker registry URL."
+                        },
+                        "url" : {
+                          "type" : "string",
+                          "title" : "Url",
+                          "description" : "The Docker host engine URL."
+                        },
+                        "username" : {
+                          "type" : "string",
+                          "title" : "Username",
+                          "description" : "The Docker client username.",
+                          "$comment" : "group:security"
+                        },
+                        "verifyTls" : {
+                          "type" : "boolean",
+                          "title" : "VerifyTls",
+                          "description" : "When enabled the client verifies the Docker host TLS.",
+                          "$comment" : "group:security"
+                        },
+                        "version" : {
+                          "type" : "string",
+                          "title" : "Version",
+                          "description" : "The Docker client version."
+                        }
+                      },
+                      "additionalProperties" : false,
+                      "title" : "Client",
+                      "description" : "Sets the Docker client endpoint."
+                    }
+                  },
+                  "additionalProperties" : false,
+                  "title" : "Docker",
+                  "description" : "Docker client"
+                }
+              },
+              "required" : [ "docker" ]
+            }, {
+              "type" : "object",
+              "properties" : {
+                "kubernetes" : {
+                  "type" : "object",
+                  "properties" : {
+                    "client" : {
+                      "type" : "object",
+                      "properties" : {
+                        "certFile" : {
+                          "type" : "string",
+                          "title" : "CertFile",
+                          "description" : "Sets the client certificate.",
+                          "$comment" : "group:security"
+                        },
+                        "client" : {
+                          "type" : "string",
+                          "title" : "Client",
+                          "description" : "Sets the reference to the Kubernetes client implementation.",
+                          "$comment" : "group:advanced"
+                        },
+                        "messageConverter" : {
+                          "type" : "string",
+                          "title" : "MessageConverter",
+                          "description" : "Sets the message converter as a bean reference.",
+                          "$comment" : "group:advanced"
+                        },
+                        "name" : {
+                          "type" : "string",
+                          "title" : "Name",
+                          "description" : "The name of the endpoint"
+                        },
+                        "namespace" : {
+                          "type" : "string",
+                          "title" : "Namespace",
+                          "description" : "Sets the namespace on the cluster."
+                        },
+                        "oAuthToken" : {
+                          "type" : "string",
+                          "title" : "OAuthToken",
+                          "description" : "Sets the OAuth token used to connect to the Kubernetes cluster.",
+                          "$comment" : "group:security"
+                        },
+                        "objectMapper" : {
+                          "type" : "string",
+                          "title" : "ObjectMapper",
+                          "description" : "Sets the object mapper.",
+                          "$comment" : "group:advanced"
+                        },
+                        "password" : {
+                          "type" : "string",
+                          "title" : "Password",
+                          "description" : "Sets the user password used to connect to the Kubernetes cluster.",
+                          "$comment" : "group:security"
+                        },
+                        "url" : {
+                          "type" : "string",
+                          "title" : "Url",
+                          "description" : "Sets the master URL in the client configuration.",
+                          "$comment" : "group:advanced"
+                        },
+                        "username" : {
+                          "type" : "string",
+                          "title" : "Username",
+                          "description" : "Sets the user name used to connect to the Kubernetes cluster.",
+                          "$comment" : "group:security"
+                        },
+                        "version" : {
+                          "type" : "string",
+                          "title" : "Version",
+                          "description" : "Sets the Kubernetes client version.",
+                          "$comment" : "group:advanced"
+                        }
+                      },
+                      "additionalProperties" : false,
+                      "title" : "Client",
+                      "description" : "Sets the Kubernetes client endpoint."
+                    }
+                  },
+                  "additionalProperties" : false,
+                  "title" : "Kubernetes",
+                  "description" : "Kubernetes client"
+                }
+              },
+              "required" : [ "kubernetes" ]
+            }, {
+              "type" : "object",
+              "properties" : {
+                "jms" : {
+                  "type" : "object",
+                  "properties" : {
+                    "asynchronous" : { },
+                    "synchronous" : { }
+                  },
+                  "additionalProperties" : false,
+                  "anyOf" : [ {
+                    "oneOf" : [ {
+                      "type" : "object",
+                      "properties" : {
+                        "asynchronous" : {
+                          "type" : "object",
+                          "properties" : {
+                            "autoStart" : {
+                              "type" : "boolean",
+                              "title" : "AutoStart",
+                              "description" : "When enabled the JMS consumer is started right after the endpoint is created.",
+                              "$comment" : "group:publishSubscribe"
+                            },
+                            "connectionFactory" : {
+                              "type" : "string",
+                              "title" : "ConnectionFactory",
+                              "description" : "The JMS connection factory."
+                            },
+                            "destination" : {
+                              "type" : "string",
+                              "title" : "Destination",
+                              "description" : "The JMS destination name."
+                            },
+                            "destinationNameResolver" : {
+                              "type" : "string",
+                              "title" : "DestinationNameResolver",
+                              "description" : "Sets the destination name resolver.",
+                              "$comment" : "group:advanced"
+                            },
+                            "destinationResolver" : {
+                              "type" : "string",
+                              "title" : "DestinationResolver",
+                              "description" : "Sets the destination resolver.",
+                              "$comment" : "group:advanced"
+                            },
+                            "durableSubscriberName" : {
+                              "type" : "string",
+                              "title" : "DurableSubscriberName",
+                              "description" : "Sets the durable subscriber name.",
+                              "$comment" : "group:publishSubscribe"
+                            },
+                            "durableSubscription" : {
+                              "type" : "boolean",
+                              "title" : "DurableSubscription",
+                              "description" : "Enables/disables durable subscription mode.",
+                              "$comment" : "group:publishSubscribe"
+                            },
+                            "filterInternalHeaders" : {
+                              "type" : "boolean",
+                              "title" : "FilterInternalHeaders",
+                              "description" : "Filter internal headers.",
+                              "$comment" : "group:advanced"
+                            },
+                            "jmsTemplate" : {
+                              "type" : "string",
+                              "title" : "JmsTemplate",
+                              "description" : "Sets the JMS template.",
+                              "$comment" : "group:advanced"
+                            },
+                            "messageConverter" : {
+                              "type" : "string",
+                              "title" : "MessageConverter",
+                              "description" : "Sets the message converter bean reference.",
+                              "$comment" : "group:advanced"
+                            },
+                            "name" : {
+                              "type" : "string",
+                              "title" : "Name",
+                              "description" : "The name of the endpoint"
+                            },
+                            "pubSubDomain" : {
+                              "type" : "boolean",
+                              "title" : "PubSubDomain",
+                              "description" : "When enabled the endpoint uses publish/subscribe mode.",
+                              "$comment" : "group:publishSubscribe"
+                            },
+                            "timeout" : {
+                              "type" : "integer",
+                              "title" : "Timeout",
+                              "description" : "Sets the receive timeout when the consumer waits for messages to arrive.",
+                              "default" : "5000"
+                            },
+                            "useObjectMessages" : {
+                              "type" : "boolean",
+                              "title" : "UseObjectMessages",
+                              "description" : "When enabled the endpoint uses object messages.",
+                              "$comment" : "group:advanced"
+                            }
+                          },
+                          "additionalProperties" : false,
+                          "title" : "Asynchronous",
+                          "description" : "Sets the Jms endpoint."
+                        }
+                      },
+                      "required" : [ "asynchronous" ]
+                    }, {
+                      "type" : "object",
+                      "properties" : {
+                        "synchronous" : {
+                          "type" : "object",
+                          "properties" : {
+                            "connectionFactory" : {
+                              "type" : "string",
+                              "title" : "ConnectionFactory",
+                              "description" : "The JMS connection factory."
+                            },
+                            "correlator" : {
+                              "type" : "string",
+                              "title" : "Correlator",
+                              "description" : "Sets the message correlator.",
+                              "$comment" : "group:advanced"
+                            },
+                            "destination" : {
+                              "type" : "string",
+                              "title" : "Destination",
+                              "description" : "The JMS destination name."
+                            },
+                            "destinationNameResolver" : {
+                              "type" : "string",
+                              "title" : "DestinationNameResolver",
+                              "description" : "Sets the destination name resolver.",
+                              "$comment" : "group:advanced"
+                            },
+                            "destinationResolver" : {
+                              "type" : "string",
+                              "title" : "DestinationResolver",
+                              "description" : "Sets the destination resolver.",
+                              "$comment" : "group:advanced"
+                            },
+                            "filterInternalHeaders" : {
+                              "type" : "boolean",
+                              "title" : "FilterInternalHeaders",
+                              "description" : "When enabled the endpoint removes all internal headers before sending a message.",
+                              "$comment" : "group:advanced"
+                            },
+                            "jmsTemplate" : {
+                              "type" : "string",
+                              "title" : "JmsTemplate",
+                              "description" : "Sets the JMS template.",
+                              "$comment" : "group:advanced"
+                            },
+                            "messageConverter" : {
+                              "type" : "string",
+                              "title" : "MessageConverter",
+                              "description" : "Sets the message converter bean reference.",
+                              "$comment" : "group:advanced"
+                            },
+                            "name" : {
+                              "type" : "string",
+                              "title" : "Name",
+                              "description" : "The name of the endpoint"
+                            },
+                            "pollingInterval" : {
+                              "type" : "integer",
+                              "title" : "PollingInterval",
+                              "description" : "Sets the polling interval.",
+                              "$comment" : "group:advanced"
+                            },
+                            "pubSubDomain" : {
+                              "type" : "boolean",
+                              "title" : "PubSubDomain",
+                              "description" : "When enabled the endpoint uses publish/subscribe mode.",
+                              "$comment" : "group:advanced"
+                            },
+                            "replyDestination" : {
+                              "type" : "string",
+                              "title" : "ReplyDestination",
+                              "description" : "Sets the reply destination name."
+                            },
+                            "timeout" : {
+                              "type" : "integer",
+                              "title" : "Timeout",
+                              "description" : "Sets the receive timeout when the consumer waits for messages to arrive."
+                            },
+                            "useObjectMessages" : {
+                              "type" : "boolean",
+                              "title" : "UseObjectMessages",
+                              "description" : "When enabled the endpoint uses object messages.",
+                              "$comment" : "group:advanced"
+                            }
+                          },
+                          "additionalProperties" : false,
+                          "title" : "Synchronous",
+                          "description" : "Sets the synchronous Jms endpoint."
+                        }
+                      },
+                      "required" : [ "synchronous" ]
+                    } ]
+                  } ],
+                  "title" : "JMS",
+                  "description" : "JMS endpoint"
+                }
+              },
+              "required" : [ "jms" ]
+            }, {
+              "type" : "object",
+              "properties" : {
+                "vertx" : {
+                  "type" : "object",
+                  "properties" : {
+                    "asynchronous" : { },
+                    "synchronous" : { }
+                  },
+                  "additionalProperties" : false,
+                  "anyOf" : [ {
+                    "oneOf" : [ {
+                      "type" : "object",
+                      "properties" : {
+                        "asynchronous" : {
+                          "type" : "object",
+                          "properties" : {
+                            "address" : {
+                              "type" : "string",
+                              "title" : "Address",
+                              "description" : "The event bus address."
+                            },
+                            "host" : {
+                              "type" : "string",
+                              "title" : "Host",
+                              "description" : "The Vert.x event bus host."
+                            },
+                            "messageConverter" : {
+                              "type" : "string",
+                              "title" : "MessageConverter",
+                              "description" : "Sets the message converter as a bean reference.",
+                              "$comment" : "group:advanced"
+                            },
+                            "name" : {
+                              "type" : "string",
+                              "title" : "Name",
+                              "description" : "The name of the endpoint"
+                            },
+                            "pollingInterval" : {
+                              "type" : "integer",
+                              "title" : "PollingInterval",
+                              "description" : "Sets the polling interval when consuming messages."
+                            },
+                            "port" : {
+                              "type" : "integer",
+                              "title" : "Port",
+                              "description" : "The Vert.x event bus port."
+                            },
+                            "pubSubDomain" : {
+                              "type" : "boolean",
+                              "title" : "PubSubDomain",
+                              "description" : "When enabled the endpoint uses publish/subscribe mode.",
+                              "$comment" : "group:advanced"
+                            },
+                            "timeout" : {
+                              "type" : "integer",
+                              "title" : "Timeout",
+                              "description" : "The endpoint timeout when waiting for messages."
+                            },
+                            "vertxFactory" : {
+                              "type" : "string",
+                              "title" : "VertxFactory",
+                              "description" : "Sets a custom Vert.x factory.",
+                              "$comment" : "group:advanced"
+                            }
+                          },
+                          "additionalProperties" : false,
+                          "title" : "Asynchronous",
+                          "description" : "Sets the Vert.x endpoint."
+                        }
+                      },
+                      "required" : [ "asynchronous" ]
+                    }, {
+                      "type" : "object",
+                      "properties" : {
+                        "synchronous" : {
+                          "type" : "object",
+                          "properties" : {
+                            "address" : {
+                              "type" : "string",
+                              "title" : "Address",
+                              "description" : "The event bus address."
+                            },
+                            "correlator" : {
+                              "type" : "string",
+                              "title" : "Correlator",
+                              "description" : "Sets the message correlator.",
+                              "$comment" : "group:advanced"
+                            },
+                            "host" : {
+                              "type" : "string",
+                              "title" : "Host",
+                              "description" : "The Vert.x event bus host."
+                            },
+                            "messageConverter" : {
+                              "type" : "string",
+                              "title" : "MessageConverter",
+                              "description" : "Sets the message converter as a bean reference.",
+                              "$comment" : "group:advanced"
+                            },
+                            "name" : {
+                              "type" : "string",
+                              "title" : "Name",
+                              "description" : "The name of the endpoint"
+                            },
+                            "pollingInterval" : {
+                              "type" : "integer",
+                              "title" : "PollingInterval",
+                              "description" : "Sets the polling interval when consuming messages."
+                            },
+                            "port" : {
+                              "type" : "integer",
+                              "title" : "Port",
+                              "description" : "The Vert.x event bus port."
+                            },
+                            "pubSubDomain" : {
+                              "type" : "boolean",
+                              "title" : "PubSubDomain",
+                              "description" : "When enabled the endpoint uses publish/subscribe mode.",
+                              "$comment" : "group:advanced"
+                            },
+                            "timeout" : {
+                              "type" : "integer",
+                              "title" : "Timeout",
+                              "description" : "The endpoint timeout when waiting for messages."
+                            },
+                            "vertxFactory" : {
+                              "type" : "string",
+                              "title" : "VertxFactory",
+                              "description" : "Sets a custom Vert.x factory.",
+                              "$comment" : "group:advanced"
+                            }
+                          },
+                          "additionalProperties" : false,
+                          "title" : "Synchronous",
+                          "description" : "Sets the synchronous Vert.x endpoint."
+                        }
+                      },
+                      "required" : [ "synchronous" ]
+                    } ]
+                  } ],
+                  "title" : "Vert.x",
+                  "description" : "Vert.x endpoint."
+                }
+              },
+              "required" : [ "vertx" ]
+            }, {
+              "type" : "object",
+              "properties" : {
+                "direct" : {
+                  "type" : "object",
+                  "properties" : {
+                    "asynchronous" : { },
+                    "synchronous" : { }
+                  },
+                  "additionalProperties" : false,
+                  "anyOf" : [ {
+                    "oneOf" : [ {
+                      "type" : "object",
+                      "properties" : {
+                        "asynchronous" : {
+                          "type" : "object",
+                          "properties" : {
+                            "autoCreateQueue" : {
+                              "type" : "boolean",
+                              "title" : "AutoCreateQueue",
+                              "description" : "When set the queue is automatically created when it does not exist in bean registry."
+                            },
+                            "name" : {
+                              "type" : "string",
+                              "title" : "Name",
+                              "description" : "The name of the endpoint"
+                            },
+                            "queue" : {
+                              "type" : "string",
+                              "title" : "Queue",
+                              "description" : "The queue name."
+                            },
+                            "timeout" : {
+                              "type" : "integer",
+                              "title" : "Timeout",
+                              "description" : "The timeout when receiving messages from the queue."
+                            }
+                          },
+                          "additionalProperties" : false,
+                          "title" : "Asynchronous",
+                          "description" : "Sets the direct endpoint."
+                        }
+                      },
+                      "required" : [ "asynchronous" ]
+                    }, {
+                      "type" : "object",
+                      "properties" : {
+                        "synchronous" : {
+                          "type" : "object",
+                          "properties" : {
+                            "autoCreateQueue" : {
+                              "type" : "boolean",
+                              "title" : "AutoCreateQueue",
+                              "description" : "When set the queue is automatically created when it does not exist in bean registry."
+                            },
+                            "correlator" : {
+                              "type" : "string",
+                              "title" : "Correlator",
+                              "description" : "Sets the message correlator.",
+                              "$comment" : "group:advanced"
+                            },
+                            "name" : {
+                              "type" : "string",
+                              "title" : "Name",
+                              "description" : "The name of the endpoint"
+                            },
+                            "pollingInterval" : {
+                              "type" : "integer",
+                              "title" : "PollingInterval",
+                              "description" : "Sets the polling interval when consuming messages."
+                            },
+                            "queue" : {
+                              "type" : "string",
+                              "title" : "Queue",
+                              "description" : "The queue name."
+                            },
+                            "timeout" : {
+                              "type" : "integer",
+                              "title" : "Timeout",
+                              "description" : "The timeout when receiving messages from the queue."
+                            }
+                          },
+                          "additionalProperties" : false,
+                          "title" : "Synchronous",
+                          "description" : "Sets the synchronous direct endpoint."
+                        }
+                      },
+                      "required" : [ "synchronous" ]
+                    } ]
+                  } ],
+                  "title" : "Direct",
+                  "description" : "Direct endpoint."
+                }
+              },
+              "required" : [ "direct" ]
+            }, {
+              "type" : "object",
+              "properties" : {
+                "kafka" : {
+                  "type" : "object",
+                  "properties" : {
+                    "asynchronous" : { },
+                    "synchronous" : { }
+                  },
+                  "additionalProperties" : false,
+                  "anyOf" : [ {
+                    "oneOf" : [ {
+                      "type" : "object",
+                      "properties" : {
+                        "asynchronous" : {
+                          "type" : "object",
+                          "properties" : {
+                            "autoCommit" : {
+                              "type" : "boolean",
+                              "title" : "AutoCommit",
+                              "description" : "Sets auto commit handling for this endpoint.",
+                              "$comment" : "group:consume"
+                            },
+                            "autoCommitInterval" : {
+                              "type" : "integer",
+                              "title" : "AutoCommitInterval",
+                              "description" : "Sets the auto commit interval.",
+                              "$comment" : "group:consume"
+                            },
+                            "clientId" : {
+                              "type" : "string",
+                              "title" : "ClientId",
+                              "description" : "Sets the client id used to connect to the Kafka server.",
+                              "$comment" : "group:advanced"
+                            },
+                            "consumerGroup" : {
+                              "type" : "string",
+                              "title" : "ConsumerGroup",
+                              "description" : "Sets the consumer group used by the endpoint.",
+                              "$comment" : "group:consume"
+                            },
+                            "consumerProperties" : {
+                              "type" : "object",
+                              "title" : "ConsumerProperties",
+                              "description" : "Sets the Kafka consumer properties.",
+                              "$comment" : "group:consume"
+                            },
+                            "headerMapper" : {
+                              "type" : "string",
+                              "title" : "HeaderMapper",
+                              "description" : "Sets the Kafka header mapper.",
+                              "$comment" : "group:advanced"
+                            },
+                            "keyDeserializer" : {
+                              "type" : "string",
+                              "title" : "KeyDeserializer",
+                              "description" : "Sets the fully qualified key deserializer type class name.",
+                              "$comment" : "group:deserialize"
+                            },
+                            "keySerializer" : {
+                              "type" : "string",
+                              "title" : "KeySerializer",
+                              "description" : "Sets the fully qualified key serializer type class name.",
+                              "$comment" : "group:serialize"
+                            },
+                            "messageConverter" : {
+                              "type" : "string",
+                              "title" : "MessageConverter",
+                              "description" : "Sets the message converter as a bean reference.",
+                              "$comment" : "group:advanced"
+                            },
+                            "name" : {
+                              "type" : "string",
+                              "title" : "Name",
+                              "description" : "The name of the endpoint"
+                            },
+                            "offsetReset" : {
+                              "type" : "string",
+                              "title" : "OffsetReset",
+                              "description" : "Sets the offset reset.",
+                              "$comment" : "group:consume"
+                            },
+                            "partition" : {
+                              "type" : "integer",
+                              "title" : "Partition",
+                              "description" : "Sets the Kafka topic partition."
+                            },
+                            "producerProperties" : {
+                              "type" : "object",
+                              "title" : "ProducerProperties",
+                              "description" : "Sets the Kafka producer properties.",
+                              "$comment" : "group:produce"
+                            },
+                            "server" : {
+                              "type" : "string",
+                              "title" : "Server",
+                              "description" : "Sets the Kafka bootstrap server."
+                            },
+                            "timeout" : {
+                              "type" : "integer",
+                              "title" : "Timeout",
+                              "description" : "Sets the Kafka consumer timeout.",
+                              "$comment" : "group:consume"
+                            },
+                            "topic" : {
+                              "type" : "string",
+                              "title" : "Topic",
+                              "description" : "Sets the Kafka topic."
+                            },
+                            "valueDeserializer" : {
+                              "type" : "string",
+                              "title" : "ValueDeserializer",
+                              "description" : "Sets the fully qualified value deserializer type class name.",
+                              "$comment" : "group:deserialize"
+                            },
+                            "valueSerializer" : {
+                              "type" : "string",
+                              "title" : "ValueSerializer",
+                              "description" : "Sets the fully qualified value serializer type class name.",
+                              "$comment" : "group:serialize"
+                            }
+                          },
+                          "additionalProperties" : false,
+                          "title" : "Asynchronous",
+                          "description" : "Sets the Kafka endpoint."
+                        }
+                      },
+                      "required" : [ "asynchronous" ]
+                    }, {
+                      "type" : "object",
+                      "properties" : {
+                        "synchronous" : {
+                          "type" : "object",
+                          "properties" : {
+                            "autoCommit" : {
+                              "type" : "boolean",
+                              "title" : "AutoCommit",
+                              "description" : "Sets auto commit handling for this endpoint.",
+                              "$comment" : "group:consume"
+                            },
+                            "autoCommitInterval" : {
+                              "type" : "integer",
+                              "title" : "AutoCommitInterval",
+                              "description" : "Sets the auto commit interval.",
+                              "$comment" : "group:consume"
+                            },
+                            "clientId" : {
+                              "type" : "string",
+                              "title" : "ClientId",
+                              "description" : "Sets the client id used to connect to the Kafka server.",
+                              "$comment" : "group:advanced"
+                            },
+                            "consumerGroup" : {
+                              "type" : "string",
+                              "title" : "ConsumerGroup",
+                              "description" : "Sets the consumer group used by the endpoint.",
+                              "$comment" : "group:consume"
+                            },
+                            "consumerProperties" : {
+                              "type" : "object",
+                              "title" : "ConsumerProperties",
+                              "description" : "Sets the Kafka consumer properties.",
+                              "$comment" : "group:consume"
+                            },
+                            "headerMapper" : {
+                              "type" : "string",
+                              "title" : "HeaderMapper",
+                              "description" : "Sets the Kafka header mapper.",
+                              "$comment" : "group:advanced"
+                            },
+                            "keyDeserializer" : {
+                              "type" : "string",
+                              "title" : "KeyDeserializer",
+                              "description" : "Sets the fully qualified key deserializer type class name.",
+                              "$comment" : "group:deserialize"
+                            },
+                            "keySerializer" : {
+                              "type" : "string",
+                              "title" : "KeySerializer",
+                              "description" : "Sets the fully qualified key serializer type class name.",
+                              "$comment" : "group:serialize"
+                            },
+                            "messageConverter" : {
+                              "type" : "string",
+                              "title" : "MessageConverter",
+                              "description" : "Sets the message converter as a bean reference.",
+                              "$comment" : "group:advanced"
+                            },
+                            "name" : {
+                              "type" : "string",
+                              "title" : "Name",
+                              "description" : "The name of the endpoint"
+                            },
+                            "offsetReset" : {
+                              "type" : "string",
+                              "title" : "OffsetReset",
+                              "description" : "Sets the offset reset.",
+                              "$comment" : "group:consume"
+                            },
+                            "partition" : {
+                              "type" : "integer",
+                              "title" : "Partition",
+                              "description" : "Sets the Kafka topic partition."
+                            },
+                            "producerProperties" : {
+                              "type" : "object",
+                              "title" : "ProducerProperties",
+                              "description" : "Sets the Kafka producer properties.",
+                              "$comment" : "group:produce"
+                            },
+                            "server" : {
+                              "type" : "string",
+                              "title" : "Server",
+                              "description" : "Sets the Kafka bootstrap server."
+                            },
+                            "timeout" : {
+                              "type" : "integer",
+                              "title" : "Timeout",
+                              "description" : "Sets the Kafka consumer timeout.",
+                              "$comment" : "group:consume"
+                            },
+                            "topic" : {
+                              "type" : "string",
+                              "title" : "Topic",
+                              "description" : "Sets the Kafka topic."
+                            },
+                            "valueDeserializer" : {
+                              "type" : "string",
+                              "title" : "ValueDeserializer",
+                              "description" : "Sets the fully qualified value deserializer type class name.",
+                              "$comment" : "group:deserialize"
+                            },
+                            "valueSerializer" : {
+                              "type" : "string",
+                              "title" : "ValueSerializer",
+                              "description" : "Sets the fully qualified value serializer type class name.",
+                              "$comment" : "group:serialize"
+                            }
+                          },
+                          "additionalProperties" : false,
+                          "title" : "Synchronous",
+                          "description" : "Sets the synchronous Kafka endpoint."
+                        }
+                      },
+                      "required" : [ "synchronous" ]
+                    } ]
+                  } ],
+                  "title" : "Kafka",
+                  "description" : "Kafka endpoint."
+                }
+              },
+              "required" : [ "kafka" ]
+            }, {
+              "type" : "object",
+              "properties" : {
+                "camel" : {
+                  "type" : "object",
+                  "properties" : {
+                    "asynchronous" : { },
+                    "synchronous" : { }
+                  },
+                  "additionalProperties" : false,
+                  "anyOf" : [ {
+                    "oneOf" : [ {
+                      "type" : "object",
+                      "properties" : {
+                        "asynchronous" : {
+                          "type" : "object",
+                          "properties" : {
+                            "camelContext" : {
+                              "type" : "string",
+                              "title" : "CamelContext",
+                              "description" : "The Camel context to use."
+                            },
+                            "endpointUri" : {
+                              "type" : "string",
+                              "title" : "EndpointUri",
+                              "description" : "The Camel endpoint uri."
+                            },
+                            "messageConverter" : {
+                              "type" : "string",
+                              "title" : "MessageConverter",
+                              "description" : "Sets the message converter as a bean reference.",
+                              "$comment" : "group:advanced"
+                            },
+                            "name" : {
+                              "type" : "string",
+                              "title" : "Name",
+                              "description" : "The name of the endpoint"
+                            },
+                            "timeout" : {
+                              "type" : "integer",
+                              "title" : "Timeout",
+                              "description" : "The endpoint timeout when waiting for messages."
+                            }
+                          },
+                          "additionalProperties" : false,
+                          "title" : "Asynchronous",
+                          "description" : "Sets the Camel endpoint."
+                        }
+                      },
+                      "required" : [ "asynchronous" ]
+                    }, {
+                      "type" : "object",
+                      "properties" : {
+                        "synchronous" : {
+                          "type" : "object",
+                          "properties" : {
+                            "camelContext" : {
+                              "type" : "string",
+                              "title" : "CamelContext",
+                              "description" : "The Camel context to use."
+                            },
+                            "correlator" : {
+                              "type" : "string",
+                              "title" : "Correlator",
+                              "description" : "Sets the message correlator.",
+                              "$comment" : "group:advanced"
+                            },
+                            "endpointUri" : {
+                              "type" : "string",
+                              "title" : "EndpointUri",
+                              "description" : "The Camel endpoint uri."
+                            },
+                            "messageConverter" : {
+                              "type" : "string",
+                              "title" : "MessageConverter",
+                              "description" : "Sets the message converter as a bean reference.",
+                              "$comment" : "group:advanced"
+                            },
+                            "name" : {
+                              "type" : "string",
+                              "title" : "Name",
+                              "description" : "The name of the endpoint"
+                            },
+                            "pollingInterval" : {
+                              "type" : "integer",
+                              "title" : "PollingInterval",
+                              "description" : "Sets the polling interval when consuming messages."
+                            },
+                            "timeout" : {
+                              "type" : "integer",
+                              "title" : "Timeout",
+                              "description" : "The endpoint timeout when waiting for messages."
+                            }
+                          },
+                          "additionalProperties" : false,
+                          "title" : "Synchronous",
+                          "description" : "Sets the synchronous Camel endpoint."
+                        }
+                      },
+                      "required" : [ "synchronous" ]
+                    } ]
+                  } ],
+                  "title" : "Camel",
+                  "description" : "Camel endpoint."
+                }
+              },
+              "required" : [ "camel" ]
+            }, {
+              "type" : "object",
+              "properties" : {
+                "channel" : {
+                  "type" : "object",
+                  "properties" : {
+                    "asynchronous" : { },
+                    "synchronous" : { }
+                  },
+                  "additionalProperties" : false,
+                  "anyOf" : [ {
+                    "oneOf" : [ {
+                      "type" : "object",
+                      "properties" : {
+                        "asynchronous" : {
+                          "type" : "object",
+                          "properties" : {
+                            "channel" : {
+                              "type" : "string",
+                              "title" : "Channel",
+                              "description" : "The Spring message channel name."
+                            },
+                            "channelResolver" : {
+                              "type" : "string",
+                              "title" : "ChannelResolver",
+                              "description" : "The channel destination resolver.",
+                              "$comment" : "group:advanced"
+                            },
+                            "filterInternalHeaders" : {
+                              "type" : "boolean",
+                              "title" : "FilterInternalHeaders",
+                              "description" : "When enabled the endpoint removes all internal headers before sending a message.",
+                              "$comment" : "group:advanced"
+                            },
+                            "messageConverter" : {
+                              "type" : "string",
+                              "title" : "MessageConverter",
+                              "description" : "Sets the message converter as a bean reference.",
+                              "$comment" : "group:advanced"
+                            },
+                            "messagingTemplate" : {
+                              "type" : "string",
+                              "title" : "MessagingTemplate",
+                              "description" : "Sets a custom messaging template.",
+                              "$comment" : "group:advanced"
+                            },
+                            "name" : {
+                              "type" : "string",
+                              "title" : "Name",
+                              "description" : "The name of the endpoint"
+                            },
+                            "timeout" : {
+                              "type" : "integer",
+                              "title" : "Timeout",
+                              "description" : "Sets the receive timeout when waiting for messages.",
+                              "default" : "5000"
+                            },
+                            "useObjectMessages" : {
+                              "type" : "boolean",
+                              "title" : "UseObjectMessages",
+                              "description" : "When enabled the endpoint uses object messages.",
+                              "$comment" : "group:advanced"
+                            }
+                          },
+                          "additionalProperties" : false,
+                          "title" : "Asynchronous",
+                          "description" : "Sets the Spring message channel endpoint."
+                        }
+                      },
+                      "required" : [ "asynchronous" ]
+                    }, {
+                      "type" : "object",
+                      "properties" : {
+                        "synchronous" : {
+                          "type" : "object",
+                          "properties" : {
+                            "channel" : {
+                              "type" : "string",
+                              "title" : "Channel",
+                              "description" : "The Spring message channel name."
+                            },
+                            "channelResolver" : {
+                              "type" : "string",
+                              "title" : "ChannelResolver",
+                              "description" : "The channel destination resolver.",
+                              "$comment" : "group:advanced"
+                            },
+                            "correlator" : {
+                              "type" : "string",
+                              "title" : "Correlator",
+                              "description" : "Sets the message correlator.",
+                              "$comment" : "group:advanced"
+                            },
+                            "filterInternalHeaders" : {
+                              "type" : "boolean",
+                              "title" : "FilterInternalHeaders",
+                              "description" : "When enabled the endpoint removes all internal headers before sending a message.",
+                              "$comment" : "group:advanced"
+                            },
+                            "messageConverter" : {
+                              "type" : "string",
+                              "title" : "MessageConverter",
+                              "description" : "Sets the message converter as a bean reference.",
+                              "$comment" : "group:advanced"
+                            },
+                            "messagingTemplate" : {
+                              "type" : "string",
+                              "title" : "MessagingTemplate",
+                              "description" : "Sets a custom messaging template.",
+                              "$comment" : "group:advanced"
+                            },
+                            "name" : {
+                              "type" : "string",
+                              "title" : "Name",
+                              "description" : "The name of the endpoint"
+                            },
+                            "pollingInterval" : {
+                              "type" : "integer",
+                              "title" : "PollingInterval",
+                              "description" : "Sets the polling interval.",
+                              "$comment" : "group:advanced"
+                            },
+                            "timeout" : {
+                              "type" : "integer",
+                              "title" : "Timeout",
+                              "description" : "Sets the receive timeout when waiting for messages.",
+                              "default" : "5000"
+                            },
+                            "useObjectMessages" : {
+                              "type" : "boolean",
+                              "title" : "UseObjectMessages",
+                              "description" : "When enabled the endpoint uses object messages.",
+                              "$comment" : "group:advanced"
+                            }
+                          },
+                          "additionalProperties" : false,
+                          "title" : "Synchronous",
+                          "description" : "Sets the synchronous Spring message channel endpoint."
+                        }
+                      },
+                      "required" : [ "synchronous" ]
+                    } ]
+                  } ],
+                  "title" : "Spring channel",
+                  "description" : "Spring channel endpoint."
+                }
+              },
+              "required" : [ "channel" ]
+            }, {
+              "type" : "object",
+              "properties" : {
+                "selenium" : {
+                  "type" : "object",
+                  "properties" : {
+                    "browser" : {
+                      "type" : "object",
+                      "properties" : {
+                        "eventListeners" : {
+                          "title" : "EventListeners",
+                          "description" : "Sets the list of event listeners.",
+                          "$comment" : "group:advanced",
+                          "type" : "array",
+                          "items" : {
+                            "type" : "string",
+                            "title" : "EventListeners",
+                            "description" : "Sets the list of event listeners.",
+                            "$comment" : "group:advanced"
+                          }
+                        },
+                        "javaScript" : {
+                          "type" : "boolean",
+                          "title" : "JavaScript",
+                          "description" : "When enabled the browser supports JavaScript."
+                        },
+                        "name" : {
+                          "type" : "string",
+                          "title" : "Name",
+                          "description" : "The name of the endpoint"
+                        },
+                        "profile" : {
+                          "type" : "string",
+                          "title" : "Profile",
+                          "description" : "The Firefox profile.",
+                          "$comment" : "group:firefox"
+                        },
+                        "remoteServerUrl" : {
+                          "type" : "string",
+                          "title" : "RemoteServerUrl",
+                          "description" : "The remote server URL."
+                        },
+                        "startPage" : {
+                          "type" : "string",
+                          "title" : "StartPage",
+                          "description" : "The URL to the start page."
+                        },
+                        "timeout" : {
+                          "type" : "integer",
+                          "title" : "Timeout",
+                          "description" : "The browser timeout."
+                        },
+                        "type" : {
+                          "type" : "string",
+                          "title" : "Type",
+                          "description" : "The Selenium browser type.",
+                          "default" : "htmlunit"
+                        },
+                        "version" : {
+                          "type" : "string",
+                          "title" : "Version",
+                          "description" : "The browser version.",
+                          "$comment" : "group:advanced"
+                        },
+                        "webDriver" : {
+                          "type" : "string",
+                          "title" : "WebDriver",
+                          "description" : "Sets a custom web driver as a bean reference.",
+                          "$comment" : "group:advanced"
+                        }
+                      },
+                      "additionalProperties" : false,
+                      "title" : "Browser",
+                      "description" : "Sets the Selenium browser endpoint."
+                    }
+                  },
+                  "additionalProperties" : false,
+                  "title" : "Selenium",
+                  "description" : "Selenium endpoint."
+                }
+              },
+              "required" : [ "selenium" ]
+            } ]
+          } ],
+          "title" : "CreateEndpoint",
+          "description" : "Create endpoints test action."
+        },
+        "createVariables" : {
+          "type" : "object",
+          "properties" : {
+            "description" : {
+              "type" : "string",
+              "title" : "Description",
+              "description" : "Test action description printed when the action is executed.",
+              "$comment" : "group:advanced"
+            },
+            "variables" : {
+              "title" : "Variables",
+              "description" : "List of test variables.",
+              "type" : "array",
+              "items" : {
+                "type" : "object",
+                "properties" : {
+                  "name" : {
+                    "type" : "string",
+                    "title" : "Name",
+                    "description" : "The test variable name."
+                  },
+                  "script" : {
+                    "type" : "object",
+                    "properties" : {
+                      "file" : {
+                        "type" : "string",
+                        "title" : "File",
+                        "description" : "The script loaded from a file resource."
+                      },
+                      "type" : {
+                        "type" : "string",
+                        "title" : "Type",
+                        "description" : "The script type.",
+                        "$comment" : "group:advanced"
+                      },
+                      "value" : {
+                        "type" : "string",
+                        "title" : "Value",
+                        "description" : "The script content."
+                      }
+                    },
+                    "additionalProperties" : false,
+                    "title" : "Script",
+                    "description" : "Script to build the variable value.",
+                    "$comment" : "group:advanced"
+                  },
+                  "value" : {
+                    "type" : "string",
+                    "title" : "Value",
+                    "description" : "The test variable value."
+                  }
+                },
+                "required" : [ "name" ],
+                "additionalProperties" : false,
+                "title" : "Variables",
+                "description" : "List of test variables."
+              }
+            }
+          },
+          "required" : [ "variables" ],
+          "additionalProperties" : false,
+          "title" : "CreateVariables",
+          "description" : "Create variables test action."
+        },
+        "delay" : {
+          "type" : "object",
+          "properties" : {
+            "description" : {
+              "type" : "string",
+              "title" : "Description",
+              "description" : "Test action description printed when the action is executed.",
+              "$comment" : "group:advanced"
+            },
+            "milliseconds" : {
+              "type" : "string",
+              "title" : "Milliseconds",
+              "description" : "Time to sleep in milliseconds."
+            },
+            "seconds" : {
+              "type" : "string",
+              "title" : "Seconds",
+              "description" : "Time to sleep in seconds."
+            }
+          },
+          "additionalProperties" : false,
+          "title" : "Delay",
+          "description" : "Delay test action."
+        },
+        "doFinally" : {
+          "type" : "object",
+          "properties" : {
+            "actions" : {
+              "title" : "Actions",
+              "description" : "Test actions to execute after the test.",
+              "type" : "array",
+              "items" : {
+                "allOf" : [ {
+                  "$ref" : "#/definitions/TestActionBuilder_Object_"
+                }, {
+                  "title" : "Actions",
+                  "description" : "Test actions to execute after the test."
+                } ]
+              }
+            },
+            "description" : {
+              "type" : "string",
+              "title" : "Description",
+              "description" : "Test action description printed when the action is executed.",
+              "$comment" : "group:advanced"
+            }
+          },
+          "required" : [ "actions" ],
+          "additionalProperties" : false,
+          "title" : "DoFinally",
+          "description" : "Runs test actions after the test."
+        },
+        "echo" : {
+          "type" : "object",
+          "properties" : {
+            "description" : {
+              "type" : "string",
+              "title" : "Description",
+              "description" : "Test action description printed when the action is executed.",
+              "$comment" : "group:advanced"
+            },
+            "message" : {
+              "type" : "string",
+              "title" : "Message",
+              "description" : "The message to print."
+            }
+          },
+          "required" : [ "message" ],
+          "additionalProperties" : false,
+          "title" : "Echo",
+          "description" : "Echo test action."
+        },
+        "expectTimeout" : {
+          "type" : "object",
+          "properties" : {
+            "endpoint" : {
+              "type" : "string",
+              "title" : "Endpoint",
+              "description" : "The message endpoint to consume messages from. Uses an endpoint URI or references an endpoint name."
+            },
+            "select" : {
+              "type" : "string",
+              "title" : "Select",
+              "description" : "Optional message selector expression to selectively consume messages.",
+              "$comment" : "group:advanced"
+            },
+            "selector" : {
+              "type" : "object",
+              "properties" : {
+                "elements" : {
+                  "title" : "Elements",
+                  "description" : "Selector elements building the selector expression.",
+                  "$comment" : "group:advanced",
+                  "type" : "array",
+                  "items" : {
+                    "type" : "object",
+                    "properties" : {
+                      "name" : {
+                        "type" : "string",
+                        "title" : "Name",
+                        "description" : "Selector key name."
+                      },
+                      "value" : {
+                        "type" : "string",
+                        "title" : "Value",
+                        "description" : "Selector expression value that the expression must match."
+                      }
+                    },
+                    "required" : [ "name", "value" ],
+                    "additionalProperties" : false,
+                    "title" : "Elements",
+                    "description" : "Selector elements building the selector expression.",
+                    "$comment" : "group:advanced"
+                  }
+                },
+                "value" : {
+                  "type" : "string",
+                  "title" : "Value",
+                  "description" : "Selector expression value."
+                }
+              },
+              "additionalProperties" : false,
+              "title" : "Selector",
+              "description" : "Message selector to selectively consume messages.",
+              "$comment" : "group:advanced"
+            },
+            "wait" : {
+              "type" : "integer",
+              "title" : "Wait",
+              "description" : "Time in milliseconds to wait for messages."
+            }
+          },
+          "required" : [ "endpoint" ],
+          "additionalProperties" : false,
+          "title" : "ExpectTimeout",
+          "description" : "Expect timeout test action."
+        },
+        "fail" : {
+          "type" : "object",
+          "properties" : {
+            "description" : {
+              "type" : "string",
+              "title" : "Description",
+              "description" : "Test action description printed when the action is executed.",
+              "$comment" : "group:advanced"
+            },
+            "message" : {
+              "type" : "string",
+              "title" : "Message",
+              "description" : "Error message describing the failure."
+            }
+          },
+          "additionalProperties" : false,
+          "title" : "Fail",
+          "description" : "Fail test action."
+        },
+        "groovy" : {
+          "type" : "object",
+          "properties" : {
+            "actor" : {
+              "type" : "string",
+              "title" : "Actor",
+              "$comment" : "group:advanced"
+            },
+            "beans" : {
+              "allOf" : [ {
+                "$ref" : "#/definitions/Script"
+              }, {
+                "title" : "Beans",
+                "description" : "Script that creates beans in the bean registry.",
+                "$comment" : "group:advanced"
+              } ]
+            },
+            "description" : {
+              "type" : "string",
+              "title" : "Description",
+              "description" : "Test action description printed when the action is executed.",
+              "$comment" : "group:advanced"
+            },
+            "endpoints" : {
+              "allOf" : [ {
+                "$ref" : "#/definitions/Script"
+              }, {
+                "title" : "Endpoints",
+                "description" : "Script that creates endpoints.",
+                "$comment" : "group:advanced"
+              } ]
+            },
+            "script" : {
+              "allOf" : [ {
+                "$ref" : "#/definitions/Script"
+              }, {
+                "title" : "Script",
+                "description" : "The Groovy script to execute."
+              } ]
+            }
+          },
+          "additionalProperties" : false,
+          "title" : "Groovy",
+          "description" : "Groovy test action."
+        },
+        "http" : {
+          "type" : "object",
+          "properties" : {
+            "actor" : {
+              "type" : "string",
+              "title" : "Actor",
+              "$comment" : "group:advanced"
+            },
+            "client" : {
+              "type" : "string",
+              "title" : "Client",
+              "description" : "The Http client. Uses an endpoint URI or references an endpoint name."
+            },
+            "description" : {
+              "type" : "string",
+              "title" : "Description",
+              "description" : "Test action description printed when the action is executed.",
+              "$comment" : "group:advanced"
+            },
+            "receiveRequest" : {
+              "type" : "object",
+              "properties" : {
+                "DELETE" : { },
+                "GET" : { },
+                "HEAD" : { },
+                "OPTIONS" : { },
+                "PATCH" : { },
+                "POST" : { },
+                "PUT" : { },
+                "TRACE" : { },
+                "extract" : {
+                  "allOf" : [ {
+                    "$ref" : "#/definitions/Extract"
+                  }, {
+                    "title" : "Extract",
+                    "description" : "Extract message content to test variables.",
+                    "$comment" : "group:advanced"
+                  } ]
+                },
+                "headerValidator" : {
+                  "type" : "string",
+                  "title" : "HeaderValidator",
+                  "description" : "Explicit message header validator.",
+                  "$comment" : "group:advanced"
+                },
+                "headerValidators" : {
+                  "type" : "string",
+                  "title" : "HeaderValidators",
+                  "description" : "List of message header validators used to validate the message.",
+                  "$comment" : "group:advanced"
+                },
+                "select" : {
+                  "type" : "string",
+                  "title" : "Select",
+                  "description" : "Message select expression to selectively consume messages.",
+                  "$comment" : "group:advanced"
+                },
+                "selector" : {
+                  "allOf" : [ {
+                    "$ref" : "#/definitions/Selector"
+                  }, {
+                    "title" : "Selector",
+                    "description" : "Message selector expression to selectively consume messages.",
+                    "$comment" : "group:advanced"
+                  } ]
+                },
+                "timeout" : {
+                  "type" : "integer",
+                  "title" : "Timeout",
+                  "description" : "Http request timeout."
+                },
+                "validate" : {
+                  "title" : "Validate",
+                  "description" : "Validate expressions.",
+                  "type" : "array",
+                  "items" : {
+                    "allOf" : [ {
+                      "$ref" : "#/definitions/Validate"
+                    }, {
+                      "title" : "Validate",
+                      "description" : "Validate expressions."
+                    } ]
+                  }
+                },
+                "validator" : {
+                  "type" : "string",
+                  "title" : "Validator",
+                  "description" : "Explicit message validator.",
+                  "$comment" : "group:advanced"
+                },
+                "validators" : {
+                  "type" : "string",
+                  "title" : "Validators",
+                  "description" : "List of message validators used to validate the message.",
+                  "$comment" : "group:advanced"
+                }
+              },
+              "additionalProperties" : false,
+              "anyOf" : [ {
+                "oneOf" : [ {
+                  "type" : "object",
+                  "properties" : {
+                    "GET" : {
+                      "allOf" : [ {
+                        "$ref" : "#/definitions/HttpRequest"
+                      }, {
+                        "title" : "GET",
+                        "description" : "Http GET request"
+                      } ]
+                    }
+                  },
+                  "required" : [ "GET" ]
+                }, {
+                  "type" : "object",
+                  "properties" : {
+                    "POST" : {
+                      "allOf" : [ {
+                        "$ref" : "#/definitions/HttpRequest"
+                      }, {
+                        "title" : "POST",
+                        "description" : "Http POST request"
+                      } ]
+                    }
+                  },
+                  "required" : [ "POST" ]
+                }, {
+                  "type" : "object",
+                  "properties" : {
+                    "PUT" : {
+                      "allOf" : [ {
+                        "$ref" : "#/definitions/HttpRequest"
+                      }, {
+                        "title" : "PUT",
+                        "description" : "Http PUT request"
+                      } ]
+                    }
+                  },
+                  "required" : [ "PUT" ]
+                }, {
+                  "type" : "object",
+                  "properties" : {
+                    "PUT" : { }
+                  },
+                  "required" : [ "PUT" ]
+                }, {
+                  "type" : "object",
+                  "properties" : {
+                    "DELETE" : {
+                      "allOf" : [ {
+                        "$ref" : "#/definitions/HttpRequest"
+                      }, {
+                        "title" : "DELETE",
+                        "description" : "Http DELETE request"
+                      } ]
+                    }
+                  },
+                  "required" : [ "DELETE" ]
+                }, {
+                  "type" : "object",
+                  "properties" : {
+                    "HEAD" : {
+                      "allOf" : [ {
+                        "$ref" : "#/definitions/HttpRequest"
+                      }, {
+                        "title" : "HEAD",
+                        "description" : "Http HEAD request"
+                      } ]
+                    }
+                  },
+                  "required" : [ "HEAD" ]
+                }, {
+                  "type" : "object",
+                  "properties" : {
+                    "OPTIONS" : {
+                      "allOf" : [ {
+                        "$ref" : "#/definitions/HttpRequest"
+                      }, {
+                        "title" : "OPTIONS",
+                        "description" : "Http OPTIONS request"
+                      } ]
+                    }
+                  },
+                  "required" : [ "OPTIONS" ]
+                }, {
+                  "type" : "object",
+                  "properties" : {
+                    "PATCH" : {
+                      "allOf" : [ {
+                        "$ref" : "#/definitions/HttpRequest"
+                      }, {
+                        "title" : "PATCH",
+                        "description" : "Http PATCH request"
+                      } ]
+                    }
+                  },
+                  "required" : [ "PATCH" ]
+                }, {
+                  "type" : "object",
+                  "properties" : {
+                    "TRACE" : {
+                      "allOf" : [ {
+                        "$ref" : "#/definitions/HttpRequest"
+                      }, {
+                        "title" : "TRACE",
+                        "description" : "Http TRACE request"
+                      } ]
+                    }
+                  },
+                  "required" : [ "TRACE" ]
+                } ]
+              } ],
+              "title" : "ReceiveRequest",
+              "description" : "Receive an Http request as a server."
+            },
+            "receiveResponse" : {
+              "type" : "object",
+              "properties" : {
+                "extract" : {
+                  "allOf" : [ {
+                    "$ref" : "#/definitions/Extract"
+                  }, {
+                    "title" : "Extract",
+                    "description" : "Extract message content to test variables.",
+                    "$comment" : "group:advanced"
+                  } ]
+                },
+                "headerValidator" : {
+                  "type" : "string",
+                  "title" : "HeaderValidator",
+                  "description" : "Explicit message header validator.",
+                  "$comment" : "group:advanced"
+                },
+                "headerValidators" : {
+                  "type" : "string",
+                  "title" : "HeaderValidators",
+                  "description" : "List of message header validators used to validate the message.",
+                  "$comment" : "group:advanced"
+                },
+                "response" : {
+                  "allOf" : [ {
+                    "$ref" : "#/definitions/HttpResponse"
+                  }, {
+                    "title" : "Response",
+                    "description" : "The expected Http response."
+                  } ]
+                },
+                "select" : {
+                  "type" : "string",
+                  "title" : "Select",
+                  "description" : "Message selector expression to selectively consume the Http response.",
+                  "$comment" : "group:advanced"
+                },
+                "selector" : {
+                  "allOf" : [ {
+                    "$ref" : "#/definitions/Selector"
+                  }, {
+                    "title" : "Selector",
+                    "description" : "Message selector to selectively consume the Http response.",
+                    "$comment" : "group:advanced"
+                  } ]
+                },
+                "timeout" : {
+                  "type" : "integer",
+                  "title" : "Timeout",
+                  "description" : "Timeout while waiting for the Http response."
+                },
+                "validate" : {
+                  "title" : "Validate",
+                  "description" : "Validate expressions.",
+                  "type" : "array",
+                  "items" : {
+                    "allOf" : [ {
+                      "$ref" : "#/definitions/Validate"
+                    }, {
+                      "title" : "Validate",
+                      "description" : "Validate expressions."
+                    } ]
+                  }
+                },
+                "validator" : {
+                  "type" : "string",
+                  "title" : "Validator",
+                  "description" : "Explicit message validator.",
+                  "$comment" : "group:advanced"
+                },
+                "validators" : {
+                  "type" : "string",
+                  "title" : "Validators",
+                  "description" : "List of message validators used to validate the message.",
+                  "$comment" : "group:advanced"
+                }
+              },
+              "additionalProperties" : false,
+              "title" : "ReceiveResponse",
+              "description" : "Receive an Http response as a client."
+            },
+            "sendRequest" : {
+              "type" : "object",
+              "properties" : {
+                "DELETE" : { },
+                "GET" : { },
+                "HEAD" : { },
+                "OPTIONS" : { },
+                "PATCH" : { },
+                "POST" : { },
+                "PUT" : { },
+                "TRACE" : { },
+                "extract" : {
+                  "allOf" : [ {
+                    "$ref" : "#/definitions/Extract"
+                  }, {
+                    "title" : "Extract",
+                    "description" : "Extract message content to test variables.",
+                    "$comment" : "group:advanced"
+                  } ]
+                },
+                "fork" : {
+                  "type" : "boolean",
+                  "title" : "Fork",
+                  "description" : "When enabled the send operation does not block while waiting for the response."
+                },
+                "uri" : {
+                  "type" : "string",
+                  "title" : "Uri",
+                  "description" : "Http request URI.",
+                  "$comment" : "group:advanced"
+                }
+              },
+              "additionalProperties" : false,
+              "anyOf" : [ {
+                "oneOf" : [ {
+                  "type" : "object",
+                  "properties" : {
+                    "GET" : {
+                      "allOf" : [ {
+                        "$ref" : "#/definitions/HttpRequest"
+                      }, {
+                        "title" : "GET",
+                        "description" : "Http GET request"
+                      } ]
+                    }
+                  },
+                  "required" : [ "GET" ]
+                }, {
+                  "type" : "object",
+                  "properties" : {
+                    "POST" : {
+                      "allOf" : [ {
+                        "$ref" : "#/definitions/HttpRequest"
+                      }, {
+                        "title" : "POST",
+                        "description" : "Http POST request"
+                      } ]
+                    }
+                  },
+                  "required" : [ "POST" ]
+                }, {
+                  "type" : "object",
+                  "properties" : {
+                    "PUT" : {
+                      "allOf" : [ {
+                        "$ref" : "#/definitions/HttpRequest"
+                      }, {
+                        "title" : "PUT",
+                        "description" : "Http PUT request"
+                      } ]
+                    }
+                  },
+                  "required" : [ "PUT" ]
+                }, {
+                  "type" : "object",
+                  "properties" : {
+                    "PUT" : { }
+                  },
+                  "required" : [ "PUT" ]
+                }, {
+                  "type" : "object",
+                  "properties" : {
+                    "DELETE" : {
+                      "allOf" : [ {
+                        "$ref" : "#/definitions/HttpRequest"
+                      }, {
+                        "title" : "DELETE",
+                        "description" : "Http DELETE request"
+                      } ]
+                    }
+                  },
+                  "required" : [ "DELETE" ]
+                }, {
+                  "type" : "object",
+                  "properties" : {
+                    "HEAD" : {
+                      "allOf" : [ {
+                        "$ref" : "#/definitions/HttpRequest"
+                      }, {
+                        "title" : "HEAD",
+                        "description" : "Http HEAD request"
+                      } ]
+                    }
+                  },
+                  "required" : [ "HEAD" ]
+                }, {
+                  "type" : "object",
+                  "properties" : {
+                    "OPTIONS" : {
+                      "allOf" : [ {
+                        "$ref" : "#/definitions/HttpRequest"
+                      }, {
+                        "title" : "OPTIONS",
+                        "description" : "Http OPTIONS request"
+                      } ]
+                    }
+                  },
+                  "required" : [ "OPTIONS" ]
+                }, {
+                  "type" : "object",
+                  "properties" : {
+                    "PATCH" : {
+                      "allOf" : [ {
+                        "$ref" : "#/definitions/HttpRequest"
+                      }, {
+                        "title" : "PATCH",
+                        "description" : "Http PATCH request"
+                      } ]
+                    }
+                  },
+                  "required" : [ "PATCH" ]
+                }, {
+                  "type" : "object",
+                  "properties" : {
+                    "TRACE" : {
+                      "allOf" : [ {
+                        "$ref" : "#/definitions/HttpRequest"
+                      }, {
+                        "title" : "TRACE",
+                        "description" : "Http TRACE request"
+                      } ]
+                    }
+                  },
+                  "required" : [ "TRACE" ]
+                } ]
+              } ],
+              "title" : "SendRequest",
+              "description" : "Send a Http request as a client."
+            },
+            "sendResponse" : {
+              "type" : "object",
+              "properties" : {
+                "extract" : {
+                  "allOf" : [ {
+                    "$ref" : "#/definitions/Extract"
+                  }, {
+                    "title" : "Extract",
+                    "description" : "Extract message content to test variables.",
+                    "$comment" : "group:advanced"
+                  } ]
+                },
+                "response" : {
+                  "allOf" : [ {
+                    "$ref" : "#/definitions/HttpResponse"
+                  }, {
+                    "title" : "Response",
+                    "description" : "Http response message."
+                  } ]
+                }
+              },
+              "additionalProperties" : false,
+              "title" : "SendResponse",
+              "description" : "Send an Http response as a server."
+            },
+            "server" : {
+              "type" : "string",
+              "title" : "Server",
+              "description" : "The Http server. Uses an endpoint URI or references an endpoint name."
+            }
+          },
+          "additionalProperties" : false,
+          "title" : "Http",
+          "description" : "Http related test actions."
+        },
+        "iterate" : {
+          "type" : "object",
+          "properties" : {
+            "actions" : {
+              "title" : "Actions",
+              "description" : "Sequence of test actions to execute.",
+              "type" : "array",
+              "items" : {
+                "allOf" : [ {
+                  "$ref" : "#/definitions/TestActionBuilder_Object_"
+                }, {
+                  "title" : "Actions",
+                  "description" : "Sequence of test actions to execute."
+                } ]
+              }
+            },
+            "condition" : {
+              "type" : "string",
+              "title" : "Condition",
+              "description" : "Condition that keeps the iteration running."
+            },
+            "description" : {
+              "type" : "string",
+              "title" : "Description",
+              "description" : "Test action description printed when the action is executed.",
+              "$comment" : "group:advanced"
+            },
+            "index" : {
+              "type" : "string",
+              "title" : "Index",
+              "description" : "Test variable holding the current iteration index.",
+              "$comment" : "group:advanced"
+            },
+            "startsWith" : {
+              "type" : "integer",
+              "title" : "StartsWith",
+              "description" : "Index starts with this value.",
+              "default" : "1",
+              "$comment" : "group:advanced"
+            },
+            "step" : {
+              "type" : "integer",
+              "title" : "Step",
+              "description" : "The step added to the index for each iteration.",
+              "default" : "1",
+              "$comment" : "group:advanced"
+            }
+          },
+          "required" : [ "actions", "condition" ],
+          "additionalProperties" : false,
+          "title" : "Iterate",
+          "description" : "Iterate test action."
+        },
+        "jbang" : {
+          "type" : "object",
+          "properties" : {
+            "app" : {
+              "type" : "string",
+              "title" : "App"
+            },
+            "args" : {
+              "title" : "Args",
+              "type" : "array",
+              "items" : {
+                "type" : "object",
+                "properties" : {
+                  "name" : {
+                    "type" : "string",
+                    "title" : "Name"
+                  },
+                  "value" : {
+                    "type" : "string",
+                    "title" : "Value"
+                  }
+                },
+                "required" : [ "name", "value" ],
+                "additionalProperties" : false,
+                "title" : "Args"
+              }
+            },
+            "command" : {
+              "type" : "string",
+              "title" : "Command"
+            },
+            "description" : {
+              "type" : "string",
+              "title" : "Description",
+              "description" : "Test action description printed when the action is executed.",
+              "$comment" : "group:advanced"
+            },
+            "exitCode" : {
+              "type" : "string",
+              "title" : "ExitCode"
+            },
+            "file" : {
+              "type" : "string",
+              "title" : "File"
+            },
+            "output" : {
+              "type" : "string",
+              "title" : "Output"
+            },
+            "printOutput" : {
+              "type" : "boolean",
+              "title" : "PrintOutput"
+            },
+            "saveOutput" : {
+              "type" : "string",
+              "title" : "SaveOutput"
+            },
+            "savePid" : {
+              "type" : "string",
+              "title" : "SavePid"
+            },
+            "systemProperties" : {
+              "title" : "SystemProperties",
+              "type" : "array",
+              "items" : {
+                "type" : "object",
+                "properties" : {
+                  "name" : {
+                    "type" : "string",
+                    "title" : "Name"
+                  },
+                  "value" : {
+                    "type" : "string",
+                    "title" : "Value"
+                  }
+                },
+                "required" : [ "name", "value" ],
+                "additionalProperties" : false,
+                "title" : "SystemProperties"
+              }
+            }
+          },
+          "additionalProperties" : false,
+          "title" : "Jbang",
+          "description" : "JBang test actions."
+        },
+        "knative" : {
+          "type" : "object",
+          "properties" : {
+            "actor" : {
+              "type" : "string",
+              "title" : "Actor",
+              "$comment" : "group:advanced"
+            },
+            "autoRemove" : {
+              "type" : "boolean",
+              "title" : "AutoRemove"
+            },
+            "client" : {
+              "type" : "string",
+              "title" : "Client"
+            },
+            "clusterType" : {
+              "type" : "string",
+              "enum" : [ "LOCAL", "KUBERNETES", "OPENSHIFT" ],
+              "title" : "ClusterType"
+            },
+            "createBroker" : {
+              "type" : "object",
+              "properties" : {
+                "name" : {
+                  "type" : "string",
+                  "title" : "Name"
+                }
+              },
+              "additionalProperties" : false,
+              "title" : "CreateBroker"
+            },
+            "createChannel" : {
+              "type" : "object",
+              "properties" : {
+                "name" : {
+                  "type" : "string",
+                  "title" : "Name"
+                }
+              },
+              "additionalProperties" : false,
+              "title" : "CreateChannel"
+            },
+            "createSubscription" : {
+              "type" : "object",
+              "properties" : {
+                "channel" : {
+                  "type" : "string",
+                  "title" : "Channel"
+                },
+                "name" : {
+                  "type" : "string",
+                  "title" : "Name"
+                },
+                "service" : {
+                  "type" : "string",
+                  "title" : "Service"
+                }
+              },
+              "additionalProperties" : false,
+              "title" : "CreateSubscription"
+            },
+            "createTrigger" : {
+              "type" : "object",
+              "properties" : {
+                "broker" : {
+                  "type" : "string",
+                  "title" : "Broker"
+                },
+                "channel" : {
+                  "type" : "string",
+                  "title" : "Channel"
+                },
+                "filter" : {
+                  "type" : "object",
+                  "properties" : {
+                    "attributes" : {
+                      "title" : "Attributes",
+                      "type" : "array",
+                      "items" : {
+                        "type" : "object",
+                        "properties" : {
+                          "name" : {
+                            "type" : "string",
+                            "title" : "Name"
+                          },
+                          "value" : {
+                            "type" : "string",
+                            "title" : "Value"
+                          }
+                        },
+                        "additionalProperties" : false,
+                        "title" : "Attributes"
+                      }
+                    }
+                  },
+                  "additionalProperties" : false,
+                  "title" : "Filter"
+                },
+                "name" : {
+                  "type" : "string",
+                  "title" : "Name"
+                },
+                "service" : {
+                  "type" : "string",
+                  "title" : "Service"
+                }
+              },
+              "additionalProperties" : false,
+              "title" : "CreateTrigger"
+            },
+            "deleteBroker" : {
+              "type" : "object",
+              "properties" : {
+                "name" : {
+                  "type" : "string",
+                  "title" : "Name"
+                }
+              },
+              "additionalProperties" : false,
+              "title" : "DeleteBroker"
+            },
+            "deleteChannel" : {
+              "type" : "object",
+              "properties" : {
+                "name" : {
+                  "type" : "string",
+                  "title" : "Name"
+                }
+              },
+              "additionalProperties" : false,
+              "title" : "DeleteChannel"
+            },
+            "deleteResource" : {
+              "type" : "object",
+              "properties" : {
+                "component" : {
+                  "type" : "string",
+                  "title" : "Component"
+                },
+                "kind" : {
+                  "type" : "string",
+                  "title" : "Kind"
+                },
+                "name" : {
+                  "type" : "string",
+                  "title" : "Name"
+                }
+              },
+              "additionalProperties" : false,
+              "title" : "DeleteResource"
+            },
+            "deleteSubscription" : {
+              "type" : "object",
+              "properties" : {
+                "name" : {
+                  "type" : "string",
+                  "title" : "Name"
+                }
+              },
+              "additionalProperties" : false,
+              "title" : "DeleteSubscription"
+            },
+            "deleteTrigger" : {
+              "type" : "object",
+              "properties" : {
+                "name" : {
+                  "type" : "string",
+                  "title" : "Name"
+                }
+              },
+              "additionalProperties" : false,
+              "title" : "DeleteTrigger"
+            },
+            "description" : {
+              "type" : "string",
+              "title" : "Description",
+              "description" : "Test action description printed when the action is executed.",
+              "$comment" : "group:advanced"
+            },
+            "kubernetesClient" : {
+              "type" : "string",
+              "title" : "KubernetesClient"
+            },
+            "namespace" : {
+              "type" : "string",
+              "title" : "Namespace"
+            },
+            "receiveEvent" : {
+              "type" : "object",
+              "properties" : {
+                "event" : {
+                  "type" : "object",
+                  "properties" : {
+                    "attributes" : {
+                      "title" : "Attributes",
+                      "type" : "array",
+                      "items" : {
+                        "type" : "object",
+                        "properties" : {
+                          "name" : {
+                            "type" : "string",
+                            "title" : "Name"
+                          },
+                          "value" : {
+                            "type" : "string",
+                            "title" : "Value"
+                          }
+                        },
+                        "additionalProperties" : false,
+                        "title" : "Attributes"
+                      }
+                    },
+                    "data" : {
+                      "type" : "string",
+                      "title" : "Data",
+                      "description" : "The event message body as inline data."
+                    }
+                  },
+                  "additionalProperties" : false,
+                  "title" : "Event"
+                },
+                "port" : {
+                  "type" : "integer",
+                  "title" : "Port"
+                },
+                "service" : {
+                  "type" : "string",
+                  "title" : "Service"
+                },
+                "timeout" : {
+                  "type" : "integer",
+                  "title" : "Timeout"
+                }
+              },
+              "additionalProperties" : false,
+              "title" : "ReceiveEvent"
+            },
+            "sendEvent" : {
+              "type" : "object",
+              "properties" : {
+                "broker" : {
+                  "type" : "string",
+                  "title" : "Broker"
+                },
+                "event" : {
+                  "type" : "object",
+                  "properties" : {
+                    "attributes" : {
+                      "title" : "Attributes",
+                      "type" : "array",
+                      "items" : {
+                        "type" : "object",
+                        "properties" : {
+                          "name" : {
+                            "type" : "string",
+                            "title" : "Name"
+                          },
+                          "value" : {
+                            "type" : "string",
+                            "title" : "Value"
+                          }
+                        },
+                        "additionalProperties" : false,
+                        "title" : "Attributes"
+                      }
+                    },
+                    "data" : {
+                      "type" : "string",
+                      "title" : "Data",
+                      "description" : "The event message body as inline data."
+                    }
+                  },
+                  "additionalProperties" : false,
+                  "title" : "Event"
+                },
+                "fork" : {
+                  "type" : "boolean",
+                  "title" : "Fork"
+                },
+                "timeout" : {
+                  "type" : "integer",
+                  "title" : "Timeout"
+                }
+              },
+              "additionalProperties" : false,
+              "title" : "SendEvent"
+            },
+            "verifyBroker" : {
+              "type" : "object",
+              "properties" : {
+                "name" : {
+                  "type" : "string",
+                  "title" : "Name"
+                }
+              },
+              "additionalProperties" : false,
+              "title" : "VerifyBroker"
+            }
+          },
+          "additionalProperties" : false,
+          "title" : "Knative",
+          "description" : "Knative test actions."
+        },
+        "kubernetes" : {
+          "type" : "object",
+          "properties" : {
+            "actor" : {
+              "type" : "string",
+              "title" : "Actor",
+              "$comment" : "group:advanced"
+            },
+            "agent" : {
+              "type" : "object",
+              "properties" : {
+                "connect" : {
+                  "type" : "object",
+                  "properties" : {
+                    "client" : {
+                      "type" : "string",
+                      "title" : "Client",
+                      "description" : "Creates and exposes a client that connects to this agent. The client can be referenced by this name."
+                    },
+                    "image" : {
+                      "type" : "string",
+                      "title" : "Image"
+                    },
+                    "localPort" : {
+                      "type" : "string",
+                      "title" : "LocalPort",
+                      "description" : "Local port on the host machine. Creates a local port forward to the Kubernetes agent service."
+                    },
+                    "name" : {
+                      "type" : "string",
+                      "title" : "Name"
+                    },
+                    "port" : {
+                      "type" : "string",
+                      "title" : "Port",
+                      "description" : "The exposed agent service port used to connect to."
+                    },
+                    "registry" : {
+                      "type" : "string",
+                      "title" : "Registry"
+                    },
+                    "testJar" : {
+                      "type" : "string",
+                      "title" : "TestJar"
+                    },
+                    "timeout" : {
+                      "type" : "string",
+                      "title" : "Timeout"
+                    },
+                    "waitForRunningState" : {
+                      "type" : "boolean",
+                      "title" : "WaitForRunningState"
+                    }
+                  },
+                  "additionalProperties" : false,
+                  "title" : "Connect"
+                },
+                "disconnect" : {
+                  "type" : "object",
+                  "properties" : {
+                    "name" : {
+                      "type" : "string",
+                      "title" : "Name"
+                    }
+                  },
+                  "additionalProperties" : false,
+                  "title" : "Disconnect"
+                }
+              },
+              "additionalProperties" : false,
+              "title" : "Agent"
+            },
+            "autoRemove" : {
+              "type" : "boolean",
+              "title" : "AutoRemove"
+            },
+            "client" : {
+              "type" : "string",
+              "title" : "Client"
+            },
+            "connect" : {
+              "type" : "object",
+              "properties" : {
+                "service" : {
+                  "type" : "object",
+                  "properties" : {
+                    "client" : {
+                      "type" : "string",
+                      "title" : "Client",
+                      "description" : "Creates and exposes a client that connects to this service. The client can be referenced by this name."
+                    },
+                    "localPort" : {
+                      "type" : "string",
+                      "title" : "LocalPort",
+                      "description" : "Local port on the host machine. Creates a local port forward to the Kubernetes service."
+                    },
+                    "name" : {
+                      "type" : "string",
+                      "title" : "Name",
+                      "description" : "The Kubernetes service name to connect to"
+                    },
+                    "port" : {
+                      "type" : "string",
+                      "title" : "Port",
+                      "description" : "The exposed service port used to connect to."
+                    }
+                  },
+                  "additionalProperties" : false,
+                  "title" : "Service",
+                  "description" : "Connects to this Kubernetes service."
+                }
+              },
+              "additionalProperties" : false,
+              "title" : "Connect"
+            },
+            "connectService" : {
+              "type" : "object",
+              "properties" : {
+                "client" : {
+                  "type" : "string",
+                  "title" : "Client",
+                  "description" : "Creates and exposes a client that connects to this service. The client can be referenced by this name."
+                },
+                "localPort" : {
+                  "type" : "string",
+                  "title" : "LocalPort",
+                  "description" : "Local port on the host machine. Creates a local port forward to the Kubernetes service."
+                },
+                "name" : {
+                  "type" : "string",
+                  "title" : "ServiceName",
+                  "description" : "The Kubernetes service name to connect to"
+                },
+                "port" : {
+                  "type" : "string",
+                  "title" : "Port",
+                  "description" : "The exposed service port used to connect to."
+                }
+              },
+              "additionalProperties" : false,
+              "title" : "ConnectService"
+            },
+            "createAnnotations" : {
+              "type" : "object",
+              "properties" : {
+                "annotations" : {
+                  "title" : "Annotations",
+                  "type" : "array",
+                  "items" : {
+                    "type" : "object",
+                    "properties" : {
+                      "name" : {
+                        "type" : "string",
+                        "title" : "Name"
+                      },
+                      "value" : {
+                        "type" : "string",
+                        "title" : "Value"
+                      }
+                    },
+                    "additionalProperties" : false,
+                    "title" : "Annotations"
+                  }
+                },
+                "resource" : {
+                  "type" : "string",
+                  "title" : "Resource"
+                },
+                "type" : {
+                  "type" : "string",
+                  "title" : "Type"
+                }
+              },
+              "additionalProperties" : false,
+              "title" : "CreateAnnotations"
+            },
+            "createConfigMap" : {
+              "type" : "object",
+              "properties" : {
+                "file" : {
+                  "type" : "string",
+                  "title" : "File"
+                },
+                "name" : {
+                  "type" : "string",
+                  "title" : "Name"
+                },
+                "properties" : {
+                  "title" : "Properties",
+                  "type" : "array",
+                  "items" : {
+                    "type" : "object",
+                    "properties" : {
+                      "name" : {
+                        "type" : "string",
+                        "title" : "Name"
+                      },
+                      "value" : {
+                        "type" : "string",
+                        "title" : "Value"
+                      }
+                    },
+                    "additionalProperties" : false,
+                    "title" : "Properties"
+                  }
+                }
+              },
+              "additionalProperties" : false,
+              "title" : "CreateConfigMap"
+            },
+            "createCustomResource" : {
+              "type" : "object",
+              "properties" : {
+                "apiVersion" : {
+                  "type" : "string",
+                  "title" : "ApiVersion"
+                },
+                "data" : { },
+                "file" : { },
+                "group" : {
+                  "type" : "string",
+                  "title" : "Group"
+                },
+                "kind" : {
+                  "type" : "string",
+                  "title" : "Kind"
+                },
+                "type" : {
+                  "type" : "string",
+                  "title" : "Type"
+                },
+                "version" : {
+                  "type" : "string",
+                  "title" : "Version"
+                }
+              },
+              "additionalProperties" : false,
+              "anyOf" : [ {
+                "oneOf" : [ {
+                  "type" : "object",
+                  "properties" : {
+                    "data" : {
+                      "type" : "string",
+                      "title" : "Data",
+                      "description" : "The custom resource specification as inline data."
+                    }
+                  },
+                  "required" : [ "data" ]
+                }, {
+                  "type" : "object",
+                  "properties" : {
+                    "file" : {
+                      "type" : "string",
+                      "title" : "File",
+                      "description" : "The custom resource specification loaded from a file resource."
+                    }
+                  },
+                  "required" : [ "file" ]
+                } ]
+              } ],
+              "title" : "CreateCustomResource"
+            },
+            "createLabels" : {
+              "type" : "object",
+              "properties" : {
+                "labels" : {
+                  "title" : "Labels",
+                  "type" : "array",
+                  "items" : {
+                    "type" : "object",
+                    "properties" : {
+                      "name" : {
+                        "type" : "string",
+                        "title" : "Name"
+                      },
+                      "value" : {
+                        "type" : "string",
+                        "title" : "Value"
+                      }
+                    },
+                    "additionalProperties" : false,
+                    "title" : "Labels"
+                  }
+                },
+                "resource" : {
+                  "type" : "string",
+                  "title" : "Resource"
+                },
+                "type" : {
+                  "type" : "string",
+                  "title" : "Type"
+                }
+              },
+              "additionalProperties" : false,
+              "title" : "CreateLabels"
+            },
+            "createResource" : {
+              "type" : "object",
+              "properties" : {
+                "data" : { },
+                "file" : { }
+              },
+              "additionalProperties" : false,
+              "anyOf" : [ {
+                "oneOf" : [ {
+                  "type" : "object",
+                  "properties" : {
+                    "data" : {
+                      "type" : "string",
+                      "title" : "Data",
+                      "description" : "The custom resource specification as inline data."
+                    }
+                  },
+                  "required" : [ "data" ]
+                }, {
+                  "type" : "object",
+                  "properties" : {
+                    "file" : {
+                      "type" : "string",
+                      "title" : "File",
+                      "description" : "The custom resource specification loaded from a file resource."
+                    }
+                  },
+                  "required" : [ "file" ]
+                } ]
+              } ],
+              "title" : "CreateResource"
+            },
+            "createSecret" : {
+              "type" : "object",
+              "properties" : {
+                "file" : {
+                  "type" : "string",
+                  "title" : "File"
+                },
+                "name" : {
+                  "type" : "string",
+                  "title" : "Name"
+                },
+                "properties" : {
+                  "title" : "Properties",
+                  "type" : "array",
+                  "items" : {
+                    "type" : "object",
+                    "properties" : {
+                      "name" : {
+                        "type" : "string",
+                        "title" : "Name"
+                      },
+                      "value" : {
+                        "type" : "string",
+                        "title" : "Value"
+                      }
+                    },
+                    "additionalProperties" : false,
+                    "title" : "Properties"
+                  }
+                }
+              },
+              "additionalProperties" : false,
+              "title" : "CreateSecret"
+            },
+            "createService" : {
+              "type" : "object",
+              "properties" : {
+                "autoCreateServerBinding" : {
+                  "type" : "boolean",
+                  "title" : "AutoCreateServerBinding"
+                },
+                "name" : {
+                  "type" : "string",
+                  "title" : "Name"
+                },
+                "ports" : {
+                  "title" : "Ports",
+                  "type" : "array",
+                  "items" : {
+                    "type" : "object",
+                    "properties" : {
+                      "port" : {
+                        "type" : "string",
+                        "title" : "Port"
+                      },
+                      "targetPort" : {
+                        "type" : "string",
+                        "title" : "TargetPort"
+                      }
+                    },
+                    "additionalProperties" : false,
+                    "title" : "Ports"
+                  }
+                },
+                "protocol" : {
+                  "type" : "string",
+                  "title" : "Protocol"
+                },
+                "selector" : {
+                  "type" : "object",
+                  "properties" : {
+                    "labels" : {
+                      "title" : "Labels",
+                      "type" : "array",
+                      "items" : {
+                        "type" : "object",
+                        "properties" : {
+                          "name" : {
+                            "type" : "string",
+                            "title" : "Name"
+                          },
+                          "value" : {
+                            "type" : "string",
+                            "title" : "Value"
+                          }
+                        },
+                        "additionalProperties" : false,
+                        "title" : "Labels"
+                      }
+                    }
+                  },
+                  "additionalProperties" : false,
+                  "title" : "Selector"
+                },
+                "server" : {
+                  "type" : "string",
+                  "title" : "Server",
+                  "description" : "Uses an endpoint URI or references an endpoint name."
+                }
+              },
+              "additionalProperties" : false,
+              "title" : "CreateService"
+            },
+            "deleteConfigMap" : {
+              "type" : "object",
+              "properties" : {
+                "name" : {
+                  "type" : "string",
+                  "title" : "Name"
+                }
+              },
+              "additionalProperties" : false,
+              "title" : "DeleteConfigMap"
+            },
+            "deleteCustomResource" : {
+              "type" : "object",
+              "properties" : {
+                "apiVersion" : {
+                  "type" : "string",
+                  "title" : "ApiVersion"
+                },
+                "group" : {
+                  "type" : "string",
+                  "title" : "Group"
+                },
+                "kind" : {
+                  "type" : "string",
+                  "title" : "Kind"
+                },
+                "name" : {
+                  "type" : "string",
+                  "title" : "Name"
+                },
+                "type" : {
+                  "type" : "string",
+                  "title" : "Type"
+                },
+                "version" : {
+                  "type" : "string",
+                  "title" : "Version"
+                }
+              },
+              "additionalProperties" : false,
+              "title" : "DeleteCustomResource"
+            },
+            "deleteResource" : {
+              "type" : "object",
+              "properties" : {
+                "data" : { },
+                "file" : { }
+              },
+              "additionalProperties" : false,
+              "anyOf" : [ {
+                "oneOf" : [ {
+                  "type" : "object",
+                  "properties" : {
+                    "data" : {
+                      "type" : "string",
+                      "title" : "Data",
+                      "description" : "The custom resource specification as inline data."
+                    }
+                  },
+                  "required" : [ "data" ]
+                }, {
+                  "type" : "object",
+                  "properties" : {
+                    "file" : {
+                      "type" : "string",
+                      "title" : "File",
+                      "description" : "The custom resource specification loaded from a file resource."
+                    }
+                  },
+                  "required" : [ "file" ]
+                } ]
+              } ],
+              "title" : "DeleteResource"
+            },
+            "deleteSecret" : {
+              "type" : "object",
+              "properties" : {
+                "name" : {
+                  "type" : "string",
+                  "title" : "Name"
+                }
+              },
+              "additionalProperties" : false,
+              "title" : "DeleteSecret"
+            },
+            "deleteService" : {
+              "type" : "object",
+              "properties" : {
+                "name" : {
+                  "type" : "string",
+                  "title" : "Name"
+                }
+              },
+              "additionalProperties" : false,
+              "title" : "DeleteService"
+            },
+            "description" : {
+              "type" : "string",
+              "title" : "Description",
+              "description" : "Test action description printed when the action is executed.",
+              "$comment" : "group:advanced"
+            },
+            "disconnect" : {
+              "type" : "object",
+              "properties" : {
+                "service" : {
+                  "type" : "object",
+                  "properties" : {
+                    "name" : {
+                      "type" : "string",
+                      "title" : "Name"
+                    }
+                  },
+                  "additionalProperties" : false,
+                  "title" : "Service"
+                }
+              },
+              "additionalProperties" : false,
+              "title" : "Disconnect"
+            },
+            "disconnectService" : {
+              "type" : "object",
+              "properties" : {
+                "client" : {
+                  "type" : "string",
+                  "title" : "Client"
+                },
+                "name" : {
+                  "type" : "string",
+                  "title" : "Name"
+                }
+              },
+              "additionalProperties" : false,
+              "title" : "DisconnectService"
+            },
+            "namespace" : {
+              "type" : "string",
+              "title" : "Namespace"
+            },
+            "verifyCustomResource" : {
+              "type" : "object",
+              "properties" : {
+                "apiVersion" : {
+                  "type" : "string",
+                  "title" : "ApiVersion"
+                },
+                "condition" : {
+                  "type" : "string",
+                  "title" : "Condition"
+                },
+                "delayBetweenAttempts" : {
+                  "type" : "integer",
+                  "title" : "DelayBetweenAttempts"
+                },
+                "group" : {
+                  "type" : "string",
+                  "title" : "Group"
+                },
+                "kind" : {
+                  "type" : "string",
+                  "title" : "Kind"
+                },
+                "label" : {
+                  "type" : "string",
+                  "title" : "Label"
+                },
+                "maxAttempts" : {
+                  "type" : "integer",
+                  "title" : "MaxAttempts"
+                },
+                "name" : {
+                  "type" : "string",
+                  "title" : "Name"
+                },
+                "type" : {
+                  "type" : "string",
+                  "title" : "Type"
+                },
+                "version" : {
+                  "type" : "string",
+                  "title" : "Version"
+                }
+              },
+              "additionalProperties" : false,
+              "title" : "VerifyCustomResource"
+            },
+            "verifyPod" : {
+              "type" : "object",
+              "properties" : {
+                "delayBetweenAttempts" : {
+                  "type" : "integer",
+                  "title" : "DelayBetweenAttempts"
+                },
+                "label" : {
+                  "type" : "string",
+                  "title" : "Label"
+                },
+                "labels" : {
+                  "title" : "Labels",
+                  "type" : "array",
+                  "items" : {
+                    "type" : "object",
+                    "properties" : {
+                      "name" : {
+                        "type" : "string",
+                        "title" : "Name"
+                      },
+                      "value" : {
+                        "type" : "string",
+                        "title" : "Value"
+                      }
+                    },
+                    "additionalProperties" : false,
+                    "title" : "Labels"
+                  }
+                },
+                "logMessage" : {
+                  "type" : "string",
+                  "title" : "LogMessage"
+                },
+                "maxAttempts" : {
+                  "type" : "integer",
+                  "title" : "MaxAttempts"
+                },
+                "name" : {
+                  "type" : "string",
+                  "title" : "Name"
+                },
+                "phase" : {
+                  "type" : "string",
+                  "title" : "Phase"
+                },
+                "printLogs" : {
+                  "type" : "boolean",
+                  "title" : "PrintLogs"
+                }
+              },
+              "additionalProperties" : false,
+              "title" : "VerifyPod"
+            },
+            "watchPodLogs" : {
+              "type" : "object",
+              "properties" : {
+                "label" : {
+                  "type" : "string",
+                  "title" : "Label"
+                },
+                "labels" : {
+                  "title" : "Labels",
+                  "type" : "array",
+                  "items" : {
+                    "type" : "object",
+                    "properties" : {
+                      "name" : {
+                        "type" : "string",
+                        "title" : "Name"
+                      },
+                      "value" : {
+                        "type" : "string",
+                        "title" : "Value"
+                      }
+                    },
+                    "additionalProperties" : false,
+                    "title" : "Labels"
+                  }
+                },
+                "name" : {
+                  "type" : "string",
+                  "title" : "Name"
+                },
+                "timeout" : {
+                  "type" : "string",
+                  "title" : "Timeout"
+                }
+              },
+              "additionalProperties" : false,
+              "title" : "WatchPodLogs"
+            }
+          },
+          "additionalProperties" : false,
+          "title" : "Kubernetes",
+          "description" : "Kubernetes test actions."
+        },
+        "load" : {
+          "type" : "object",
+          "properties" : {
+            "properties" : {
+              "type" : "object",
+              "properties" : {
+                "file" : {
+                  "type" : "string",
+                  "title" : "File",
+                  "description" : "Properties file resource."
+                }
+              },
+              "required" : [ "file" ],
+              "additionalProperties" : false,
+              "title" : "Properties",
+              "description" : "The properties source."
+            }
+          },
+          "required" : [ "properties" ],
+          "additionalProperties" : false,
+          "title" : "Load",
+          "description" : "Load properties test action."
+        },
+        "openapi" : {
+          "type" : "object",
+          "properties" : {
+            "actor" : {
+              "type" : "string",
+              "title" : "Actor",
+              "$comment" : "group:advanced"
+            },
+            "client" : {
+              "type" : "string",
+              "title" : "Client",
+              "description" : "Sets the Http client used to send requests. Uses an endpoint URI or references an endpoint name."
+            },
+            "description" : {
+              "type" : "string",
+              "title" : "Description",
+              "description" : "Test action description printed when the action is executed.",
+              "$comment" : "group:advanced"
+            },
+            "receiveRequest" : {
+              "type" : "object",
+              "properties" : {
+                "extract" : {
+                  "allOf" : [ {
+                    "$ref" : "#/definitions/Extract"
+                  }, {
+                    "title" : "Extract",
+                    "description" : "Extract message content to test variables.",
+                    "$comment" : "group:advanced"
+                  } ]
+                },
+                "headerValidator" : {
+                  "type" : "string",
+                  "title" : "HeaderValidator",
+                  "description" : "Explicit message header validator.",
+                  "$comment" : "group:advanced"
+                },
+                "headerValidators" : {
+                  "type" : "string",
+                  "title" : "HeaderValidators",
+                  "description" : "List of message header validators used to validate the message.",
+                  "$comment" : "group:advanced"
+                },
+                "operation" : {
+                  "type" : "string",
+                  "title" : "Operation",
+                  "description" : "The expected API operation."
+                },
+                "schemaValidation" : {
+                  "type" : "boolean",
+                  "title" : "SchemaValidation",
+                  "description" : "Enables the schema validation.",
+                  "default" : "false"
+                },
+                "select" : {
+                  "type" : "string",
+                  "title" : "Select",
+                  "description" : "Message selector expression to selectively consume messages.",
+                  "$comment" : "group:advanced"
+                },
+                "timeout" : {
+                  "type" : "integer",
+                  "title" : "Timeout",
+                  "description" : "The timeout while waiting for incoming Http requests."
+                },
+                "validates" : {
+                  "title" : "Validates",
+                  "description" : "Additional message validation expressions.",
+                  "type" : "array",
+                  "items" : {
+                    "allOf" : [ {
+                      "$ref" : "#/definitions/Validate"
+                    }, {
+                      "title" : "Validates",
+                      "description" : "Additional message validation expressions."
+                    } ]
+                  }
+                },
+                "validator" : {
+                  "type" : "string",
+                  "title" : "Validator",
+                  "description" : "Explicit message validator.",
+                  "$comment" : "group:advanced"
+                },
+                "validators" : {
+                  "type" : "string",
+                  "title" : "Validators",
+                  "description" : "List of message validators used to validate the message.",
+                  "$comment" : "group:advanced"
+                }
+              },
+              "required" : [ "operation" ],
+              "additionalProperties" : false,
+              "title" : "ReceiveRequest",
+              "description" : "Receives a client request as a server."
+            },
+            "receiveResponse" : {
+              "type" : "object",
+              "properties" : {
+                "extract" : {
+                  "allOf" : [ {
+                    "$ref" : "#/definitions/Extract"
+                  }, {
+                    "title" : "Extract",
+                    "description" : "Extract message content to test variables.",
+                    "$comment" : "group:advanced"
+                  } ]
+                },
+                "headerValidator" : {
+                  "type" : "string",
+                  "title" : "HeaderValidator",
+                  "description" : "Explicit message header validator.",
+                  "$comment" : "group:advanced"
+                },
+                "headerValidators" : {
+                  "type" : "string",
+                  "title" : "HeaderValidators",
+                  "description" : "List of message header validators used to validate the message.",
+                  "$comment" : "group:advanced"
+                },
+                "operation" : {
+                  "type" : "string",
+                  "title" : "Operation",
+                  "description" : "The OpenAPI operation that defines the expected response."
+                },
+                "schemaValidation" : {
+                  "type" : "boolean",
+                  "title" : "SchemaValidation",
+                  "description" : "Enables the schema validation.",
+                  "default" : "false"
+                },
+                "select" : {
+                  "type" : "string",
+                  "title" : "Select",
+                  "description" : "Message selector expression to selectively consume messages.",
+                  "$comment" : "group:advanced"
+                },
+                "selector" : {
+                  "allOf" : [ {
+                    "$ref" : "#/definitions/Selector"
+                  }, {
+                    "title" : "Selector",
+                    "description" : "Message selector to selectively consume messages.",
+                    "$comment" : "group:advanced"
+                  } ]
+                },
+                "status" : {
+                  "type" : "string",
+                  "title" : "Status",
+                  "description" : "Expected response status."
+                },
+                "timeout" : {
+                  "type" : "integer",
+                  "title" : "Timeout",
+                  "description" : "Timeout in milliseconds while waiting for the server response."
+                },
+                "validator" : {
+                  "type" : "string",
+                  "title" : "Validator",
+                  "description" : "Explicit message validator.",
+                  "$comment" : "group:advanced"
+                },
+                "validators" : {
+                  "type" : "string",
+                  "title" : "Validators",
+                  "description" : "List of message validators used to validate the message.",
+                  "$comment" : "group:advanced"
+                }
+              },
+              "required" : [ "operation" ],
+              "additionalProperties" : false,
+              "title" : "ReceiveResponse",
+              "description" : "Receives a response as a client."
+            },
+            "sendRequest" : {
+              "type" : "object",
+              "properties" : {
+                "autoFill" : {
+                  "allOf" : [ {
+                    "$ref" : "#/definitions/AutoFillType"
+                  }, {
+                    "title" : "AutoFill",
+                    "description" : "Define which of the request fields are automatically filled with generated test data."
+                  } ]
+                },
+                "extract" : {
+                  "allOf" : [ {
+                    "$ref" : "#/definitions/Extract"
+                  }, {
+                    "title" : "Extract",
+                    "description" : "Extract message content to test variables before the request is sent.",
+                    "$comment" : "group:advanced"
+                  } ]
+                },
+                "fork" : {
+                  "type" : "boolean",
+                  "title" : "Fork",
+                  "description" : "When enabled send operation does not block while waiting for the response.",
+                  "$comment" : "group:advanced"
+                },
+                "operation" : {
+                  "type" : "string",
+                  "title" : "Operation",
+                  "description" : "The API operation to call."
+                },
+                "schemaValidation" : {
+                  "type" : "boolean",
+                  "title" : "SchemaValidation",
+                  "description" : "Enables the schema validation.",
+                  "default" : "false",
+                  "$comment" : "group:advanced"
+                },
+                "uri" : {
+                  "type" : "string",
+                  "title" : "Uri",
+                  "description" : "Http endpoint URI overwrite.",
+                  "$comment" : "group:advanced"
+                }
+              },
+              "required" : [ "operation" ],
+              "additionalProperties" : false,
+              "title" : "SendRequest",
+              "description" : "Send a request as a client."
+            },
+            "sendResponse" : {
+              "type" : "object",
+              "properties" : {
+                "autoFill" : {
+                  "allOf" : [ {
+                    "$ref" : "#/definitions/AutoFillType"
+                  }, {
+                    "title" : "AutoFill",
+                    "description" : "Define which response fields are set with generated values."
+                  } ]
+                },
+                "extract" : {
+                  "allOf" : [ {
+                    "$ref" : "#/definitions/Extract"
+                  }, {
+                    "title" : "Extract",
+                    "description" : "Extract message content to test variables.",
+                    "$comment" : "group:advanced"
+                  } ]
+                },
+                "operation" : {
+                  "type" : "string",
+                  "title" : "Operation",
+                  "description" : "The OpenAPI operation that generates the response."
+                },
+                "schemaValidation" : {
+                  "type" : "boolean",
+                  "title" : "SchemaValidation",
+                  "description" : "Enables the schema validation.",
+                  "default" : "false",
+                  "$comment" : "group:advanced"
+                },
+                "status" : {
+                  "type" : "string",
+                  "title" : "Status",
+                  "description" : "The response to generate."
+                }
+              },
+              "required" : [ "operation" ],
+              "additionalProperties" : false,
+              "title" : "SendResponse",
+              "description" : "Sends a response as a server."
+            },
+            "server" : {
+              "type" : "string",
+              "title" : "Server",
+              "description" : "Sets the Http server that provides the Http API. Uses an endpoint URI or references an endpoint name."
+            },
+            "specification" : {
+              "type" : "string",
+              "title" : "Specification",
+              "description" : "The OpenAPI specification source. Can be a local file resource or an Http endpoint URI."
+            }
+          },
+          "required" : [ "specification" ],
+          "additionalProperties" : false,
+          "title" : "Openapi",
+          "description" : "OpenAPI related test actions."
+        },
+        "parallel" : {
+          "type" : "object",
+          "properties" : {
+            "actions" : {
+              "title" : "Actions",
+              "description" : "Test actions to execute.",
+              "type" : "array",
+              "items" : {
+                "allOf" : [ {
+                  "$ref" : "#/definitions/TestActionBuilder_Object_"
+                }, {
+                  "title" : "Actions",
+                  "description" : "Test actions to execute."
+                } ]
+              }
+            },
+            "description" : {
+              "type" : "string",
+              "title" : "Description",
+              "description" : "Test action description printed when the action is executed.",
+              "$comment" : "group:advanced"
+            }
+          },
+          "required" : [ "actions" ],
+          "additionalProperties" : false,
+          "title" : "Parallel",
+          "description" : "Parallel test action."
+        },
+        "plsql" : {
+          "type" : "object",
+          "properties" : {
+            "dataSource" : {
+              "type" : "string",
+              "title" : "DataSource"
+            },
+            "description" : {
+              "type" : "string",
+              "title" : "Description",
+              "description" : "Test action description printed when the action is executed.",
+              "$comment" : "group:advanced"
+            },
+            "ignoreErrors" : {
+              "type" : "boolean",
+              "title" : "IgnoreErrors"
+            },
+            "statements" : {
+              "title" : "Statements",
+              "type" : "array",
+              "items" : {
+                "type" : "object",
+                "properties" : {
+                  "file" : {
+                    "type" : "string",
+                    "title" : "File"
+                  },
+                  "script" : {
+                    "type" : "string",
+                    "title" : "Script"
+                  },
+                  "statement" : {
+                    "type" : "string",
+                    "title" : "Statement"
+                  }
+                },
+                "additionalProperties" : false,
+                "title" : "Statements"
+              }
+            },
+            "transaction" : {
+              "type" : "object",
+              "properties" : {
+                "isolationLevel" : {
+                  "type" : "string",
+                  "title" : "IsolationLevel"
+                },
+                "manager" : {
+                  "type" : "string",
+                  "title" : "Manager"
+                },
+                "timeout" : {
+                  "type" : "string",
+                  "title" : "Timeout"
+                }
+              },
+              "additionalProperties" : false,
+              "title" : "Transaction"
+            }
+          },
+          "required" : [ "statements" ],
+          "additionalProperties" : false,
+          "title" : "Plsql",
+          "description" : "PLSQL test actions."
+        },
+        "print" : {
+          "type" : "object",
+          "properties" : {
+            "description" : {
+              "type" : "string",
+              "title" : "Description",
+              "description" : "Test action description printed when the action is executed.",
+              "$comment" : "group:advanced"
+            },
+            "message" : {
+              "type" : "string",
+              "title" : "Message",
+              "description" : "The message to print."
+            }
+          },
+          "required" : [ "message" ],
+          "additionalProperties" : false,
+          "title" : "Print",
+          "description" : "Print test action."
+        },
+        "purge" : {
+          "type" : "object",
+          "properties" : {
+            "endpoint" : {
+              "type" : "string",
+              "title" : "Endpoint",
+              "description" : "The name of the endpoint to purge. Uses an endpoint URI or references an endpoint name."
+            },
+            "endpoints" : {
+              "title" : "Endpoints",
+              "description" : "List of endpoints to purge.",
+              "type" : "array",
+              "items" : {
+                "type" : "object",
+                "properties" : {
+                  "name" : {
+                    "type" : "string",
+                    "title" : "Name",
+                    "description" : "The name of the endpoint. Uses an endpoint URI or references an endpoint name."
+                  },
+                  "ref" : {
+                    "type" : "string",
+                    "title" : "Ref",
+                    "description" : "Reference to the endpoint in the bean registry. Uses an endpoint URI or references an endpoint name."
+                  }
+                },
+                "additionalProperties" : false,
+                "title" : "Endpoints",
+                "description" : "List of endpoints to purge."
+              }
+            },
+            "select" : {
+              "type" : "string",
+              "title" : "Select",
+              "description" : "Message selector to purge only matching messages.",
+              "$comment" : "group:advanced"
+            },
+            "selector" : {
+              "type" : "object",
+              "properties" : {
+                "elements" : {
+                  "title" : "Elements",
+                  "description" : "Select on given elements.",
+                  "type" : "array",
+                  "items" : {
+                    "type" : "object",
+                    "properties" : {
+                      "name" : {
+                        "type" : "string",
+                        "title" : "Name",
+                        "description" : "Key of the selector expression."
+                      },
+                      "value" : {
+                        "type" : "string",
+                        "title" : "Value",
+                        "description" : "Select value of the selector expression."
+                      }
+                    },
+                    "required" : [ "name", "value" ],
+                    "additionalProperties" : false,
+                    "title" : "Elements",
+                    "description" : "Select on given elements."
+                  }
+                },
+                "value" : {
+                  "type" : "string",
+                  "title" : "Value",
+                  "description" : "Selector expression value."
+                }
+              },
+              "additionalProperties" : false,
+              "title" : "Selector",
+              "description" : "Message selector to find matching messages that should be purged.",
+              "$comment" : "group:advanced"
+            },
+            "sleep" : {
+              "type" : "integer",
+              "title" : "Sleep",
+              "description" : "Wait this time between reading attempts.",
+              "$comment" : "group:advanced"
+            },
+            "timeout" : {
+              "type" : "integer",
+              "title" : "Timeout",
+              "description" : "Timeout when reading messages from the endpoint."
+            }
+          },
+          "additionalProperties" : false,
+          "title" : "Purge",
+          "description" : "Purge test action."
+        },
+        "purgeQueues" : {
+          "type" : "object",
+          "properties" : {
+            "actor" : {
+              "type" : "string",
+              "title" : "Actor",
+              "$comment" : "group:advanced"
+            },
+            "connectionFactory" : {
+              "type" : "string",
+              "title" : "ConnectionFactory",
+              "description" : "The JMS connection factory."
+            },
+            "description" : {
+              "type" : "string",
+              "title" : "Description",
+              "description" : "Test action description printed when the action is executed.",
+              "$comment" : "group:advanced"
+            },
+            "queue" : {
+              "type" : "string",
+              "title" : "Queue",
+              "description" : "The JMS queue to purge."
+            },
+            "queues" : {
+              "title" : "Queues",
+              "description" : "List of JMS queues to purge.",
+              "type" : "array",
+              "items" : {
+                "type" : "string",
+                "title" : "Queues",
+                "description" : "List of JMS queues to purge."
+              }
+            },
+            "sleep" : {
+              "type" : "integer",
+              "title" : "Sleep",
+              "description" : "Time to wait between message consume attempts.",
+              "$comment" : "group:advanced"
+            },
+            "timeout" : {
+              "type" : "integer",
+              "title" : "Timeout",
+              "description" : "Request timeout while consuming messages from the queue."
+            }
+          },
+          "required" : [ "connectionFactory" ],
+          "additionalProperties" : false,
+          "title" : "PurgeQueues",
+          "description" : "Purge JMS queue test action."
+        },
+        "receive" : {
+          "type" : "object",
+          "properties" : {
+            "actor" : {
+              "type" : "string",
+              "title" : "Actor",
+              "$comment" : "group:advanced"
+            },
+            "description" : {
+              "type" : "string",
+              "title" : "Description",
+              "description" : "Test action description printed when the action is executed.",
+              "$comment" : "group:advanced"
+            },
+            "endpoint" : {
+              "type" : "string",
+              "title" : "Endpoint",
+              "description" : "The message endpoint name or URI used to receive the message. Uses an endpoint URI or references an endpoint name."
+            },
+            "extract" : {
+              "allOf" : [ {
+                "$ref" : "#/definitions/Extract"
+              }, {
+                "title" : "Extract",
+                "description" : "Extract message content to test variables after the message validation.",
+                "$comment" : "group:extract"
+              } ]
+            },
+            "headerValidator" : {
+              "type" : "string",
+              "title" : "HeaderValidator",
+              "description" : "Explicit message header validator.",
+              "$comment" : "group:validator"
+            },
+            "headerValidators" : {
+              "type" : "string",
+              "title" : "HeaderValidators",
+              "description" : "List of message header validators used to validate the message.",
+              "$comment" : "group:validator"
+            },
+            "ignore" : {
+              "title" : "Ignore",
+              "description" : "List of expressions to identify message elements that should be ignored during validation.",
+              "$comment" : "group:ignore",
+              "type" : "array",
+              "items" : {
+                "type" : "object",
+                "properties" : {
+                  "path" : {
+                    "type" : "string",
+                    "title" : "Path",
+                    "description" : "Path expression identifies the message element to ignore."
+                  }
+                },
+                "required" : [ "path" ],
+                "additionalProperties" : false,
+                "title" : "Ignore",
+                "description" : "List of expressions to identify message elements that should be ignored during validation.",
+                "$comment" : "group:ignore"
+              }
+            },
+            "message" : {
+              "allOf" : [ {
+                "$ref" : "#/definitions/Message"
+              }, {
+                "title" : "Message",
+                "description" : "The expected message used to validate."
+              } ]
+            },
+            "namespace" : {
+              "title" : "Namespace",
+              "description" : "Optional XML namespace to validate.",
+              "$comment" : "group:xml",
+              "type" : "array",
+              "items" : {
+                "type" : "object",
+                "properties" : {
+                  "prefix" : {
+                    "type" : "string",
+                    "title" : "Prefix",
+                    "description" : "Expected namespace prefix."
+                  },
+                  "value" : {
+                    "type" : "string",
+                    "title" : "Value",
+                    "description" : "Expected namespace value."
+                  }
+                },
+                "required" : [ "prefix", "value" ],
+                "additionalProperties" : false,
+                "title" : "Namespace",
+                "description" : "Optional XML namespace to validate.",
+                "$comment" : "group:xml"
+              }
+            },
+            "select" : {
+              "type" : "string",
+              "title" : "Select",
+              "description" : "Message select expression to selectively receive a message.",
+              "$comment" : "group:selector"
+            },
+            "selector" : {
+              "allOf" : [ {
+                "$ref" : "#/definitions/Selector"
+              }, {
+                "title" : "Selector",
+                "description" : "Message selector used to selectively receive a message.",
+                "$comment" : "group:selector"
+              } ]
+            },
+            "timeout" : {
+              "type" : "integer",
+              "title" : "Timeout",
+              "description" : "Receive timeout."
+            },
+            "validate" : {
+              "title" : "Validate",
+              "description" : "Validation expressions evaluated on the message.",
+              "type" : "array",
+              "items" : {
+                "allOf" : [ {
+                  "$ref" : "#/definitions/Validate"
+                }, {
+                  "title" : "Validate",
+                  "description" : "Validation expressions evaluated on the message."
+                } ]
+              }
+            },
+            "validator" : {
+              "type" : "string",
+              "title" : "Validator",
+              "description" : "Explicit message validator.",
+              "$comment" : "group:validator"
+            },
+            "validators" : {
+              "type" : "string",
+              "title" : "Validators",
+              "description" : "List of message validators used to validate the message.",
+              "$comment" : "group:validator"
+            }
+          },
+          "required" : [ "endpoint", "message" ],
+          "additionalProperties" : false,
+          "title" : "Receive",
+          "description" : "Receive message test action."
+        },
+        "repeat" : {
+          "type" : "object",
+          "properties" : {
+            "actions" : {
+              "title" : "Actions",
+              "description" : "Sequence of test actions to execute.",
+              "type" : "array",
+              "items" : {
+                "allOf" : [ {
+                  "$ref" : "#/definitions/TestActionBuilder_Object_"
+                }, {
+                  "title" : "Actions",
+                  "description" : "Sequence of test actions to execute."
+                } ]
+              }
+            },
+            "description" : {
+              "type" : "string",
+              "title" : "Description",
+              "description" : "Test action description printed when the action is executed.",
+              "$comment" : "group:advanced"
+            },
+            "index" : {
+              "type" : "string",
+              "title" : "Index",
+              "description" : "Test variable holding the current iteration index.",
+              "$comment" : "group:advanced"
+            },
+            "startsWith" : {
+              "type" : "integer",
+              "title" : "StartsWith",
+              "description" : "Index starts with this value.",
+              "default" : "1",
+              "$comment" : "group:advanced"
+            },
+            "until" : {
+              "type" : "string",
+              "title" : "Until",
+              "description" : "Condition that ends the iteration."
+            }
+          },
+          "required" : [ "actions" ],
+          "additionalProperties" : false,
+          "title" : "Repeat",
+          "description" : "Repeat test action."
+        },
+        "repeatOnError" : {
+          "type" : "object",
+          "properties" : {
+            "actions" : {
+              "title" : "Actions",
+              "description" : "Sequence of test actions to execute.",
+              "type" : "array",
+              "items" : {
+                "allOf" : [ {
+                  "$ref" : "#/definitions/TestActionBuilder_Object_"
+                }, {
+                  "title" : "Actions",
+                  "description" : "Sequence of test actions to execute."
+                } ]
+              }
+            },
+            "autoSleep" : {
+              "type" : "integer",
+              "title" : "AutoSleep",
+              "description" : "Automatically sleep the time in milliseconds with each attempt."
+            },
+            "description" : {
+              "type" : "string",
+              "title" : "Description",
+              "description" : "Test action description printed when the action is executed.",
+              "$comment" : "group:advanced"
+            },
+            "index" : {
+              "type" : "string",
+              "title" : "Index",
+              "description" : "Test variable holding the current iteration index.",
+              "$comment" : "group:advanced"
+            },
+            "startsWith" : {
+              "type" : "integer",
+              "title" : "StartsWith",
+              "description" : "Index starts with this value.",
+              "default" : "1",
+              "$comment" : "group:advanced"
+            },
+            "until" : {
+              "type" : "string",
+              "title" : "Until",
+              "description" : "Condition that ends the iteration."
+            }
+          },
+          "required" : [ "actions" ],
+          "additionalProperties" : false,
+          "title" : "RepeatOnError",
+          "description" : "Repeat on error test action."
+        },
+        "selenium" : {
+          "type" : "object",
+          "properties" : {
+            "actor" : {
+              "type" : "string",
+              "title" : "Actor",
+              "$comment" : "group:advanced"
+            },
+            "alert" : {
+              "type" : "object",
+              "properties" : {
+                "accept" : {
+                  "type" : "boolean",
+                  "title" : "Accept"
+                },
+                "dismiss" : {
+                  "type" : "boolean",
+                  "title" : "Dismiss"
+                },
+                "text" : {
+                  "type" : "string",
+                  "title" : "Text"
+                }
+              },
+              "additionalProperties" : false,
+              "title" : "Alert"
+            },
+            "browser" : {
+              "type" : "string",
+              "title" : "Browser",
+              "description" : "Sets the Selenium browser.Uses an endpoint URI or references an endpoint name."
+            },
+            "checkInput" : {
+              "type" : "object",
+              "properties" : {
+                "checked" : {
+                  "type" : "boolean",
+                  "title" : "Checked"
+                },
+                "element" : {
+                  "allOf" : [ {
+                    "$ref" : "#/definitions/Element"
+                  }, {
+                    "title" : "Element"
+                  } ]
+                }
+              },
+              "additionalProperties" : false,
+              "title" : "CheckInput"
+            },
+            "clearCache" : {
+              "type" : "object",
+              "additionalProperties" : false,
+              "title" : "ClearCache"
+            },
+            "click" : {
+              "type" : "object",
+              "properties" : {
+                "element" : {
+                  "allOf" : [ {
+                    "$ref" : "#/definitions/Element"
+                  }, {
+                    "title" : "Element"
+                  } ]
+                }
+              },
+              "additionalProperties" : false,
+              "title" : "Click"
+            },
+            "closeWindow" : {
+              "type" : "object",
+              "properties" : {
+                "name" : {
+                  "type" : "string",
+                  "title" : "Name"
+                },
+                "window" : {
+                  "type" : "string",
+                  "title" : "Window"
+                }
+              },
+              "additionalProperties" : false,
+              "title" : "CloseWindow"
+            },
+            "description" : {
+              "type" : "string",
+              "title" : "Description",
+              "description" : "Test action description printed when the action is executed.",
+              "$comment" : "group:advanced"
+            },
+            "dropdownSelect" : {
+              "type" : "object",
+              "properties" : {
+                "element" : {
+                  "allOf" : [ {
+                    "$ref" : "#/definitions/Element"
+                  }, {
+                    "title" : "Element"
+                  } ]
+                },
+                "option" : {
+                  "type" : "string",
+                  "title" : "Option"
+                },
+                "options" : {
+                  "title" : "Options",
+                  "type" : "array",
+                  "items" : {
+                    "type" : "string",
+                    "title" : "Options"
+                  }
+                }
+              },
+              "additionalProperties" : false,
+              "title" : "DropdownSelect"
+            },
+            "fillForm" : {
+              "type" : "object",
+              "properties" : {
+                "fields" : {
+                  "title" : "Fields",
+                  "type" : "array",
+                  "items" : {
+                    "type" : "object",
+                    "properties" : {
+                      "id" : {
+                        "type" : "string",
+                        "title" : "Id"
+                      },
+                      "value" : {
+                        "type" : "string",
+                        "title" : "Value"
+                      }
+                    },
+                    "additionalProperties" : false,
+                    "title" : "Fields"
+                  }
+                },
+                "json" : {
+                  "type" : "string",
+                  "title" : "Json"
+                },
+                "submit" : {
+                  "type" : "string",
+                  "title" : "Submit"
+                }
+              },
+              "additionalProperties" : false,
+              "title" : "FillForm"
+            },
+            "find" : {
+              "type" : "object",
+              "properties" : {
+                "element" : {
+                  "allOf" : [ {
+                    "$ref" : "#/definitions/Element"
+                  }, {
+                    "title" : "Element"
+                  } ]
+                },
+                "validate" : {
+                  "type" : "object",
+                  "properties" : {
+                    "attributes" : {
+                      "title" : "Attributes",
+                      "type" : "array",
+                      "items" : {
+                        "type" : "object",
+                        "properties" : {
+                          "name" : {
+                            "type" : "string",
+                            "title" : "Name"
+                          },
+                          "value" : {
+                            "type" : "string",
+                            "title" : "Value"
+                          }
+                        },
+                        "additionalProperties" : false,
+                        "title" : "Attributes"
+                      }
+                    },
+                    "displayed" : {
+                      "type" : "boolean",
+                      "title" : "Displayed"
+                    },
+                    "enabled" : {
+                      "type" : "boolean",
+                      "title" : "Enabled"
+                    },
+                    "styles" : {
+                      "title" : "Styles",
+                      "type" : "array",
+                      "items" : {
+                        "type" : "object",
+                        "properties" : {
+                          "name" : {
+                            "type" : "string",
+                            "title" : "Name"
+                          },
+                          "value" : {
+                            "type" : "string",
+                            "title" : "Value"
+                          }
+                        },
+                        "additionalProperties" : false,
+                        "title" : "Styles"
+                      }
+                    },
+                    "tagName" : {
+                      "type" : "string",
+                      "title" : "TagName"
+                    },
+                    "text" : {
+                      "type" : "string",
+                      "title" : "Text"
+                    }
+                  },
+                  "additionalProperties" : false,
+                  "title" : "Validate"
+                }
+              },
+              "additionalProperties" : false,
+              "title" : "Find"
+            },
+            "focusWindow" : {
+              "allOf" : [ {
+                "$ref" : "#/definitions/SwitchWindow"
+              }, {
+                "title" : "FocusWindow"
+              } ]
+            },
+            "getStoredFile" : {
+              "type" : "object",
+              "properties" : {
+                "fileName" : {
+                  "type" : "string",
+                  "title" : "FileName"
+                }
+              },
+              "additionalProperties" : false,
+              "title" : "GetStoredFile"
+            },
+            "hover" : {
+              "type" : "object",
+              "properties" : {
+                "element" : {
+                  "allOf" : [ {
+                    "$ref" : "#/definitions/Element"
+                  }, {
+                    "title" : "Element"
+                  } ]
+                }
+              },
+              "additionalProperties" : false,
+              "title" : "Hover"
+            },
+            "javaScript" : {
+              "type" : "object",
+              "properties" : {
+                "argument" : {
+                  "title" : "Argument"
+                },
+                "arguments" : {
+                  "title" : "Arguments",
+                  "type" : "array",
+                  "items" : {
+                    "title" : "Arguments"
+                  }
+                },
+                "error" : {
+                  "type" : "string",
+                  "title" : "Error"
+                },
+                "errors" : {
+                  "title" : "Errors",
+                  "type" : "array",
+                  "items" : {
+                    "type" : "string",
+                    "title" : "Errors"
+                  }
+                },
+                "script" : {
+                  "type" : "string",
+                  "title" : "Script"
+                }
+              },
+              "additionalProperties" : false,
+              "title" : "JavaScript"
+            },
+            "navigate" : {
+              "type" : "object",
+              "properties" : {
+                "page" : {
+                  "type" : "string",
+                  "title" : "Page"
+                }
+              },
+              "additionalProperties" : false,
+              "title" : "Navigate"
+            },
+            "openWindow" : {
+              "type" : "object",
+              "properties" : {
+                "name" : {
+                  "type" : "string",
+                  "title" : "Name"
+                },
+                "window" : {
+                  "type" : "string",
+                  "title" : "Window"
+                }
+              },
+              "additionalProperties" : false,
+              "title" : "OpenWindow"
+            },
+            "page" : {
+              "type" : "object",
+              "properties" : {
+                "action" : {
+                  "type" : "string",
+                  "title" : "Action"
+                },
+                "argument" : {
+                  "type" : "string",
+                  "title" : "Argument"
+                },
+                "arguments" : {
+                  "title" : "Arguments",
+                  "type" : "array",
+                  "items" : {
+                    "type" : "string",
+                    "title" : "Arguments"
+                  }
+                },
+                "execute" : {
+                  "type" : "string",
+                  "title" : "Execute"
+                },
+                "name" : {
+                  "type" : "string",
+                  "title" : "Name"
+                },
+                "type" : {
+                  "type" : "string",
+                  "title" : "Type"
+                },
+                "validator" : {
+                  "type" : "string",
+                  "title" : "Validator"
+                }
+              },
+              "additionalProperties" : false,
+              "title" : "Page"
+            },
+            "screenshot" : {
+              "type" : "object",
+              "properties" : {
+                "outputDir" : {
+                  "type" : "string",
+                  "title" : "OutputDir"
+                }
+              },
+              "additionalProperties" : false,
+              "title" : "Screenshot"
+            },
+            "setInput" : {
+              "type" : "object",
+              "properties" : {
+                "element" : {
+                  "allOf" : [ {
+                    "$ref" : "#/definitions/Element"
+                  }, {
+                    "title" : "Element"
+                  } ]
+                },
+                "value" : {
+                  "type" : "string",
+                  "title" : "Value"
+                }
+              },
+              "additionalProperties" : false,
+              "title" : "SetInput"
+            },
+            "start" : {
+              "type" : "object",
+              "properties" : {
+                "allowAlreadyStarted" : {
+                  "type" : "boolean",
+                  "title" : "AllowAlreadyStarted"
+                },
+                "browser" : {
+                  "type" : "string",
+                  "title" : "Browser",
+                  "description" : "Sets the Selenium browser.Uses an endpoint URI or references an endpoint name."
+                }
+              },
+              "additionalProperties" : false,
+              "title" : "Start"
+            },
+            "stop" : {
+              "type" : "object",
+              "properties" : {
+                "browser" : {
+                  "type" : "string",
+                  "title" : "Browser",
+                  "description" : "Sets the Selenium browser.Uses an endpoint URI or references an endpoint name."
+                }
+              },
+              "additionalProperties" : false,
+              "title" : "Stop"
+            },
+            "storeFile" : {
+              "type" : "object",
+              "properties" : {
+                "filePath" : {
+                  "type" : "string",
+                  "title" : "FilePath"
+                }
+              },
+              "additionalProperties" : false,
+              "title" : "StoreFile"
+            },
+            "switchWindow" : {
+              "allOf" : [ {
+                "$ref" : "#/definitions/SwitchWindow"
+              }, {
+                "title" : "SwitchWindow"
+              } ]
+            },
+            "waitUntil" : {
+              "type" : "object",
+              "properties" : {
+                "condition" : {
+                  "type" : "string",
+                  "title" : "Condition"
+                },
+                "element" : {
+                  "allOf" : [ {
+                    "$ref" : "#/definitions/Element"
+                  }, {
+                    "title" : "Element"
+                  } ]
+                },
+                "timeout" : {
+                  "type" : "integer",
+                  "title" : "Timeout"
+                },
+                "until" : {
+                  "type" : "string",
+                  "title" : "Until"
+                }
+              },
+              "additionalProperties" : false,
+              "title" : "WaitUntil"
+            }
+          },
+          "additionalProperties" : false,
+          "title" : "Selenium",
+          "description" : "Selenium test actions."
+        },
+        "send" : {
+          "type" : "object",
+          "properties" : {
+            "actor" : {
+              "type" : "string",
+              "title" : "Actor",
+              "$comment" : "group:advanced"
+            },
+            "description" : {
+              "type" : "string",
+              "title" : "Description",
+              "description" : "Test action description printed when the action is executed.",
+              "$comment" : "group:advanced"
+            },
+            "endpoint" : {
+              "type" : "string",
+              "title" : "Endpoint",
+              "description" : "The message endpoint name or URI. Uses an endpoint URI or references an endpoint name."
+            },
+            "extract" : {
+              "allOf" : [ {
+                "$ref" : "#/definitions/Extract"
+              }, {
+                "title" : "Extract",
+                "description" : "Extract message content to test variables before the message is sent.",
+                "$comment" : "group:extract"
+              } ]
+            },
+            "fork" : {
+              "type" : "boolean",
+              "title" : "Fork",
+              "description" : "When set the send operation does not block while waiting for the response."
+            },
+            "message" : {
+              "allOf" : [ {
+                "$ref" : "#/definitions/Message"
+              }, {
+                "title" : "Message",
+                "description" : "The message to send."
+              } ]
+            }
+          },
+          "required" : [ "endpoint" ],
+          "additionalProperties" : false,
+          "title" : "Send",
+          "description" : "Send message test action."
+        },
+        "sequential" : {
+          "type" : "object",
+          "properties" : {
+            "actions" : {
+              "title" : "Actions",
+              "description" : "Sequence of test actions to execute.",
+              "type" : "array",
+              "items" : {
+                "allOf" : [ {
+                  "$ref" : "#/definitions/TestActionBuilder_Object_"
+                }, {
+                  "title" : "Actions",
+                  "description" : "Sequence of test actions to execute."
+                } ]
+              }
+            },
+            "description" : {
+              "type" : "string",
+              "title" : "Description",
+              "description" : "Test action description printed when the action is executed.",
+              "$comment" : "group:advanced"
+            }
+          },
+          "required" : [ "actions" ],
+          "additionalProperties" : false,
+          "title" : "Sequential",
+          "description" : "Sequential test action."
+        },
+        "sleep" : {
+          "type" : "object",
+          "properties" : {
+            "description" : {
+              "type" : "string",
+              "title" : "Description",
+              "description" : "Test action description printed when the action is executed.",
+              "$comment" : "group:advanced"
+            },
+            "milliseconds" : {
+              "type" : "string",
+              "title" : "Milliseconds",
+              "description" : "Time to sleep in milliseconds."
+            },
+            "seconds" : {
+              "type" : "string",
+              "title" : "Seconds",
+              "description" : "Time to sleep in seconds."
+            }
+          },
+          "additionalProperties" : false,
+          "title" : "Sleep",
+          "description" : "Sleep test action."
+        },
+        "soap" : {
+          "type" : "object",
+          "properties" : {
+            "actor" : {
+              "type" : "string",
+              "title" : "Actor",
+              "$comment" : "group:advanced"
+            },
+            "assertFault" : {
+              "type" : "object",
+              "properties" : {
+                "faultActor" : {
+                  "type" : "string",
+                  "title" : "FaultActor",
+                  "description" : "The SOAP fault actor.",
+                  "$comment" : "group:advanced"
+                },
+                "faultCode" : {
+                  "type" : "string",
+                  "title" : "FaultCode",
+                  "description" : "The SOAP fault code."
+                },
+                "faultDetails" : {
+                  "title" : "FaultDetails",
+                  "description" : "The SOAP fault details.",
+                  "$comment" : "group:advanced",
+                  "type" : "array",
+                  "items" : {
+                    "allOf" : [ {
+                      "$ref" : "#/definitions/SoapFaultDetail"
+                    }, {
+                      "title" : "FaultDetails",
+                      "description" : "The SOAP fault details.",
+                      "$comment" : "group:advanced"
+                    } ]
+                  }
+                },
+                "faultString" : {
+                  "type" : "string",
+                  "title" : "FaultString",
+                  "description" : "The SOAP fault string."
+                },
+                "validator" : {
+                  "type" : "string",
+                  "title" : "Validator",
+                  "description" : "Explicit message validator.",
+                  "$comment" : "group:advanced"
+                },
+                "when" : {
+                  "allOf" : [ {
+                    "$ref" : "#/definitions/TestActionBuilder_Object_"
+                  }, {
+                    "title" : "When",
+                    "description" : "The test action raising the SOAP fault response message."
+                  } ]
+                }
+              },
+              "required" : [ "when" ],
+              "additionalProperties" : false,
+              "title" : "AssertFault",
+              "description" : "Expects a SOAP fault response as a client."
+            },
+            "client" : {
+              "type" : "string",
+              "title" : "Client",
+              "description" : "Sets the SOAP Http client. Uses an endpoint URI or references an endpoint name."
+            },
+            "description" : {
+              "type" : "string",
+              "title" : "Description",
+              "description" : "Test action description printed when the action is executed.",
+              "$comment" : "group:advanced"
+            },
+            "receiveRequest" : {
+              "type" : "object",
+              "properties" : {
+                "attachmentValidator" : {
+                  "type" : "string",
+                  "title" : "AttachmentValidator",
+                  "description" : "Explicit SOAP attachment validator.",
+                  "$comment" : "group:advanced"
+                },
+                "extract" : {
+                  "allOf" : [ {
+                    "$ref" : "#/definitions/Extract"
+                  }, {
+                    "title" : "Extract",
+                    "description" : "Extract message content to test variables.",
+                    "$comment" : "group:advanced"
+                  } ]
+                },
+                "headerValidator" : {
+                  "type" : "string",
+                  "title" : "HeaderValidator",
+                  "description" : "Explicit message header validator.",
+                  "$comment" : "group:advanced"
+                },
+                "headerValidators" : {
+                  "type" : "string",
+                  "title" : "HeaderValidators",
+                  "description" : "List of message header validators used to validate the message.",
+                  "$comment" : "group:advanced"
+                },
+                "message" : {
+                  "allOf" : [ {
+                    "$ref" : "#/definitions/SoapRequest"
+                  }, {
+                    "title" : "Message",
+                    "description" : "The expected SOAP request message."
+                  } ]
+                },
+                "select" : {
+                  "type" : "string",
+                  "title" : "Select",
+                  "description" : "Message selector expression to selectively consume messages.",
+                  "$comment" : "group:advanced"
+                },
+                "selector" : {
+                  "allOf" : [ {
+                    "$ref" : "#/definitions/Selector"
+                  }, {
+                    "title" : "Selector",
+                    "description" : "Message selector to selectively consume messages.",
+                    "$comment" : "group:advanced"
+                  } ]
+                },
+                "timeout" : {
+                  "type" : "integer",
+                  "title" : "Timeout",
+                  "description" : "Timeout while waiting for the incoming SOAP request."
+                },
+                "validator" : {
+                  "type" : "string",
+                  "title" : "Validator",
+                  "description" : "Explicit message validator.",
+                  "$comment" : "group:advanced"
+                },
+                "validators" : {
+                  "type" : "string",
+                  "title" : "Validators",
+                  "description" : "List of message validators used to validate the message.",
+                  "$comment" : "group:advanced"
+                }
+              },
+              "required" : [ "message" ],
+              "additionalProperties" : false,
+              "title" : "ReceiveRequest",
+              "description" : "Receives a SOAP request as a server."
+            },
+            "receiveResponse" : {
+              "type" : "object",
+              "properties" : {
+                "attachmentValidator" : {
+                  "type" : "string",
+                  "title" : "AttachmentValidator",
+                  "description" : "Explicit SOAP attachment validator.",
+                  "$comment" : "group:advanced"
+                },
+                "extract" : {
+                  "allOf" : [ {
+                    "$ref" : "#/definitions/Extract"
+                  }, {
+                    "title" : "Extract",
+                    "description" : "Extract message content to test variables.",
+                    "$comment" : "group:advanced"
+                  } ]
+                },
+                "headerValidator" : {
+                  "type" : "string",
+                  "title" : "HeaderValidator",
+                  "description" : "Explicit message header validator.",
+                  "$comment" : "group:advanced"
+                },
+                "headerValidators" : {
+                  "type" : "string",
+                  "title" : "HeaderValidators",
+                  "description" : "List of message header validators used to validate the message.",
+                  "$comment" : "group:advanced"
+                },
+                "message" : {
+                  "allOf" : [ {
+                    "$ref" : "#/definitions/SoapResponse"
+                  }, {
+                    "title" : "Message",
+                    "description" : "The expected SOAP response message."
+                  } ]
+                },
+                "select" : {
+                  "type" : "string",
+                  "title" : "Select",
+                  "description" : "Message selector to selectively consume messages.",
+                  "$comment" : "group:advanced"
+                },
+                "selector" : {
+                  "allOf" : [ {
+                    "$ref" : "#/definitions/Selector"
+                  }, {
+                    "title" : "Selector",
+                    "description" : "Message selector to selectively consume messages.",
+                    "$comment" : "group:advanced"
+                  } ]
+                },
+                "timeout" : {
+                  "type" : "integer",
+                  "title" : "Timeout",
+                  "description" : "Timeout while waiting for the SOAP response message."
+                },
+                "validate" : {
+                  "title" : "Validate",
+                  "description" : "Message validation expressions.",
+                  "type" : "array",
+                  "items" : {
+                    "allOf" : [ {
+                      "$ref" : "#/definitions/Validate"
+                    }, {
+                      "title" : "Validate",
+                      "description" : "Message validation expressions."
+                    } ]
+                  }
+                },
+                "validator" : {
+                  "type" : "string",
+                  "title" : "Validator",
+                  "description" : "Explicit message validator.",
+                  "$comment" : "group:advanced"
+                },
+                "validators" : {
+                  "type" : "string",
+                  "title" : "Validators",
+                  "description" : "List of message validators used to validate the message.",
+                  "$comment" : "group:advanced"
+                }
+              },
+              "required" : [ "message" ],
+              "additionalProperties" : false,
+              "title" : "ReceiveResponse",
+              "description" : "Receives a SOAP response as a client."
+            },
+            "sendFault" : {
+              "type" : "object",
+              "properties" : {
+                "extract" : {
+                  "allOf" : [ {
+                    "$ref" : "#/definitions/Extract"
+                  }, {
+                    "title" : "Extract",
+                    "description" : "Extract message content to test variables.",
+                    "$comment" : "group:advanced"
+                  } ]
+                },
+                "message" : {
+                  "type" : "object",
+                  "properties" : {
+                    "attachments" : {
+                      "title" : "Attachments",
+                      "description" : "List of SOAP attachments for this message.",
+                      "$comment" : "group:advanced",
+                      "type" : "array",
+                      "items" : {
+                        "allOf" : [ {
+                          "$ref" : "#/definitions/Attachment"
+                        }, {
+                          "title" : "Attachments",
+                          "description" : "List of SOAP attachments for this message.",
+                          "$comment" : "group:advanced"
+                        } ]
+                      }
+                    },
+                    "body" : {
+                      "allOf" : [ {
+                        "$ref" : "#/definitions/Body"
+                      }, {
+                        "title" : "Body",
+                        "description" : "The message body."
+                      } ]
+                    },
+                    "contentType" : {
+                      "type" : "string",
+                      "title" : "ContentType",
+                      "description" : "The SOAP response content type."
+                    },
+                    "dataDictionary" : {
+                      "type" : "string",
+                      "title" : "DataDictionary",
+                      "description" : "Sets a data dictionary that transforms message content before it is being processed.",
+                      "$comment" : "group:dictionary"
+                    },
+                    "expression" : {
+                      "title" : "Expression",
+                      "description" : "List of path expressions to evaluate on the message content before processing the message.",
+                      "$comment" : "group:advanced",
+                      "type" : "array",
+                      "items" : {
+                        "allOf" : [ {
+                          "$ref" : "#/definitions/Expression"
+                        }, {
+                          "title" : "Expression",
+                          "description" : "List of path expressions to evaluate on the message content before processing the message.",
+                          "$comment" : "group:advanced"
+                        } ]
+                      }
+                    },
+                    "faultActor" : {
+                      "type" : "string",
+                      "title" : "FaultActor",
+                      "description" : "The SOAP fault actor.",
+                      "$comment" : "group:advanced"
+                    },
+                    "faultCode" : {
+                      "type" : "string",
+                      "title" : "FaultCode",
+                      "description" : "The SOAP fault code."
+                    },
+                    "faultDetails" : {
+                      "title" : "FaultDetails",
+                      "description" : "The SOAP fault details.",
+                      "$comment" : "group:advanced",
+                      "type" : "array",
+                      "items" : {
+                        "allOf" : [ {
+                          "$ref" : "#/definitions/SoapFaultDetail"
+                        }, {
+                          "title" : "FaultDetails",
+                          "description" : "The SOAP fault details.",
+                          "$comment" : "group:advanced"
+                        } ]
+                      }
+                    },
+                    "faultString" : {
+                      "type" : "string",
+                      "title" : "FaultString",
+                      "description" : "The SOAP fault string."
+                    },
+                    "headerIgnoreCase" : {
+                      "type" : "string",
+                      "title" : "HeaderIgnoreCase",
+                      "description" : "When enabled the header case is not verified.",
+                      "$comment" : "group:advanced"
+                    },
+                    "headers" : {
+                      "title" : "Headers",
+                      "description" : "The message headers.",
+                      "type" : "array",
+                      "items" : {
+                        "allOf" : [ {
+                          "$ref" : "#/definitions/Header"
+                        }, {
+                          "title" : "Headers",
+                          "description" : "The message headers."
+                        } ]
+                      }
+                    },
+                    "name" : {
+                      "type" : "string",
+                      "title" : "Name",
+                      "description" : "The message name. Named messages may be referenced in subsequent test steps."
+                    },
+                    "reasonPhrase" : {
+                      "type" : "string",
+                      "title" : "ReasonPhrase",
+                      "description" : "The SOAP response reason phrase.",
+                      "$comment" : "group:advanced"
+                    },
+                    "schema" : {
+                      "type" : "string",
+                      "title" : "Schema",
+                      "description" : "The reference to a schema in the bean registry that should be used for validation.",
+                      "$comment" : "group:schema"
+                    },
+                    "schemaRepository" : {
+                      "type" : "string",
+                      "title" : "SchemaRepository",
+                      "description" : "The schema repository holding the schema.",
+                      "$comment" : "group:schema"
+                    },
+                    "schemaValidation" : {
+                      "type" : "boolean",
+                      "title" : "SchemaValidation",
+                      "description" : "Enables the schema validation.",
+                      "$comment" : "group:schema"
+                    },
+                    "status" : {
+                      "type" : "string",
+                      "title" : "Status",
+                      "description" : "The SOAP response status."
+                    },
+                    "type" : {
+                      "type" : "string",
+                      "title" : "Type",
+                      "description" : "The message type. Gives the validator a hint which validatory are capable of performing proper message validation.",
+                      "$comment" : "group:advanced"
+                    },
+                    "version" : {
+                      "type" : "string",
+                      "title" : "Version",
+                      "description" : "The SOAP version.",
+                      "$comment" : "group:advanced"
+                    }
+                  },
+                  "additionalProperties" : false,
+                  "title" : "Message",
+                  "description" : "The SOAP fault response message to send."
+                }
+              },
+              "required" : [ "message" ],
+              "additionalProperties" : false,
+              "title" : "SendFault",
+              "description" : "Sends a SOAP fault response as a server"
+            },
+            "sendRequest" : {
+              "type" : "object",
+              "properties" : {
+                "extract" : {
+                  "allOf" : [ {
+                    "$ref" : "#/definitions/Extract"
+                  }, {
+                    "title" : "Extract",
+                    "description" : "Extract message content to test variables.",
+                    "$comment" : "group:advanced"
+                  } ]
+                },
+                "fork" : {
+                  "type" : "boolean",
+                  "title" : "Fork",
+                  "description" : "When enabled the send operation does not block while waiting for the response."
+                },
+                "message" : {
+                  "allOf" : [ {
+                    "$ref" : "#/definitions/SoapRequest"
+                  }, {
+                    "title" : "Message",
+                    "description" : "The SOAP request message."
+                  } ]
+                },
+                "uri" : {
+                  "type" : "string",
+                  "title" : "Uri",
+                  "description" : "Http endpoint URI overwrite.",
+                  "$comment" : "group:advanced"
+                }
+              },
+              "required" : [ "message" ],
+              "additionalProperties" : false,
+              "title" : "SendRequest",
+              "description" : "Sends a SOAP request as a client."
+            },
+            "sendResponse" : {
+              "type" : "object",
+              "properties" : {
+                "extract" : {
+                  "allOf" : [ {
+                    "$ref" : "#/definitions/Extract"
+                  }, {
+                    "title" : "Extract",
+                    "description" : "Extract message content to test variables.",
+                    "$comment" : "group:advanced"
+                  } ]
+                },
+                "message" : {
+                  "allOf" : [ {
+                    "$ref" : "#/definitions/SoapResponse"
+                  }, {
+                    "title" : "Message",
+                    "description" : "The SOAP response message to send."
+                  } ]
+                }
+              },
+              "required" : [ "message" ],
+              "additionalProperties" : false,
+              "title" : "SendResponse",
+              "description" : "Sends a SOAP response as a server."
+            },
+            "server" : {
+              "type" : "string",
+              "title" : "Server",
+              "description" : "Sets the SOAP Http server."
+            }
+          },
+          "additionalProperties" : false,
+          "title" : "Soap",
+          "description" : "SOAP Web Services related test actions."
+        },
+        "sql" : {
+          "type" : "object",
+          "properties" : {
+            "dataSource" : {
+              "type" : "string",
+              "title" : "DataSource"
+            },
+            "description" : {
+              "type" : "string",
+              "title" : "Description",
+              "description" : "Test action description printed when the action is executed.",
+              "$comment" : "group:advanced"
+            },
+            "extract" : {
+              "title" : "Extract",
+              "type" : "array",
+              "items" : {
+                "type" : "object",
+                "properties" : {
+                  "column" : {
+                    "type" : "string",
+                    "title" : "Column"
+                  },
+                  "variable" : {
+                    "type" : "string",
+                    "title" : "Variable"
+                  }
+                },
+                "additionalProperties" : false,
+                "title" : "Extract"
+              }
+            },
+            "ignoreErrors" : {
+              "type" : "boolean",
+              "title" : "IgnoreErrors"
+            },
+            "statements" : {
+              "title" : "Statements",
+              "type" : "array",
+              "items" : {
+                "type" : "object",
+                "properties" : {
+                  "file" : {
+                    "type" : "string",
+                    "title" : "File"
+                  },
+                  "statement" : {
+                    "type" : "string",
+                    "title" : "Statement"
+                  }
+                },
+                "additionalProperties" : false,
+                "title" : "Statements"
+              }
+            },
+            "transaction" : {
+              "type" : "object",
+              "properties" : {
+                "isolationLevel" : {
+                  "type" : "string",
+                  "title" : "IsolationLevel"
+                },
+                "manager" : {
+                  "type" : "string",
+                  "title" : "Manager"
+                },
+                "timeout" : {
+                  "type" : "string",
+                  "title" : "Timeout"
+                }
+              },
+              "additionalProperties" : false,
+              "title" : "Transaction"
+            },
+            "validate" : {
+              "title" : "Validate",
+              "type" : "array",
+              "items" : {
+                "type" : "object",
+                "properties" : {
+                  "column" : {
+                    "type" : "string",
+                    "title" : "Column"
+                  },
+                  "script" : {
+                    "type" : "object",
+                    "properties" : {
+                      "charset" : {
+                        "type" : "string",
+                        "title" : "Charset"
+                      },
+                      "file" : {
+                        "type" : "string",
+                        "title" : "File"
+                      },
+                      "type" : {
+                        "type" : "string",
+                        "title" : "Type"
+                      },
+                      "value" : {
+                        "type" : "string",
+                        "title" : "Value"
+                      }
+                    },
+                    "additionalProperties" : false,
+                    "title" : "Script"
+                  },
+                  "value" : {
+                    "type" : "string",
+                    "title" : "Value"
+                  },
+                  "values" : {
+                    "title" : "Values",
+                    "type" : "array",
+                    "items" : {
+                      "type" : "string",
+                      "title" : "Values"
+                    }
+                  }
+                },
+                "additionalProperties" : false,
+                "title" : "Validate"
+              }
+            }
+          },
+          "required" : [ "statements" ],
+          "additionalProperties" : false,
+          "title" : "Sql",
+          "description" : "SQL test actions."
+        },
+        "start" : {
+          "type" : "object",
+          "properties" : {
+            "server" : {
+              "type" : "string",
+              "title" : "Server",
+              "description" : "Uses an endpoint URI or references an endpoint name."
+            },
+            "servers" : {
+              "title" : "Servers",
+              "type" : "array",
+              "items" : {
+                "type" : "object",
+                "properties" : {
+                  "name" : {
+                    "type" : "string",
+                    "title" : "Name"
+                  }
+                },
+                "additionalProperties" : false,
+                "title" : "Servers"
+              }
+            }
+          },
+          "additionalProperties" : false,
+          "title" : "Start",
+          "description" : "Start server test action."
+        },
+        "stop" : {
+          "type" : "object",
+          "properties" : {
+            "server" : {
+              "type" : "string",
+              "title" : "Server",
+              "description" : "Uses an endpoint URI or references an endpoint name."
+            },
+            "servers" : {
+              "title" : "Servers",
+              "type" : "array",
+              "items" : {
+                "type" : "object",
+                "properties" : {
+                  "name" : {
+                    "type" : "string",
+                    "title" : "Name",
+                    "description" : "Uses an endpoint URI or references an endpoint name."
+                  }
+                },
+                "additionalProperties" : false,
+                "title" : "Servers"
+              }
+            }
+          },
+          "additionalProperties" : false,
+          "title" : "Stop",
+          "description" : "Stop server test action."
+        },
+        "stopTime" : {
+          "type" : "object",
+          "properties" : {
+            "description" : {
+              "type" : "string",
+              "title" : "Description",
+              "description" : "Test action description printed when the action is executed.",
+              "$comment" : "group:advanced"
+            },
+            "id" : {
+              "type" : "string",
+              "title" : "Id",
+              "description" : "The time line identifier."
+            },
+            "suffix" : {
+              "type" : "string",
+              "title" : "Suffix",
+              "description" : "Suffix added to the value test variable."
+            }
+          },
+          "additionalProperties" : false,
+          "title" : "StopTime",
+          "description" : "Stop time test action."
+        },
+        "stopTimer" : {
+          "type" : "object",
+          "properties" : {
+            "description" : {
+              "type" : "string",
+              "title" : "Description",
+              "description" : "Test action description printed when the action is executed.",
+              "$comment" : "group:advanced"
+            },
+            "id" : {
+              "type" : "string",
+              "title" : "Id",
+              "description" : "Name identifying the timer."
+            }
+          },
+          "required" : [ "id" ],
+          "additionalProperties" : false,
+          "title" : "StopTimer",
+          "description" : "Stop timer test action."
+        },
+        "testcontainers" : {
+          "type" : "object",
+          "properties" : {
+            "actor" : {
+              "type" : "string",
+              "title" : "Actor",
+              "$comment" : "group:advanced"
+            },
+            "compose" : {
+              "type" : "object",
+              "properties" : {
+                "down" : {
+                  "type" : "object",
+                  "properties" : {
+                    "name" : {
+                      "type" : "string",
+                      "title" : "Name"
+                    }
+                  },
+                  "required" : [ "name" ],
+                  "additionalProperties" : false,
+                  "title" : "Down"
+                },
+                "up" : {
+                  "type" : "object",
+                  "properties" : {
+                    "autoRemove" : {
+                      "type" : "boolean",
+                      "title" : "AutoRemove"
+                    },
+                    "exposedServices" : {
+                      "title" : "ExposedServices",
+                      "type" : "array",
+                      "items" : {
+                        "type" : "object",
+                        "properties" : {
+                          "name" : {
+                            "type" : "string",
+                            "title" : "Name"
+                          },
+                          "port" : {
+                            "type" : "integer",
+                            "title" : "Port"
+                          },
+                          "waitFor" : {
+                            "type" : "object",
+                            "properties" : {
+                              "disabled" : {
+                                "type" : "boolean",
+                                "title" : "Disabled"
+                              },
+                              "logMessage" : {
+                                "type" : "string",
+                                "title" : "LogMessage"
+                              },
+                              "url" : {
+                                "type" : "string",
+                                "title" : "Url"
+                              }
+                            },
+                            "additionalProperties" : false,
+                            "title" : "WaitFor"
+                          }
+                        },
+                        "additionalProperties" : false,
+                        "title" : "ExposedServices"
+                      }
+                    },
+                    "file" : {
+                      "type" : "string",
+                      "title" : "File"
+                    },
+                    "name" : {
+                      "type" : "string",
+                      "title" : "Name"
+                    },
+                    "startUpTimeout" : {
+                      "type" : "integer",
+                      "title" : "StartUpTimeout"
+                    }
+                  },
+                  "additionalProperties" : false,
+                  "title" : "Up"
+                }
+              },
+              "additionalProperties" : false,
+              "title" : "Compose"
+            },
+            "description" : {
+              "type" : "string",
+              "title" : "Description",
+              "description" : "Test action description printed when the action is executed.",
+              "$comment" : "group:advanced"
+            },
+            "start" : {
+              "type" : "object",
+              "properties" : {
+                "container" : {
+                  "type" : "object",
+                  "properties" : {
+                    "autoRemove" : {
+                      "type" : "boolean",
+                      "title" : "AutoRemove"
+                    },
+                    "command" : {
+                      "type" : "string",
+                      "title" : "Command"
+                    },
+                    "env" : {
+                      "title" : "Env",
+                      "type" : "array",
+                      "items" : {
+                        "allOf" : [ {
+                          "$ref" : "#/definitions/Variable"
+                        }, {
+                          "title" : "Env"
+                        } ]
+                      }
+                    },
+                    "exposedPorts" : {
+                      "title" : "ExposedPorts",
+                      "type" : "array",
+                      "items" : {
+                        "type" : "integer",
+                        "title" : "ExposedPorts"
+                      }
+                    },
+                    "image" : {
+                      "type" : "string",
+                      "title" : "Image"
+                    },
+                    "labels" : {
+                      "title" : "Labels",
+                      "type" : "array",
+                      "items" : {
+                        "allOf" : [ {
+                          "$ref" : "#/definitions/Label"
+                        }, {
+                          "title" : "Labels"
+                        } ]
+                      }
+                    },
+                    "name" : {
+                      "type" : "string",
+                      "title" : "Name"
+                    },
+                    "portBindings" : {
+                      "title" : "PortBindings",
+                      "type" : "array",
+                      "items" : {
+                        "type" : "string",
+                        "title" : "PortBindings"
+                      }
+                    },
+                    "serviceName" : {
+                      "type" : "string",
+                      "title" : "ServiceName"
+                    },
+                    "startUpTimeout" : {
+                      "type" : "integer",
+                      "title" : "StartUpTimeout"
+                    },
+                    "volumeMounts" : {
+                      "title" : "VolumeMounts",
+                      "type" : "array",
+                      "items" : {
+                        "allOf" : [ {
+                          "$ref" : "#/definitions/VolumeMount"
+                        }, {
+                          "title" : "VolumeMounts"
+                        } ]
+                      }
+                    },
+                    "waitFor" : {
+                      "allOf" : [ {
+                        "$ref" : "#/definitions/WaitFor"
+                      }, {
+                        "title" : "WaitFor"
+                      } ]
+                    }
+                  },
+                  "additionalProperties" : false,
+                  "title" : "Container"
+                },
+                "kafka" : {
+                  "type" : "object",
+                  "properties" : {
+                    "autoRemove" : {
+                      "type" : "boolean",
+                      "title" : "AutoRemove"
+                    },
+                    "command" : {
+                      "type" : "string",
+                      "title" : "Command"
+                    },
+                    "env" : {
+                      "title" : "Env",
+                      "type" : "array",
+                      "items" : {
+                        "allOf" : [ {
+                          "$ref" : "#/definitions/Variable"
+                        }, {
+                          "title" : "Env"
+                        } ]
+                      }
+                    },
+                    "exposedPorts" : {
+                      "title" : "ExposedPorts",
+                      "type" : "array",
+                      "items" : {
+                        "type" : "integer",
+                        "title" : "ExposedPorts"
+                      }
+                    },
+                    "image" : {
+                      "type" : "string",
+                      "title" : "Image"
+                    },
+                    "implementation" : {
+                      "type" : "string",
+                      "title" : "Implementation"
+                    },
+                    "labels" : {
+                      "title" : "Labels",
+                      "type" : "array",
+                      "items" : {
+                        "allOf" : [ {
+                          "$ref" : "#/definitions/Label"
+                        }, {
+                          "title" : "Labels"
+                        } ]
+                      }
+                    },
+                    "name" : {
+                      "type" : "string",
+                      "title" : "Name"
+                    },
+                    "port" : {
+                      "type" : "integer",
+                      "title" : "Port"
+                    },
+                    "portBindings" : {
+                      "title" : "PortBindings",
+                      "type" : "array",
+                      "items" : {
+                        "type" : "string",
+                        "title" : "PortBindings"
+                      }
+                    },
+                    "serviceName" : {
+                      "type" : "string",
+                      "title" : "ServiceName"
+                    },
+                    "startUpTimeout" : {
+                      "type" : "integer",
+                      "title" : "StartUpTimeout"
+                    },
+                    "version" : {
+                      "type" : "string",
+                      "title" : "Version"
+                    },
+                    "volumeMounts" : {
+                      "title" : "VolumeMounts",
+                      "type" : "array",
+                      "items" : {
+                        "allOf" : [ {
+                          "$ref" : "#/definitions/VolumeMount"
+                        }, {
+                          "title" : "VolumeMounts"
+                        } ]
+                      }
+                    },
+                    "waitFor" : {
+                      "allOf" : [ {
+                        "$ref" : "#/definitions/WaitFor"
+                      }, {
+                        "title" : "WaitFor"
+                      } ]
+                    }
+                  },
+                  "additionalProperties" : false,
+                  "title" : "Kafka"
+                },
+                "localstack" : {
+                  "type" : "object",
+                  "properties" : {
+                    "autoCreateClients" : {
+                      "type" : "boolean",
+                      "title" : "AutoCreateClients"
+                    },
+                    "autoRemove" : {
+                      "type" : "boolean",
+                      "title" : "AutoRemove"
+                    },
+                    "command" : {
+                      "type" : "string",
+                      "title" : "Command"
+                    },
+                    "env" : {
+                      "title" : "Env",
+                      "type" : "array",
+                      "items" : {
+                        "allOf" : [ {
+                          "$ref" : "#/definitions/Variable"
+                        }, {
+                          "title" : "Env"
+                        } ]
+                      }
+                    },
+                    "exposedPorts" : {
+                      "title" : "ExposedPorts",
+                      "type" : "array",
+                      "items" : {
+                        "type" : "integer",
+                        "title" : "ExposedPorts"
+                      }
+                    },
+                    "image" : {
+                      "type" : "string",
+                      "title" : "Image"
+                    },
+                    "labels" : {
+                      "title" : "Labels",
+                      "type" : "array",
+                      "items" : {
+                        "allOf" : [ {
+                          "$ref" : "#/definitions/Label"
+                        }, {
+                          "title" : "Labels"
+                        } ]
+                      }
+                    },
+                    "name" : {
+                      "type" : "string",
+                      "title" : "Name"
+                    },
+                    "options" : {
+                      "type" : "object",
+                      "title" : "Options",
+                      "additionalProperties" : {
+                        "type" : "string",
+                        "title" : "Options"
+                      }
+                    },
+                    "portBindings" : {
+                      "title" : "PortBindings",
+                      "type" : "array",
+                      "items" : {
+                        "type" : "string",
+                        "title" : "PortBindings"
+                      }
+                    },
+                    "serviceName" : {
+                      "type" : "string",
+                      "title" : "ServiceName"
+                    },
+                    "services" : {
+                      "title" : "Services",
+                      "type" : "array",
+                      "items" : {
+                        "type" : "string",
+                        "title" : "Services"
+                      }
+                    },
+                    "startUpTimeout" : {
+                      "type" : "integer",
+                      "title" : "StartUpTimeout"
+                    },
+                    "version" : {
+                      "type" : "string",
+                      "title" : "Version"
+                    },
+                    "volumeMounts" : {
+                      "title" : "VolumeMounts",
+                      "type" : "array",
+                      "items" : {
+                        "allOf" : [ {
+                          "$ref" : "#/definitions/VolumeMount"
+                        }, {
+                          "title" : "VolumeMounts"
+                        } ]
+                      }
+                    },
+                    "waitFor" : {
+                      "allOf" : [ {
+                        "$ref" : "#/definitions/WaitFor"
+                      }, {
+                        "title" : "WaitFor"
+                      } ]
+                    }
+                  },
+                  "additionalProperties" : false,
+                  "title" : "Localstack"
+                },
+                "mongodb" : {
+                  "type" : "object",
+                  "properties" : {
+                    "autoRemove" : {
+                      "type" : "boolean",
+                      "title" : "AutoRemove"
+                    },
+                    "command" : {
+                      "type" : "string",
+                      "title" : "Command"
+                    },
+                    "env" : {
+                      "title" : "Env",
+                      "type" : "array",
+                      "items" : {
+                        "allOf" : [ {
+                          "$ref" : "#/definitions/Variable"
+                        }, {
+                          "title" : "Env"
+                        } ]
+                      }
+                    },
+                    "exposedPorts" : {
+                      "title" : "ExposedPorts",
+                      "type" : "array",
+                      "items" : {
+                        "type" : "integer",
+                        "title" : "ExposedPorts"
+                      }
+                    },
+                    "image" : {
+                      "type" : "string",
+                      "title" : "Image"
+                    },
+                    "labels" : {
+                      "title" : "Labels",
+                      "type" : "array",
+                      "items" : {
+                        "allOf" : [ {
+                          "$ref" : "#/definitions/Label"
+                        }, {
+                          "title" : "Labels"
+                        } ]
+                      }
+                    },
+                    "name" : {
+                      "type" : "string",
+                      "title" : "Name"
+                    },
+                    "portBindings" : {
+                      "title" : "PortBindings",
+                      "type" : "array",
+                      "items" : {
+                        "type" : "string",
+                        "title" : "PortBindings"
+                      }
+                    },
+                    "serviceName" : {
+                      "type" : "string",
+                      "title" : "ServiceName"
+                    },
+                    "startUpTimeout" : {
+                      "type" : "integer",
+                      "title" : "StartUpTimeout"
+                    },
+                    "version" : {
+                      "type" : "string",
+                      "title" : "Version"
+                    },
+                    "volumeMounts" : {
+                      "title" : "VolumeMounts",
+                      "type" : "array",
+                      "items" : {
+                        "allOf" : [ {
+                          "$ref" : "#/definitions/VolumeMount"
+                        }, {
+                          "title" : "VolumeMounts"
+                        } ]
+                      }
+                    },
+                    "waitFor" : {
+                      "allOf" : [ {
+                        "$ref" : "#/definitions/WaitFor"
+                      }, {
+                        "title" : "WaitFor"
+                      } ]
+                    }
+                  },
+                  "additionalProperties" : false,
+                  "title" : "Mongodb"
+                },
+                "postgresql" : {
+                  "type" : "object",
+                  "properties" : {
+                    "autoRemove" : {
+                      "type" : "boolean",
+                      "title" : "AutoRemove"
+                    },
+                    "command" : {
+                      "type" : "string",
+                      "title" : "Command"
+                    },
+                    "dataSourceName" : {
+                      "type" : "string",
+                      "title" : "DataSourceName"
+                    },
+                    "database" : {
+                      "type" : "string",
+                      "title" : "Database"
+                    },
+                    "env" : {
+                      "title" : "Env",
+                      "type" : "array",
+                      "items" : {
+                        "allOf" : [ {
+                          "$ref" : "#/definitions/Variable"
+                        }, {
+                          "title" : "Env"
+                        } ]
+                      }
+                    },
+                    "exposedPorts" : {
+                      "title" : "ExposedPorts",
+                      "type" : "array",
+                      "items" : {
+                        "type" : "integer",
+                        "title" : "ExposedPorts"
+                      }
+                    },
+                    "image" : {
+                      "type" : "string",
+                      "title" : "Image"
+                    },
+                    "initScript" : {
+                      "type" : "object",
+                      "properties" : {
+                        "file" : {
+                          "type" : "string",
+                          "title" : "File"
+                        },
+                        "value" : {
+                          "type" : "string",
+                          "title" : "Value"
+                        }
+                      },
+                      "additionalProperties" : false,
+                      "title" : "InitScript"
+                    },
+                    "labels" : {
+                      "title" : "Labels",
+                      "type" : "array",
+                      "items" : {
+                        "allOf" : [ {
+                          "$ref" : "#/definitions/Label"
+                        }, {
+                          "title" : "Labels"
+                        } ]
+                      }
+                    },
+                    "name" : {
+                      "type" : "string",
+                      "title" : "Name"
+                    },
+                    "password" : {
+                      "type" : "string",
+                      "title" : "Password"
+                    },
+                    "portBindings" : {
+                      "title" : "PortBindings",
+                      "type" : "array",
+                      "items" : {
+                        "type" : "string",
+                        "title" : "PortBindings"
+                      }
+                    },
+                    "serviceName" : {
+                      "type" : "string",
+                      "title" : "ServiceName"
+                    },
+                    "startUpTimeout" : {
+                      "type" : "integer",
+                      "title" : "StartUpTimeout"
+                    },
+                    "username" : {
+                      "type" : "string",
+                      "title" : "Username"
+                    },
+                    "version" : {
+                      "type" : "string",
+                      "title" : "Version"
+                    },
+                    "volumeMounts" : {
+                      "title" : "VolumeMounts",
+                      "type" : "array",
+                      "items" : {
+                        "allOf" : [ {
+                          "$ref" : "#/definitions/VolumeMount"
+                        }, {
+                          "title" : "VolumeMounts"
+                        } ]
+                      }
+                    },
+                    "waitFor" : {
+                      "allOf" : [ {
+                        "$ref" : "#/definitions/WaitFor"
+                      }, {
+                        "title" : "WaitFor"
+                      } ]
+                    }
+                  },
+                  "additionalProperties" : false,
+                  "title" : "Postgresql"
+                },
+                "redpanda" : {
+                  "type" : "object",
+                  "properties" : {
+                    "autoRemove" : {
+                      "type" : "boolean",
+                      "title" : "AutoRemove"
+                    },
+                    "command" : {
+                      "type" : "string",
+                      "title" : "Command"
+                    },
+                    "env" : {
+                      "title" : "Env",
+                      "type" : "array",
+                      "items" : {
+                        "allOf" : [ {
+                          "$ref" : "#/definitions/Variable"
+                        }, {
+                          "title" : "Env"
+                        } ]
+                      }
+                    },
+                    "exposedPorts" : {
+                      "title" : "ExposedPorts",
+                      "type" : "array",
+                      "items" : {
+                        "type" : "integer",
+                        "title" : "ExposedPorts"
+                      }
+                    },
+                    "image" : {
+                      "type" : "string",
+                      "title" : "Image"
+                    },
+                    "labels" : {
+                      "title" : "Labels",
+                      "type" : "array",
+                      "items" : {
+                        "allOf" : [ {
+                          "$ref" : "#/definitions/Label"
+                        }, {
+                          "title" : "Labels"
+                        } ]
+                      }
+                    },
+                    "name" : {
+                      "type" : "string",
+                      "title" : "Name"
+                    },
+                    "portBindings" : {
+                      "title" : "PortBindings",
+                      "type" : "array",
+                      "items" : {
+                        "type" : "string",
+                        "title" : "PortBindings"
+                      }
+                    },
+                    "serviceName" : {
+                      "type" : "string",
+                      "title" : "ServiceName"
+                    },
+                    "startUpTimeout" : {
+                      "type" : "integer",
+                      "title" : "StartUpTimeout"
+                    },
+                    "version" : {
+                      "type" : "string",
+                      "title" : "Version"
+                    },
+                    "volumeMounts" : {
+                      "title" : "VolumeMounts",
+                      "type" : "array",
+                      "items" : {
+                        "allOf" : [ {
+                          "$ref" : "#/definitions/VolumeMount"
+                        }, {
+                          "title" : "VolumeMounts"
+                        } ]
+                      }
+                    },
+                    "waitFor" : {
+                      "allOf" : [ {
+                        "$ref" : "#/definitions/WaitFor"
+                      }, {
+                        "title" : "WaitFor"
+                      } ]
+                    }
+                  },
+                  "additionalProperties" : false,
+                  "title" : "Redpanda"
+                }
+              },
+              "additionalProperties" : false,
+              "title" : "Start"
+            },
+            "stop" : {
+              "type" : "object",
+              "properties" : {
+                "name" : {
+                  "type" : "string",
+                  "title" : "Name"
+                }
+              },
+              "additionalProperties" : false,
+              "title" : "Stop"
+            }
+          },
+          "additionalProperties" : false,
+          "title" : "Testcontainers",
+          "description" : "Testcontainers test actions."
+        },
+        "timer" : {
+          "type" : "object",
+          "properties" : {
+            "actions" : {
+              "title" : "Actions",
+              "description" : "Sequence of test actions to execute.",
+              "type" : "array",
+              "items" : {
+                "allOf" : [ {
+                  "$ref" : "#/definitions/TestActionBuilder_Object_"
+                }, {
+                  "title" : "Actions",
+                  "description" : "Sequence of test actions to execute."
+                } ]
+              }
+            },
+            "autoStop" : {
+              "type" : "boolean",
+              "title" : "AutoStop",
+              "description" : "Automatically stop the timer when the test is finished.",
+              "default" : "true",
+              "$comment" : "group:advanced"
+            },
+            "delay" : {
+              "type" : "integer",
+              "title" : "Delay",
+              "description" : "Initial delay to wait before starting the timer.",
+              "$comment" : "group:advanced"
+            },
+            "description" : {
+              "type" : "string",
+              "title" : "Description",
+              "description" : "Test action description printed when the action is executed.",
+              "$comment" : "group:advanced"
+            },
+            "fork" : {
+              "type" : "boolean",
+              "title" : "Fork",
+              "description" : "Do not block the test while the timer is running.",
+              "default" : "false",
+              "$comment" : "group:advanced"
+            },
+            "id" : {
+              "type" : "string",
+              "title" : "Id",
+              "description" : "The id of the timer."
+            },
+            "interval" : {
+              "type" : "integer",
+              "title" : "Interval",
+              "description" : "Timer interval in milliseconds.",
+              "default" : "1000"
+            },
+            "repeatCount" : {
+              "type" : "integer",
+              "title" : "RepeatCount",
+              "description" : "Number of timer executions.",
+              "$comment" : "group:advanced"
+            }
+          },
+          "required" : [ "actions" ],
+          "additionalProperties" : false,
+          "title" : "Timer",
+          "description" : "Timer test action."
+        },
+        "trace" : {
+          "type" : "object",
+          "properties" : {
+            "variable" : {
+              "type" : "string",
+              "title" : "Variable",
+              "description" : "Name of the test variable to include."
+            },
+            "variables" : {
+              "title" : "Variables",
+              "description" : "Test variable names to include.",
+              "type" : "array",
+              "items" : {
+                "type" : "object",
+                "properties" : {
+                  "name" : {
+                    "type" : "string",
+                    "title" : "Name"
+                  }
+                },
+                "required" : [ "name" ],
+                "additionalProperties" : false,
+                "title" : "Variables",
+                "description" : "Test variable names to include."
+              }
+            }
+          },
+          "additionalProperties" : false,
+          "title" : "Trace",
+          "description" : "Trace variables test action."
+        },
+        "transform" : {
+          "type" : "object",
+          "properties" : {
+            "description" : {
+              "type" : "string",
+              "title" : "Description",
+              "description" : "Test action description printed when the action is executed.",
+              "$comment" : "group:advanced"
+            },
+            "result" : {
+              "type" : "string",
+              "title" : "Result",
+              "description" : "Set the target variable for the result."
+            },
+            "source" : {
+              "type" : "object",
+              "properties" : {
+                "charset" : {
+                  "type" : "string",
+                  "title" : "Charset",
+                  "description" : "Optional charset used when reading the file.",
+                  "$comment" : "group:advanced"
+                },
+                "file" : {
+                  "type" : "string",
+                  "title" : "File",
+                  "description" : "The XML document file."
+                },
+                "value" : {
+                  "type" : "string",
+                  "title" : "Value",
+                  "description" : "XML document as inline data."
+                }
+              },
+              "additionalProperties" : false,
+              "title" : "Source",
+              "description" : "The XML document to transform"
+            },
+            "variable" : {
+              "type" : "string",
+              "title" : "Variable",
+              "description" : "Set the target variable for the result."
+            },
+            "xslt" : {
+              "type" : "object",
+              "properties" : {
+                "charset" : {
+                  "type" : "string",
+                  "title" : "Charset",
+                  "description" : "Optional charset used when reading the file.",
+                  "$comment" : "group:advanced"
+                },
+                "file" : {
+                  "type" : "string",
+                  "title" : "File",
+                  "description" : "The XSLT document file."
+                },
+                "value" : {
+                  "type" : "string",
+                  "title" : "Value",
+                  "description" : "The XSLT document as inline data."
+                }
+              },
+              "additionalProperties" : false,
+              "title" : "Xslt",
+              "description" : "The XSLT document performing the transformation."
+            }
+          },
+          "required" : [ "xslt" ],
+          "additionalProperties" : false,
+          "title" : "Transform",
+          "description" : "Transform test action."
+        },
+        "waitFor" : {
+          "type" : "object",
+          "properties" : {
+            "action" : { },
+            "description" : {
+              "type" : "string",
+              "title" : "Description",
+              "description" : "Test action description printed when the action is executed.",
+              "$comment" : "group:advanced"
+            },
+            "file" : { },
+            "http" : { },
+            "interval" : {
+              "type" : "string",
+              "title" : "Interval",
+              "description" : "Interval in milliseconds to check for the given wait condition."
+            },
+            "message" : { },
+            "timeout" : {
+              "type" : "string",
+              "title" : "Timeout",
+              "description" : "Time to wait for the condition to become satisfied."
+            }
+          },
+          "additionalProperties" : false,
+          "anyOf" : [ {
+            "oneOf" : [ {
+              "type" : "object",
+              "properties" : {
+                "message" : {
+                  "type" : "object",
+                  "properties" : {
+                    "name" : {
+                      "type" : "string",
+                      "title" : "Name",
+                      "description" : "Message name in the message store."
+                    }
+                  },
+                  "additionalProperties" : false,
+                  "title" : "Message",
+                  "description" : "Wait for given message to exist in message store."
+                }
+              },
+              "required" : [ "message" ]
+            }, {
+              "type" : "object",
+              "properties" : {
+                "http" : {
+                  "type" : "object",
+                  "properties" : {
+                    "method" : {
+                      "type" : "string",
+                      "title" : "Method",
+                      "description" : "The Http request method to use."
+                    },
+                    "status" : {
+                      "type" : "string",
+                      "title" : "Status",
+                      "description" : "The expected Http status code."
+                    },
+                    "timeout" : {
+                      "type" : "string",
+                      "title" : "Timeout",
+                      "description" : "Http request timeout."
+                    },
+                    "url" : {
+                      "type" : "string",
+                      "title" : "Url",
+                      "description" : "Http request URL."
+                    }
+                  },
+                  "additionalProperties" : false,
+                  "title" : "Http",
+                  "description" : "Wait for given Http endpoint to return a proper response code."
+                }
+              },
+              "required" : [ "http" ]
+            }, {
+              "type" : "object",
+              "properties" : {
+                "file" : {
+                  "type" : "object",
+                  "properties" : {
+                    "path" : {
+                      "type" : "string",
+                      "title" : "Path",
+                      "description" : "File path to evaluate."
+                    }
+                  },
+                  "additionalProperties" : false,
+                  "title" : "File",
+                  "description" : "Wait for given file path to exist."
+                }
+              },
+              "required" : [ "file" ]
+            }, {
+              "type" : "object",
+              "properties" : {
+                "action" : {
+                  "allOf" : [ {
+                    "$ref" : "#/definitions/TestActionBuilder_Object_"
+                  }, {
+                    "title" : "Action",
+                    "description" : "Waits for the test action to complete."
+                  } ]
+                }
+              },
+              "required" : [ "action" ]
+            } ]
+          } ],
+          "title" : "WaitFor",
+          "description" : "Wait for test action."
+        }
+      }
+    },
+    "Validate" : {
+      "type" : "object",
+      "properties" : {
+        "jsonPath" : {
+          "title" : "JsonPath",
+          "description" : "JsonPath validation expression.",
+          "$comment" : "group:jsonPath",
+          "type" : "array",
+          "items" : {
+            "type" : "object",
+            "properties" : {
+              "expression" : {
+                "type" : "string",
+                "title" : "Expression",
+                "description" : "The Json path expression to evaluate."
+              },
+              "value" : {
+                "type" : "string",
+                "title" : "Value",
+                "description" : "The expected result."
+              }
+            },
+            "required" : [ "expression", "value" ],
+            "additionalProperties" : false,
+            "title" : "JsonPath",
+            "description" : "JsonPath validation expression.",
+            "$comment" : "group:jsonPath"
+          }
+        },
+        "namespace" : {
+          "title" : "Namespace",
+          "description" : "List of expected namespaces.",
+          "$comment" : "group:xml",
+          "type" : "array",
+          "items" : {
+            "type" : "object",
+            "properties" : {
+              "prefix" : {
+                "type" : "string",
+                "title" : "Prefix",
+                "description" : "The expected namespace prefix."
+              },
+              "value" : {
+                "type" : "string",
+                "title" : "Value",
+                "description" : "The expected namespace value."
+              }
+            },
+            "required" : [ "prefix", "value" ],
+            "additionalProperties" : false,
+            "title" : "Namespace",
+            "description" : "List of expected namespaces.",
+            "$comment" : "group:xml"
+          }
+        },
+        "path" : {
+          "type" : "string",
+          "title" : "Path",
+          "description" : "Message validation expression."
+        },
+        "resultType" : {
+          "type" : "string",
+          "title" : "ResultType",
+          "description" : "Expected expression result type.",
+          "$comment" : "group:advanced"
+        },
+        "script" : {
+          "type" : "object",
+          "properties" : {
+            "charset" : {
+              "type" : "string",
+              "title" : "Charset",
+              "description" : "The charset used to load the file resource.",
+              "$comment" : "group:advanced"
+            },
+            "content" : {
+              "type" : "string",
+              "title" : "Content",
+              "description" : "The script content as inline data."
+            },
+            "file" : {
+              "type" : "string",
+              "title" : "File",
+              "description" : "The script content loaded as a file resource."
+            },
+            "type" : {
+              "type" : "string",
+              "title" : "Type",
+              "description" : "The script type.",
+              "default" : "groovy"
+            }
+          },
+          "additionalProperties" : false,
+          "title" : "Script",
+          "description" : "Script that builds the expected validate value.",
+          "$comment" : "group:script"
+        },
+        "value" : {
+          "type" : "string",
+          "title" : "Value",
+          "description" : "Expected message validation expression value."
+        },
+        "xpath" : {
+          "title" : "Xpath",
+          "description" : "Xpath validation expression.",
+          "$comment" : "group:xml",
+          "type" : "array",
+          "items" : {
+            "type" : "object",
+            "properties" : {
+              "expression" : {
+                "type" : "string",
+                "title" : "Expression",
+                "description" : "The Xpath expression to evaluate."
+              },
+              "resultType" : {
+                "type" : "string",
+                "title" : "ResultType",
+                "description" : "The expected result type.",
+                "$comment" : "group:advanced"
+              },
+              "value" : {
+                "type" : "string",
+                "title" : "Value",
+                "description" : "The expected result."
+              }
+            },
+            "required" : [ "expression", "value" ],
+            "additionalProperties" : false,
+            "title" : "Xpath",
+            "description" : "Xpath validation expression.",
+            "$comment" : "group:xml"
+          }
+        }
+      },
+      "additionalProperties" : false
+    },
+    "Variable" : {
+      "type" : "object",
+      "properties" : {
+        "name" : {
+          "type" : "string",
+          "title" : "Name"
+        },
+        "value" : {
+          "type" : "string",
+          "title" : "Value"
+        }
+      },
+      "additionalProperties" : false
+    },
+    "VolumeMount" : {
+      "type" : "object",
+      "properties" : {
+        "file" : {
+          "type" : "string",
+          "title" : "File"
+        },
+        "mountPath" : {
+          "type" : "string",
+          "title" : "MountPath"
+        }
+      },
+      "additionalProperties" : false
+    },
+    "WaitFor" : {
+      "type" : "object",
+      "properties" : {
+        "disabled" : {
+          "type" : "boolean",
+          "title" : "Disabled"
+        },
+        "logMessage" : {
+          "type" : "string",
+          "title" : "LogMessage"
+        },
+        "url" : {
+          "type" : "string",
+          "title" : "Url"
+        }
+      },
+      "additionalProperties" : false
+    }
+  },
+  "type" : "object",
+  "properties" : {
+    "actions" : {
+      "title" : "Actions",
+      "description" : "The test actions.",
+      "$comment" : "group:actions",
+      "type" : "array",
+      "items" : {
+        "allOf" : [ {
+          "$ref" : "#/definitions/TestActions"
+        }, {
+          "title" : "Actions",
+          "description" : "The test actions.",
+          "$comment" : "group:actions"
+        } ]
+      }
+    },
+    "author" : {
+      "type" : "string",
+      "title" : "Author",
+      "description" : "The test author.",
+      "$comment" : "group:metaData"
+    },
+    "description" : {
+      "type" : "string",
+      "title" : "Description",
+      "description" : "The test description.",
+      "$comment" : "group:metaData"
+    },
+    "endpoints" : {
+      "title" : "Endpoints",
+      "description" : "List of endpoints for this test.",
+      "$comment" : "group:endpoints",
+      "type" : "array",
+      "items" : {
+        "type" : "object",
+        "properties" : {
+          "camel" : { },
+          "channel" : { },
+          "context" : { },
+          "direct" : { },
+          "docker" : { },
+          "ftp" : { },
+          "http" : { },
+          "jms" : { },
+          "kafka" : { },
+          "kubernetes" : { },
+          "mail" : { },
+          "name" : {
+            "type" : "string",
+            "title" : "Name",
+            "description" : "The endpoint name. When set the endpoint is registered in the bean registry for later reference.",
+            "$comment" : "group:generic"
+          },
+          "properties" : {
+            "type" : "object",
+            "title" : "Properties",
+            "description" : "The endpoint properties.",
+            "additionalProperties" : {
+              "type" : "string",
+              "title" : "Properties",
+              "description" : "The endpoint properties.",
+              "$comment" : "group:generic"
+            },
+            "$comment" : "group:generic"
+          },
+          "scp" : { },
+          "selenium" : { },
+          "sftp" : { },
+          "soap" : { },
+          "type" : {
+            "type" : "string",
+            "title" : "Type",
+            "description" : "The endpoint type.",
+            "$comment" : "group:generic"
+          },
+          "vertx" : { },
+          "webSocket" : { }
+        },
+        "additionalProperties" : false,
+        "anyOf" : [ {
+          "oneOf" : [ {
+            "type" : "object",
+            "properties" : {
+              "http" : {
+                "type" : "object",
+                "properties" : {
+                  "client" : { },
+                  "server" : { }
+                },
+                "additionalProperties" : false,
+                "anyOf" : [ {
+                  "oneOf" : [ {
+                    "type" : "object",
+                    "properties" : {
+                      "client" : {
+                        "type" : "object",
+                        "properties" : {
+                          "authentication" : {
+                            "type" : "string",
+                            "title" : "Authentication",
+                            "description" : "Use given authentication mechanism.",
+                            "$comment" : "group:security"
+                          },
+                          "binaryMediaTypes" : {
+                            "title" : "BinaryMediaTypes",
+                            "description" : "Sets the list of binary media types.",
+                            "$comment" : "group:advanced",
+                            "type" : "array",
+                            "items" : {
+                              "type" : "string",
+                              "title" : "BinaryMediaTypes",
+                              "description" : "Sets the list of binary media types.",
+                              "$comment" : "group:advanced"
+                            }
+                          },
+                          "charset" : {
+                            "type" : "string",
+                            "title" : "Charset",
+                            "description" : "The default charset.",
+                            "$comment" : "group:advanced"
+                          },
+                          "contentType" : {
+                            "type" : "string",
+                            "title" : "ContentType",
+                            "description" : "Sets the default content type header set for each request.",
+                            "$comment" : "group:advanced"
+                          },
+                          "correlator" : {
+                            "type" : "string",
+                            "title" : "Correlator",
+                            "description" : "Sets the message correlator.",
+                            "$comment" : "group:advanced"
+                          },
+                          "defaultAcceptHeader" : {
+                            "type" : "boolean",
+                            "title" : "DefaultAcceptHeader",
+                            "description" : "When enabled the client adds the default accept header to requests.",
+                            "$comment" : "group:advanced"
+                          },
+                          "disableRedirectHandling" : {
+                            "type" : "boolean",
+                            "title" : "DisableRedirectHandling",
+                            "description" : "Disables the redirect handling for this client.",
+                            "$comment" : "group:advanced"
+                          },
+                          "endpointResolver" : {
+                            "type" : "string",
+                            "title" : "EndpointResolver",
+                            "description" : "Sets the endpoint URI resolver.",
+                            "$comment" : "group:advanced"
+                          },
+                          "errorHandler" : {
+                            "type" : "string",
+                            "title" : "ErrorHandler",
+                            "description" : "Sets a custom error handler.",
+                            "$comment" : "group:errorHandling"
+                          },
+                          "errorHandlingStrategy" : {
+                            "allOf" : [ {
+                              "$ref" : "#/definitions/ErrorHandlingStrategy"
+                            }, {
+                              "title" : "ErrorHandlingStrategy",
+                              "description" : "Sets the error handling strategy.",
+                              "$comment" : "group:errorHandling"
+                            } ]
+                          },
+                          "handleCookies" : {
+                            "type" : "boolean",
+                            "title" : "HandleCookies",
+                            "description" : "When enabled the client handles cookies.",
+                            "$comment" : "group:advanced"
+                          },
+                          "headerMapper" : {
+                            "type" : "string",
+                            "title" : "HeaderMapper",
+                            "description" : "Sets a custom header mapper bean reference.",
+                            "$comment" : "group:advanced"
+                          },
+                          "interceptor" : {
+                            "type" : "string",
+                            "title" : "Interceptor",
+                            "description" : "Sets a client interceptor.",
+                            "$comment" : "group:intercept"
+                          },
+                          "interceptors" : {
+                            "title" : "Interceptors",
+                            "description" : "Sets the list of client interceptor bean references.",
+                            "$comment" : "group:intercept",
+                            "type" : "array",
+                            "items" : {
+                              "type" : "string",
+                              "title" : "Interceptors",
+                              "description" : "Sets the list of client interceptor bean references.",
+                              "$comment" : "group:intercept"
+                            }
+                          },
+                          "messageConverter" : {
+                            "type" : "string",
+                            "title" : "MessageConverter",
+                            "description" : "Bean reference to a message converter.",
+                            "$comment" : "group:advanced"
+                          },
+                          "name" : {
+                            "type" : "string",
+                            "title" : "Name",
+                            "description" : "The name of the endpoint"
+                          },
+                          "pollingInterval" : {
+                            "type" : "integer",
+                            "title" : "PollingInterval",
+                            "description" : "Sets the polling interval when consuming messages.",
+                            "$comment" : "group:advanced"
+                          },
+                          "requestFactory" : {
+                            "type" : "string",
+                            "title" : "RequestFactory",
+                            "description" : "Reference to a request factory.",
+                            "$comment" : "group:advanced"
+                          },
+                          "requestMethod" : {
+                            "allOf" : [ {
+                              "$ref" : "#/definitions/RequestMethod"
+                            }, {
+                              "title" : "RequestMethod",
+                              "description" : "The default request method to use"
+                            } ]
+                          },
+                          "requestUrl" : {
+                            "type" : "string",
+                            "title" : "RequestUrl",
+                            "description" : "Sets the Http client request URL."
+                          },
+                          "restTemplate" : {
+                            "type" : "string",
+                            "title" : "RestTemplate",
+                            "description" : "The reference to a REST template bean.",
+                            "$comment" : "group:advanced"
+                          },
+                          "securedConnection" : {
+                            "type" : "string",
+                            "title" : "SecuredConnection",
+                            "description" : "Secure the connection with given security mechanism.",
+                            "$comment" : "group:security"
+                          },
+                          "timeout" : {
+                            "type" : "integer",
+                            "title" : "Timeout",
+                            "description" : "The Http request timeout while waiting for a response",
+                            "default" : "5000"
+                          }
+                        },
+                        "additionalProperties" : false,
+                        "title" : "Client",
+                        "description" : "Sets the Http client endpoint."
+                      }
+                    },
+                    "required" : [ "client" ]
+                  }, {
+                    "type" : "object",
+                    "properties" : {
+                      "server" : {
+                        "type" : "object",
+                        "properties" : {
+                          "authentication" : {
+                            "type" : "string",
+                            "title" : "Authentication",
+                            "description" : "Use given authentication mechanism for all request paths.",
+                            "$comment" : "group:security"
+                          },
+                          "autoStart" : {
+                            "type" : "boolean",
+                            "title" : "AutoStart",
+                            "description" : "When enabled the server is automatically started after creation."
+                          },
+                          "binaryMediaTypes" : {
+                            "title" : "BinaryMediaTypes",
+                            "description" : "List of supported media types on this server.",
+                            "$comment" : "group:advanced",
+                            "type" : "array",
+                            "items" : {
+                              "type" : "string",
+                              "title" : "BinaryMediaTypes",
+                              "description" : "List of supported media types on this server.",
+                              "$comment" : "group:advanced"
+                            }
+                          },
+                          "connector" : {
+                            "type" : "string",
+                            "title" : "Connector",
+                            "description" : "Add a connector to this server.",
+                            "$comment" : "group:servlet"
+                          },
+                          "connectors" : {
+                            "title" : "Connectors",
+                            "description" : "Sets a list of connectors for this server.",
+                            "$comment" : "group:servlet",
+                            "type" : "array",
+                            "items" : {
+                              "type" : "string",
+                              "title" : "Connectors",
+                              "description" : "Sets a list of connectors for this server.",
+                              "$comment" : "group:servlet"
+                            }
+                          },
+                          "contextConfigLocation" : {
+                            "type" : "string",
+                            "title" : "ContextConfigLocation",
+                            "description" : "Sets the Spring context configuration loaded for this Http server.",
+                            "$comment" : "group:advanced"
+                          },
+                          "contextPath" : {
+                            "type" : "string",
+                            "title" : "ContextPath",
+                            "description" : "Sets the context path on this server.",
+                            "$comment" : "group:servlet"
+                          },
+                          "debugLogging" : {
+                            "type" : "boolean",
+                            "title" : "DebugLogging",
+                            "description" : "When enabled the server prints debug logging output.",
+                            "$comment" : "group:advanced"
+                          },
+                          "defaultStatus" : {
+                            "allOf" : [ {
+                              "$ref" : "#/definitions/HttpStatus"
+                            }, {
+                              "title" : "DefaultStatus",
+                              "description" : "Sets the default status returned by the server.",
+                              "$comment" : "group:advanced"
+                            } ]
+                          },
+                          "endpointAdapter" : {
+                            "type" : "string",
+                            "title" : "EndpointAdapter",
+                            "description" : "Sets a custom endpoint adapter to handle requests.",
+                            "$comment" : "group:advanced"
+                          },
+                          "filterMappings" : {
+                            "type" : "object",
+                            "title" : "FilterMappings",
+                            "description" : "Filter mapping used on this server.",
+                            "additionalProperties" : {
+                              "type" : "string",
+                              "title" : "FilterMappings",
+                              "description" : "Filter mapping used on this server.",
+                              "$comment" : "group:filter"
+                            },
+                            "$comment" : "group:filter"
+                          },
+                          "filters" : {
+                            "type" : "object",
+                            "title" : "Filters",
+                            "description" : "Map of Http filters used on this server.",
+                            "additionalProperties" : {
+                              "type" : "string",
+                              "title" : "Filters",
+                              "description" : "Map of Http filters used on this server.",
+                              "$comment" : "group:filter"
+                            },
+                            "$comment" : "group:filter"
+                          },
+                          "handleAttributeHeaders" : {
+                            "type" : "boolean",
+                            "title" : "HandleAttributeHeaders",
+                            "description" : "When enabled the server handles attribute headers.",
+                            "$comment" : "group:advanced"
+                          },
+                          "handleCookies" : {
+                            "type" : "boolean",
+                            "title" : "HandleCookies",
+                            "description" : "When enabled the server handles cookies.",
+                            "$comment" : "group:advanced"
+                          },
+                          "interceptor" : {
+                            "type" : "string",
+                            "title" : "Interceptor",
+                            "description" : "Sets a handler interceptor.",
+                            "$comment" : "group:intercept"
+                          },
+                          "interceptors" : {
+                            "title" : "Interceptors",
+                            "description" : "Sets the list of handler interceptor bean references.",
+                            "$comment" : "group:intercept",
+                            "type" : "array",
+                            "items" : {
+                              "type" : "string",
+                              "title" : "Interceptors",
+                              "description" : "Sets the list of handler interceptor bean references.",
+                              "$comment" : "group:intercept"
+                            }
+                          },
+                          "messageConverter" : {
+                            "type" : "string",
+                            "title" : "MessageConverter",
+                            "description" : "Sets the Http message converter bean reference.",
+                            "$comment" : "group:advanced"
+                          },
+                          "name" : {
+                            "type" : "string",
+                            "title" : "Name",
+                            "description" : "The name of the endpoint"
+                          },
+                          "port" : {
+                            "type" : "integer",
+                            "title" : "Port",
+                            "description" : "The Http server port."
+                          },
+                          "removeSemicolonPathContent" : {
+                            "type" : "boolean",
+                            "title" : "RemoveSemicolonPathContent",
+                            "description" : "When enabled the server removes semicolon path content from headers.",
+                            "$comment" : "group:advanced"
+                          },
+                          "resourceBase" : {
+                            "type" : "string",
+                            "title" : "ResourceBase",
+                            "description" : "The server resource base path where resources get loaded from.",
+                            "$comment" : "group:advanced"
+                          },
+                          "responseCacheSize" : {
+                            "type" : "integer",
+                            "title" : "ResponseCacheSize",
+                            "description" : "Sets the response cache size.",
+                            "$comment" : "group:advanced"
+                          },
+                          "rootParentContext" : {
+                            "type" : "boolean",
+                            "title" : "RootParentContext",
+                            "description" : "When enabled the server uses the root Spring application context.",
+                            "$comment" : "group:advanced"
+                          },
+                          "securePort" : {
+                            "type" : "integer",
+                            "title" : "SecurePort",
+                            "description" : "The secured port.",
+                            "$comment" : "group:security"
+                          },
+                          "securedConnection" : {
+                            "type" : "string",
+                            "title" : "SecuredConnection",
+                            "description" : "Secure the connections on given secured port with given security mechanism.",
+                            "$comment" : "group:security"
+                          },
+                          "securityHandler" : {
+                            "type" : "string",
+                            "title" : "SecurityHandler",
+                            "description" : "Sets the security handler as a bean reference.",
+                            "$comment" : "group:security"
+                          },
+                          "serServletHandler" : {
+                            "type" : "string",
+                            "title" : "SerServletHandler",
+                            "description" : "Sets a custom servlet handler as a bean reference.",
+                            "$comment" : "group:servlet"
+                          },
+                          "servletMappingPath" : {
+                            "type" : "string",
+                            "title" : "ServletMappingPath",
+                            "description" : "Sets the servlet mapping path.",
+                            "$comment" : "group:servlet"
+                          },
+                          "servletName" : {
+                            "type" : "string",
+                            "title" : "ServletName",
+                            "description" : "Sets the servlet name.",
+                            "$comment" : "group:servlet"
+                          },
+                          "timeout" : {
+                            "type" : "integer",
+                            "title" : "Timeout",
+                            "description" : "Sets the server timeout while waiting for incoming requests.",
+                            "default" : "5000"
+                          },
+                          "useDefaultFilters" : {
+                            "type" : "boolean",
+                            "title" : "UseDefaultFilters",
+                            "description" : "When enabled the server uses the default set of Http servlet filters.",
+                            "$comment" : "group:filter"
+                          }
+                        },
+                        "additionalProperties" : false,
+                        "title" : "Server",
+                        "description" : "Sets the Http server endpoint."
+                      }
+                    },
+                    "required" : [ "server" ]
+                  } ]
+                } ],
+                "title" : "Http",
+                "description" : "Http client and server endpoints"
+              }
+            },
+            "required" : [ "http" ]
+          }, {
+            "type" : "object",
+            "properties" : {
+              "soap" : {
+                "type" : "object",
+                "properties" : {
+                  "client" : { },
+                  "server" : { }
+                },
+                "additionalProperties" : false,
+                "anyOf" : [ {
+                  "oneOf" : [ {
+                    "type" : "object",
+                    "properties" : {
+                      "client" : {
+                        "type" : "object",
+                        "properties" : {
+                          "correlator" : {
+                            "type" : "string",
+                            "title" : "Correlator",
+                            "description" : "Sets the message correlator.",
+                            "$comment" : "group:advanced"
+                          },
+                          "defaultUri" : {
+                            "type" : "string",
+                            "title" : "DefaultUri",
+                            "description" : "Sets the SOAP Web Service server url."
+                          },
+                          "endpointResolver" : {
+                            "type" : "string",
+                            "title" : "EndpointResolver",
+                            "description" : "Sets the endpoint resolver.",
+                            "$comment" : "group:advanced"
+                          },
+                          "faultStrategy" : {
+                            "allOf" : [ {
+                              "$ref" : "#/definitions/ErrorHandlingStrategy"
+                            }, {
+                              "title" : "FaultStrategy",
+                              "description" : "Sets the error handling strategy.",
+                              "$comment" : "group:errorHandler"
+                            } ]
+                          },
+                          "interceptor" : {
+                            "type" : "string",
+                            "title" : "Interceptor",
+                            "description" : "Sets a custom client interceptor.",
+                            "$comment" : "group:intercept"
+                          },
+                          "interceptors" : {
+                            "title" : "Interceptors",
+                            "description" : "Sets client interceptors.",
+                            "$comment" : "group:intercept",
+                            "type" : "array",
+                            "items" : {
+                              "type" : "string",
+                              "title" : "Interceptors",
+                              "description" : "Sets client interceptors.",
+                              "$comment" : "group:intercept"
+                            }
+                          },
+                          "keepSoapEnvelope" : {
+                            "type" : "boolean",
+                            "title" : "KeepSoapEnvelope",
+                            "description" : "When enabled the client does not remove the SOAP envelope before processing the message.",
+                            "$comment" : "group:advanced"
+                          },
+                          "messageConverter" : {
+                            "type" : "string",
+                            "title" : "MessageConverter",
+                            "description" : "Sets a custom message converter implementation.",
+                            "$comment" : "group:advanced"
+                          },
+                          "messageFactory" : {
+                            "type" : "string",
+                            "title" : "MessageFactory",
+                            "description" : "Sets a custom message factory.",
+                            "$comment" : "group:advanced"
+                          },
+                          "messageSender" : {
+                            "type" : "string",
+                            "title" : "MessageSender",
+                            "description" : "Sets a custom message sender implementation.",
+                            "$comment" : "group:advanced"
+                          },
+                          "name" : {
+                            "type" : "string",
+                            "title" : "Name",
+                            "description" : "The name of the endpoint"
+                          },
+                          "pollingInterval" : {
+                            "type" : "integer",
+                            "title" : "PollingInterval",
+                            "description" : "Sets the polling interval when consuming messages."
+                          },
+                          "timeout" : {
+                            "type" : "integer",
+                            "title" : "Timeout",
+                            "description" : "Sets the receive timeout when the client waits for response messages.",
+                            "default" : "5000"
+                          },
+                          "webServiceTemplate" : {
+                            "type" : "string",
+                            "title" : "WebServiceTemplate",
+                            "description" : "Sets custom web service template reference.",
+                            "$comment" : "group:advanced"
+                          }
+                        },
+                        "additionalProperties" : false,
+                        "title" : "Client",
+                        "description" : "Sets the SOAP WebService client endpoint."
+                      }
+                    },
+                    "required" : [ "client" ]
+                  }, {
+                    "type" : "object",
+                    "properties" : {
+                      "server" : {
+                        "type" : "object",
+                        "properties" : {
+                          "autoStart" : {
+                            "type" : "boolean",
+                            "title" : "AutoStart",
+                            "description" : "When enabled the server is automatically started after creation."
+                          },
+                          "connector" : {
+                            "type" : "string",
+                            "title" : "Connector",
+                            "description" : "Add a connector to this server.",
+                            "$comment" : "group:servlet"
+                          },
+                          "connectors" : {
+                            "title" : "Connectors",
+                            "description" : "Sets a list of connectors for this server.",
+                            "$comment" : "group:servlet",
+                            "type" : "array",
+                            "items" : {
+                              "type" : "string",
+                              "title" : "Connectors",
+                              "description" : "Sets a list of connectors for this server.",
+                              "$comment" : "group:servlet"
+                            }
+                          },
+                          "contextConfigLocation" : {
+                            "type" : "string",
+                            "title" : "ContextConfigLocation",
+                            "description" : "Sets the path to the Spring context configuration for this server.",
+                            "$comment" : "group:advanced"
+                          },
+                          "contextPath" : {
+                            "type" : "string",
+                            "title" : "ContextPath",
+                            "description" : "Sets the context path on this server.",
+                            "$comment" : "group:servlet"
+                          },
+                          "debugLogging" : {
+                            "type" : "boolean",
+                            "title" : "DebugLogging",
+                            "description" : "When enabled the server prints debug logging output.",
+                            "$comment" : "group:advanced"
+                          },
+                          "endpointAdapter" : {
+                            "type" : "string",
+                            "title" : "EndpointAdapter",
+                            "description" : "Sets a custom endpoint adapter to handle requests.",
+                            "$comment" : "group:advanced"
+                          },
+                          "handleAttributeHeaders" : {
+                            "type" : "boolean",
+                            "title" : "HandleAttributeHeaders",
+                            "description" : "When enabled the server handles attribute headers.",
+                            "$comment" : "group:advanced"
+                          },
+                          "handleMimeHeaders" : {
+                            "type" : "boolean",
+                            "title" : "HandleMimeHeaders",
+                            "description" : "When enabled the server handles mime headers.",
+                            "$comment" : "group:advanced"
+                          },
+                          "interceptor" : {
+                            "type" : "string",
+                            "title" : "Interceptor",
+                            "description" : "Sets a endpoint interceptor.",
+                            "$comment" : "group:intercept"
+                          },
+                          "interceptors" : {
+                            "title" : "Interceptors",
+                            "description" : "Sets the list of endpoint interceptor bean references.",
+                            "$comment" : "group:intercept",
+                            "type" : "array",
+                            "items" : {
+                              "type" : "string",
+                              "title" : "Interceptors",
+                              "description" : "Sets the list of endpoint interceptor bean references.",
+                              "$comment" : "group:intercept"
+                            }
+                          },
+                          "keepSoapEnvelope" : {
+                            "type" : "boolean",
+                            "title" : "KeepSoapEnvelope",
+                            "description" : "When enabled the server does not remove the SOAP envelope before processing messages.",
+                            "$comment" : "group:advanced"
+                          },
+                          "messageConverter" : {
+                            "type" : "string",
+                            "title" : "MessageConverter",
+                            "description" : "Sets the Http message converter bean reference.",
+                            "$comment" : "group:advanced"
+                          },
+                          "messageFactory" : {
+                            "type" : "string",
+                            "title" : "MessageFactory",
+                            "description" : "Sets a custom message factory.",
+                            "$comment" : "group:advanced"
+                          },
+                          "name" : {
+                            "type" : "string",
+                            "title" : "Name",
+                            "description" : "The name of the endpoint"
+                          },
+                          "port" : {
+                            "type" : "integer",
+                            "title" : "Port",
+                            "description" : "The SOAP WebService server port."
+                          },
+                          "resourceBase" : {
+                            "type" : "string",
+                            "title" : "ResourceBase",
+                            "description" : "Sets the resource base path where the server reads resources from.",
+                            "$comment" : "group:advanced"
+                          },
+                          "rootParentContext" : {
+                            "type" : "boolean",
+                            "title" : "RootParentContext",
+                            "description" : "When enabled the server uses the root Spring application context.",
+                            "$comment" : "group:advanced"
+                          },
+                          "securityHandler" : {
+                            "type" : "string",
+                            "title" : "SecurityHandler",
+                            "description" : "Sets the security handler as a bean reference.",
+                            "$comment" : "group:security"
+                          },
+                          "serServletHandler" : {
+                            "type" : "string",
+                            "title" : "SerServletHandler",
+                            "description" : "Sets a custom servlet handler as a bean reference.",
+                            "$comment" : "group:servlet"
+                          },
+                          "servletMappingPath" : {
+                            "type" : "string",
+                            "title" : "ServletMappingPath",
+                            "description" : "Sets the servlet mapping path.",
+                            "$comment" : "group:servlet"
+                          },
+                          "servletName" : {
+                            "type" : "string",
+                            "title" : "ServletName",
+                            "description" : "Sets the servlet name.",
+                            "$comment" : "group:servlet"
+                          },
+                          "soapHeaderNamespace" : {
+                            "type" : "string",
+                            "title" : "SoapHeaderNamespace",
+                            "description" : "Sets the SOAP header namespace.",
+                            "$comment" : "group:advanced"
+                          },
+                          "soapHeaderPrefix" : {
+                            "type" : "string",
+                            "title" : "SoapHeaderPrefix",
+                            "description" : "Sets the SOAP header namespace prefix.",
+                            "$comment" : "group:advanced"
+                          },
+                          "timeout" : {
+                            "type" : "integer",
+                            "title" : "Timeout",
+                            "description" : "Sets the server timeout while waiting for incoming requests.",
+                            "default" : "5000"
+                          }
+                        },
+                        "additionalProperties" : false,
+                        "title" : "Server",
+                        "description" : "Sets the SOAP WebService server endpoint."
+                      }
+                    },
+                    "required" : [ "server" ]
+                  } ]
+                } ],
+                "title" : "Soap",
+                "description" : "SOAP WebService client and server endpoints"
+              }
+            },
+            "required" : [ "soap" ]
+          }, {
+            "type" : "object",
+            "properties" : {
+              "webSocket" : {
+                "type" : "object",
+                "properties" : {
+                  "client" : { },
+                  "server" : { }
+                },
+                "additionalProperties" : false,
+                "anyOf" : [ {
+                  "oneOf" : [ {
+                    "type" : "object",
+                    "properties" : {
+                      "client" : {
+                        "type" : "object",
+                        "properties" : {
+                          "endpointResolver" : {
+                            "type" : "string",
+                            "title" : "EndpointResolver",
+                            "description" : "Sets the endpoint URI resolver.",
+                            "$comment" : "group:advanced"
+                          },
+                          "messageConverter" : {
+                            "type" : "string",
+                            "title" : "MessageConverter",
+                            "description" : "Bean reference to a message converter.",
+                            "$comment" : "group:advanced"
+                          },
+                          "name" : {
+                            "type" : "string",
+                            "title" : "Name",
+                            "description" : "The name of the endpoint"
+                          },
+                          "pollingInterval" : {
+                            "type" : "integer",
+                            "title" : "PollingInterval",
+                            "description" : "Sets the polling interval when consuming messages.",
+                            "$comment" : "group:advanced"
+                          },
+                          "requestUrl" : {
+                            "type" : "string",
+                            "title" : "RequestUrl",
+                            "description" : "Sets the client request URL."
+                          },
+                          "timeout" : {
+                            "type" : "integer",
+                            "title" : "Timeout",
+                            "description" : "The Http request timeout while waiting for a response",
+                            "default" : "5000"
+                          }
+                        },
+                        "additionalProperties" : false,
+                        "title" : "Client",
+                        "description" : "Sets the WebSocket client endpoint."
+                      }
+                    },
+                    "required" : [ "client" ]
+                  }, {
+                    "type" : "object",
+                    "properties" : {
+                      "server" : {
+                        "type" : "object",
+                        "properties" : {
+                          "authentication" : {
+                            "type" : "string",
+                            "title" : "Authentication",
+                            "description" : "Use given authentication mechanism for all request paths.",
+                            "$comment" : "group:security"
+                          },
+                          "autoStart" : {
+                            "type" : "boolean",
+                            "title" : "AutoStart",
+                            "description" : "When enabled the server is automatically started after creation."
+                          },
+                          "binaryMediaTypes" : {
+                            "title" : "BinaryMediaTypes",
+                            "description" : "List of supported media types on this server.",
+                            "$comment" : "group:advanced",
+                            "type" : "array",
+                            "items" : {
+                              "type" : "string",
+                              "title" : "BinaryMediaTypes",
+                              "description" : "List of supported media types on this server.",
+                              "$comment" : "group:advanced"
+                            }
+                          },
+                          "connector" : {
+                            "type" : "string",
+                            "title" : "Connector",
+                            "description" : "Add a connector to this server.",
+                            "$comment" : "group:servlet"
+                          },
+                          "connectors" : {
+                            "title" : "Connectors",
+                            "description" : "Sets a list of connectors for this server.",
+                            "$comment" : "group:servlet",
+                            "type" : "array",
+                            "items" : {
+                              "type" : "string",
+                              "title" : "Connectors",
+                              "description" : "Sets a list of connectors for this server.",
+                              "$comment" : "group:servlet"
+                            }
+                          },
+                          "contextConfigLocation" : {
+                            "type" : "string",
+                            "title" : "ContextConfigLocation",
+                            "description" : "Sets the Spring context configuration loaded for this Http server.",
+                            "$comment" : "group:advanced"
+                          },
+                          "contextPath" : {
+                            "type" : "string",
+                            "title" : "ContextPath",
+                            "description" : "Sets the context path on this server.",
+                            "$comment" : "group:servlet"
+                          },
+                          "debugLogging" : {
+                            "type" : "boolean",
+                            "title" : "DebugLogging",
+                            "description" : "When enabled the server prints debug logging output.",
+                            "$comment" : "group:advanced"
+                          },
+                          "defaultStatus" : {
+                            "allOf" : [ {
+                              "$ref" : "#/definitions/HttpStatus"
+                            }, {
+                              "title" : "DefaultStatus",
+                              "description" : "Sets the default status returned by the server.",
+                              "$comment" : "group:advanced"
+                            } ]
+                          },
+                          "endpointAdapter" : {
+                            "type" : "string",
+                            "title" : "EndpointAdapter",
+                            "description" : "Sets a custom endpoint adapter to handle requests.",
+                            "$comment" : "group:advanced"
+                          },
+                          "filterMappings" : {
+                            "type" : "object",
+                            "title" : "FilterMappings",
+                            "description" : "Filter mapping used on this server.",
+                            "additionalProperties" : {
+                              "type" : "string",
+                              "title" : "FilterMappings",
+                              "description" : "Filter mapping used on this server.",
+                              "$comment" : "group:filter"
+                            },
+                            "$comment" : "group:filter"
+                          },
+                          "filters" : {
+                            "type" : "object",
+                            "title" : "Filters",
+                            "description" : "Map of Http filters used on this server.",
+                            "additionalProperties" : {
+                              "type" : "string",
+                              "title" : "Filters",
+                              "description" : "Map of Http filters used on this server.",
+                              "$comment" : "group:filter"
+                            },
+                            "$comment" : "group:filter"
+                          },
+                          "handleAttributeHeaders" : {
+                            "type" : "boolean",
+                            "title" : "HandleAttributeHeaders",
+                            "description" : "When enabled the server handles attribute headers.",
+                            "$comment" : "group:advanced"
+                          },
+                          "handleCookies" : {
+                            "type" : "boolean",
+                            "title" : "HandleCookies",
+                            "description" : "When enabled the server handles cookies.",
+                            "$comment" : "group:advanced"
+                          },
+                          "interceptor" : {
+                            "type" : "string",
+                            "title" : "Interceptor",
+                            "description" : "Sets a handler interceptor.",
+                            "$comment" : "group:intercept"
+                          },
+                          "interceptors" : {
+                            "title" : "Interceptors",
+                            "description" : "Sets the list of handler interceptor bean references.",
+                            "$comment" : "group:intercept",
+                            "type" : "array",
+                            "items" : {
+                              "type" : "string",
+                              "title" : "Interceptors",
+                              "description" : "Sets the list of handler interceptor bean references.",
+                              "$comment" : "group:intercept"
+                            }
+                          },
+                          "messageConverter" : {
+                            "type" : "string",
+                            "title" : "MessageConverter",
+                            "description" : "Sets the Http message converter bean reference.",
+                            "$comment" : "group:advanced"
+                          },
+                          "name" : {
+                            "type" : "string",
+                            "title" : "Name",
+                            "description" : "The name of the endpoint"
+                          },
+                          "port" : {
+                            "type" : "integer",
+                            "title" : "Port",
+                            "description" : "The Http server port."
+                          },
+                          "removeSemicolonPathContent" : {
+                            "type" : "boolean",
+                            "title" : "RemoveSemicolonPathContent",
+                            "description" : "When enabled the server removes semicolon path content from headers.",
+                            "$comment" : "group:advanced"
+                          },
+                          "resourceBase" : {
+                            "type" : "string",
+                            "title" : "ResourceBase",
+                            "description" : "The server resource base path where resources get loaded from.",
+                            "$comment" : "group:advanced"
+                          },
+                          "responseCacheSize" : {
+                            "type" : "integer",
+                            "title" : "ResponseCacheSize",
+                            "description" : "Sets the response cache size.",
+                            "$comment" : "group:advanced"
+                          },
+                          "rootParentContext" : {
+                            "type" : "boolean",
+                            "title" : "RootParentContext",
+                            "description" : "When enabled the server uses the root Spring application context.",
+                            "$comment" : "group:advanced"
+                          },
+                          "securePort" : {
+                            "type" : "integer",
+                            "title" : "SecurePort",
+                            "description" : "The secured port.",
+                            "$comment" : "group:security"
+                          },
+                          "securedConnection" : {
+                            "type" : "string",
+                            "title" : "SecuredConnection",
+                            "description" : "Secure the connections on given secured port with given security mechanism.",
+                            "$comment" : "group:security"
+                          },
+                          "securityHandler" : {
+                            "type" : "string",
+                            "title" : "SecurityHandler",
+                            "description" : "Sets the security handler as a bean reference.",
+                            "$comment" : "group:security"
+                          },
+                          "serServletHandler" : {
+                            "type" : "string",
+                            "title" : "SerServletHandler",
+                            "description" : "Sets a custom servlet handler as a bean reference.",
+                            "$comment" : "group:servlet"
+                          },
+                          "servletMappingPath" : {
+                            "type" : "string",
+                            "title" : "ServletMappingPath",
+                            "description" : "Sets the servlet mapping path.",
+                            "$comment" : "group:servlet"
+                          },
+                          "servletName" : {
+                            "type" : "string",
+                            "title" : "ServletName",
+                            "description" : "Sets the servlet name.",
+                            "$comment" : "group:servlet"
+                          },
+                          "timeout" : {
+                            "type" : "integer",
+                            "title" : "Timeout",
+                            "description" : "Sets the server timeout while waiting for incoming requests.",
+                            "default" : "5000"
+                          },
+                          "useDefaultFilters" : {
+                            "type" : "boolean",
+                            "title" : "UseDefaultFilters",
+                            "description" : "When enabled the server uses the default set of Http servlet filters.",
+                            "$comment" : "group:filter"
+                          },
+                          "webSockets" : {
+                            "title" : "WebSockets",
+                            "description" : "Sets the list of web sockets for this server.",
+                            "type" : "array",
+                            "items" : {
+                              "type" : "string",
+                              "title" : "WebSockets",
+                              "description" : "Sets the list of web sockets for this server."
+                            }
+                          }
+                        },
+                        "additionalProperties" : false,
+                        "title" : "Server",
+                        "description" : "Sets the WebSocket server endpoint."
+                      }
+                    },
+                    "required" : [ "server" ]
+                  } ]
+                } ],
+                "title" : "WebSocket",
+                "description" : "WebSocket client and server endpoints"
+              }
+            },
+            "required" : [ "webSocket" ]
+          }, {
+            "type" : "object",
+            "properties" : {
+              "context" : {
+                "type" : "object",
+                "properties" : {
+                  "messageStore" : {
+                    "type" : "object",
+                    "properties" : {
+                      "messageName" : {
+                        "type" : "string",
+                        "title" : "MessageName",
+                        "description" : "The message name."
+                      },
+                      "name" : {
+                        "type" : "string",
+                        "title" : "Name",
+                        "description" : "The name of the endpoint"
+                      },
+                      "timeout" : {
+                        "type" : "integer",
+                        "title" : "Timeout",
+                        "description" : "The timeout when receiving messages from the message store."
+                      }
+                    },
+                    "additionalProperties" : false,
+                    "title" : "MessageStore",
+                    "description" : "Sets a message store endpoint ."
+                  }
+                },
+                "additionalProperties" : false,
+                "title" : "Context",
+                "description" : "Context endpoint."
+              }
+            },
+            "required" : [ "context" ]
+          }, {
+            "type" : "object",
+            "properties" : {
+              "mail" : {
+                "type" : "object",
+                "properties" : {
+                  "client" : { },
+                  "server" : { }
+                },
+                "additionalProperties" : false,
+                "anyOf" : [ {
+                  "oneOf" : [ {
+                    "type" : "object",
+                    "properties" : {
+                      "client" : {
+                        "type" : "object",
+                        "properties" : {
+                          "host" : {
+                            "type" : "string",
+                            "title" : "Host",
+                            "description" : "The mail server host to connect to."
+                          },
+                          "javaMailProperties" : {
+                            "type" : "object",
+                            "title" : "JavaMailProperties",
+                            "description" : "Custom properties passed to the java mail implementation.",
+                            "$comment" : "group:advanced"
+                          },
+                          "marshaller" : {
+                            "type" : "string",
+                            "title" : "Marshaller",
+                            "description" : "Sets a custom mail message marshaller.",
+                            "$comment" : "group:advanced"
+                          },
+                          "messageConverter" : {
+                            "type" : "string",
+                            "title" : "MessageConverter",
+                            "description" : "Sets custom message converter.",
+                            "$comment" : "group:advanced"
+                          },
+                          "name" : {
+                            "type" : "string",
+                            "title" : "Name",
+                            "description" : "The name of the endpoint"
+                          },
+                          "password" : {
+                            "type" : "string",
+                            "title" : "Password",
+                            "description" : "The client user password.",
+                            "$comment" : "group:security"
+                          },
+                          "port" : {
+                            "type" : "integer",
+                            "title" : "Port",
+                            "description" : "The mail server port."
+                          },
+                          "protocol" : {
+                            "type" : "string",
+                            "title" : "Protocol",
+                            "description" : "The mail protocol."
+                          },
+                          "timeout" : {
+                            "type" : "integer",
+                            "title" : "Timeout",
+                            "description" : "Mail client timeout when waiting for a response."
+                          },
+                          "username" : {
+                            "type" : "string",
+                            "title" : "Username",
+                            "description" : "The client user name.",
+                            "$comment" : "group:security"
+                          }
+                        },
+                        "additionalProperties" : false,
+                        "title" : "Client",
+                        "description" : "Sets the mail client endpoint."
+                      }
+                    },
+                    "required" : [ "client" ]
+                  }, {
+                    "type" : "object",
+                    "properties" : {
+                      "server" : {
+                        "type" : "object",
+                        "properties" : {
+                          "authRequired" : {
+                            "type" : "boolean",
+                            "title" : "AuthRequired",
+                            "description" : "When enabled users must authenticate with the server.",
+                            "$comment" : "group:security"
+                          },
+                          "autoAccept" : {
+                            "type" : "boolean",
+                            "title" : "AutoAccept",
+                            "description" : "When enabled server will auto accept client connections.",
+                            "$comment" : "group:security"
+                          },
+                          "autoStart" : {
+                            "type" : "boolean",
+                            "title" : "AutoStart",
+                            "description" : "When enabled the server is automatically started after creation."
+                          },
+                          "debugLogging" : {
+                            "type" : "boolean",
+                            "title" : "DebugLogging",
+                            "description" : "When enabled the server prints debug logging output.",
+                            "$comment" : "group:advanced"
+                          },
+                          "endpointAdapter" : {
+                            "type" : "string",
+                            "title" : "EndpointAdapter",
+                            "description" : "Sets a custom endpoint adapter to handle requests.",
+                            "$comment" : "group:advanced"
+                          },
+                          "javaMailProperties" : {
+                            "type" : "object",
+                            "title" : "JavaMailProperties",
+                            "description" : "Custom properties passed to the java mail implementation.",
+                            "$comment" : "group:advanced"
+                          },
+                          "knownUsers" : {
+                            "title" : "KnownUsers",
+                            "description" : "Sets a list of known users that will be accepted when establishing a connection.",
+                            "$comment" : "group:security",
+                            "type" : "array",
+                            "items" : {
+                              "type" : "string",
+                              "title" : "KnownUsers",
+                              "description" : "Sets a list of known users that will be accepted when establishing a connection.",
+                              "$comment" : "group:security"
+                            }
+                          },
+                          "marshaller" : {
+                            "type" : "string",
+                            "title" : "Marshaller",
+                            "description" : "Sets a custom mail message marshaller.",
+                            "$comment" : "group:advanced"
+                          },
+                          "messageConverter" : {
+                            "type" : "string",
+                            "title" : "MessageConverter",
+                            "description" : "Sets custom message converter.",
+                            "$comment" : "group:advanced"
+                          },
+                          "name" : {
+                            "type" : "string",
+                            "title" : "Name",
+                            "description" : "The name of the endpoint"
+                          },
+                          "port" : {
+                            "type" : "integer",
+                            "title" : "Port",
+                            "description" : "The mail server port."
+                          },
+                          "smtp" : {
+                            "type" : "string",
+                            "title" : "Smtp",
+                            "description" : "Sets the SMTP implementation.",
+                            "$comment" : "group:advanced"
+                          },
+                          "splitMultipart" : {
+                            "type" : "boolean",
+                            "title" : "SplitMultipart",
+                            "description" : "When enabled the server splits multipart messages into individual parts.",
+                            "$comment" : "group:advanced"
+                          },
+                          "timeout" : {
+                            "type" : "integer",
+                            "title" : "Timeout",
+                            "description" : "The server timeout.",
+                            "default" : "5000"
+                          }
+                        },
+                        "additionalProperties" : false,
+                        "title" : "Server",
+                        "description" : "Sets the mail server endpoint."
+                      }
+                    },
+                    "required" : [ "server" ]
+                  } ]
+                } ],
+                "title" : "Mail",
+                "description" : "Mail client and server endpoints"
+              }
+            },
+            "required" : [ "mail" ]
+          }, {
+            "type" : "object",
+            "properties" : {
+              "ftp" : {
+                "type" : "object",
+                "properties" : {
+                  "client" : { },
+                  "server" : { }
+                },
+                "additionalProperties" : false,
+                "anyOf" : [ {
+                  "oneOf" : [ {
+                    "type" : "object",
+                    "properties" : {
+                      "client" : {
+                        "type" : "object",
+                        "properties" : {
+                          "autoReadFiles" : {
+                            "type" : "boolean",
+                            "title" : "AutoReadFiles",
+                            "description" : "When enabled the client automatically reads new files."
+                          },
+                          "correlator" : {
+                            "type" : "string",
+                            "title" : "Correlator",
+                            "description" : "Sets the message correlator.",
+                            "$comment" : "group:advanced"
+                          },
+                          "errorHandlingStrategy" : {
+                            "allOf" : [ {
+                              "$ref" : "#/definitions/ErrorHandlingStrategy"
+                            }, {
+                              "title" : "ErrorHandlingStrategy",
+                              "description" : "Sets the error handling strategy.",
+                              "$comment" : "group:errorHandler"
+                            } ]
+                          },
+                          "host" : {
+                            "type" : "string",
+                            "title" : "Host",
+                            "description" : "The Ftp server host."
+                          },
+                          "localPassiveMode" : {
+                            "type" : "boolean",
+                            "title" : "LocalPassiveMode",
+                            "description" : "SEnables the local passive mode."
+                          },
+                          "name" : {
+                            "type" : "string",
+                            "title" : "Name",
+                            "description" : "The name of the endpoint"
+                          },
+                          "password" : {
+                            "type" : "string",
+                            "title" : "Password",
+                            "description" : "Sets the user password.",
+                            "$comment" : "group:security"
+                          },
+                          "pollingInterval" : {
+                            "type" : "integer",
+                            "title" : "PollingInterval",
+                            "description" : "Sets the polling interval when consuming messages."
+                          },
+                          "port" : {
+                            "type" : "integer",
+                            "title" : "Port",
+                            "description" : "The Ftp server port."
+                          },
+                          "timeout" : {
+                            "type" : "integer",
+                            "title" : "Timeout",
+                            "description" : "The endpoint timeout when waiting for messages."
+                          },
+                          "username" : {
+                            "type" : "string",
+                            "title" : "Username",
+                            "description" : "Sets the user name.",
+                            "$comment" : "group:security"
+                          }
+                        },
+                        "additionalProperties" : false,
+                        "title" : "Client",
+                        "description" : "Sets the ftp client endpoint."
+                      }
+                    },
+                    "required" : [ "client" ]
+                  }, {
+                    "type" : "object",
+                    "properties" : {
+                      "server" : {
+                        "type" : "object",
+                        "properties" : {
+                          "autoConnect" : {
+                            "type" : "boolean",
+                            "title" : "AutoConnect",
+                            "description" : "When enabled the server uses automatic connect mode."
+                          },
+                          "autoHandleCommands" : {
+                            "type" : "string",
+                            "title" : "AutoHandleCommands",
+                            "description" : "Enables the auto handle commands mode."
+                          },
+                          "autoLogin" : {
+                            "type" : "boolean",
+                            "title" : "AutoLogin",
+                            "description" : "When enabled the server uses automatic login mode."
+                          },
+                          "autoReadFiles" : {
+                            "type" : "boolean",
+                            "title" : "AutoReadFiles",
+                            "description" : "When enabled the client automatically reads new files."
+                          },
+                          "autoStart" : {
+                            "type" : "boolean",
+                            "title" : "AutoStart",
+                            "description" : "When enabled the server is automatically started after creation."
+                          },
+                          "correlator" : {
+                            "type" : "string",
+                            "title" : "Correlator",
+                            "description" : "Sets the message correlator.",
+                            "$comment" : "group:advanced"
+                          },
+                          "debugLogging" : {
+                            "type" : "boolean",
+                            "title" : "DebugLogging",
+                            "description" : "When enabled the server prints debug logging output.",
+                            "$comment" : "group:advanced"
+                          },
+                          "endpointAdapter" : {
+                            "type" : "string",
+                            "title" : "EndpointAdapter",
+                            "description" : "Sets a custom endpoint adapter to handle requests.",
+                            "$comment" : "group:advanced"
+                          },
+                          "errorHandlingStrategy" : {
+                            "allOf" : [ {
+                              "$ref" : "#/definitions/ErrorHandlingStrategy"
+                            }, {
+                              "title" : "ErrorHandlingStrategy",
+                              "description" : "Sets the error handling strategy.",
+                              "$comment" : "group:errorHandler"
+                            } ]
+                          },
+                          "host" : {
+                            "type" : "string",
+                            "title" : "Host",
+                            "description" : "The Ftp server host."
+                          },
+                          "listenerFactory" : {
+                            "type" : "string",
+                            "title" : "ListenerFactory",
+                            "description" : "Sets a custom listener factory implementation.",
+                            "$comment" : "group:advanced"
+                          },
+                          "localPassiveMode" : {
+                            "type" : "boolean",
+                            "title" : "LocalPassiveMode",
+                            "description" : "Enables the local passive mode."
+                          },
+                          "marshaller" : {
+                            "type" : "string",
+                            "title" : "Marshaller",
+                            "description" : "Sets a custom Ftp message marshaller.",
+                            "$comment" : "group:advanced"
+                          },
+                          "name" : {
+                            "type" : "string",
+                            "title" : "Name",
+                            "description" : "The name of the endpoint"
+                          },
+                          "password" : {
+                            "type" : "string",
+                            "title" : "Password",
+                            "description" : "Sets the allowed user password.",
+                            "$comment" : "group:security"
+                          },
+                          "port" : {
+                            "type" : "integer",
+                            "title" : "Port",
+                            "description" : "The Ftp server port."
+                          },
+                          "server" : {
+                            "type" : "string",
+                            "title" : "Server",
+                            "description" : "Sets the Ftp server implementation.",
+                            "$comment" : "group:advanced"
+                          },
+                          "timeout" : {
+                            "type" : "integer",
+                            "title" : "Timeout",
+                            "description" : "The server timeout.",
+                            "default" : "5000"
+                          },
+                          "user" : {
+                            "type" : "string",
+                            "title" : "User",
+                            "description" : "Sets the allowed user name."
+                          },
+                          "userManager" : {
+                            "type" : "string",
+                            "title" : "UserManager",
+                            "description" : "Sets a custom user manager implementation.",
+                            "$comment" : "group:advanced"
+                          },
+                          "userManagerProperties" : {
+                            "type" : "string",
+                            "title" : "UserManagerProperties",
+                            "description" : "Loads user manage properties from a file resource.",
+                            "$comment" : "group:advanced"
+                          }
+                        },
+                        "additionalProperties" : false,
+                        "title" : "Server",
+                        "description" : "Sets the ftp server endpoint."
+                      }
+                    },
+                    "required" : [ "server" ]
+                  } ]
+                } ],
+                "title" : "Ftp",
+                "description" : "Ftp client and server endpoints"
+              }
+            },
+            "required" : [ "ftp" ]
+          }, {
+            "type" : "object",
+            "properties" : {
+              "sftp" : {
+                "type" : "object",
+                "properties" : {
+                  "client" : { },
+                  "server" : { }
+                },
+                "additionalProperties" : false,
+                "anyOf" : [ {
+                  "oneOf" : [ {
+                    "type" : "object",
+                    "properties" : {
+                      "client" : {
+                        "type" : "object",
+                        "properties" : {
+                          "autoReadFiles" : {
+                            "type" : "boolean",
+                            "title" : "AutoReadFiles",
+                            "description" : "When enabled the client automatically reads new files."
+                          },
+                          "correlator" : {
+                            "type" : "string",
+                            "title" : "Correlator",
+                            "description" : "Sets the message correlator.",
+                            "$comment" : "group:advanced"
+                          },
+                          "errorHandlingStrategy" : {
+                            "allOf" : [ {
+                              "$ref" : "#/definitions/ErrorHandlingStrategy"
+                            }, {
+                              "title" : "ErrorHandlingStrategy",
+                              "description" : "Sets the error handling strategy.",
+                              "$comment" : "group:errorHandler"
+                            } ]
+                          },
+                          "host" : {
+                            "type" : "string",
+                            "title" : "Host",
+                            "description" : "The Ftp server host."
+                          },
+                          "knownHosts" : {
+                            "type" : "string",
+                            "title" : "KnownHosts",
+                            "description" : "List of known hosts.",
+                            "$comment" : "group:security"
+                          },
+                          "localPassiveMode" : {
+                            "type" : "boolean",
+                            "title" : "LocalPassiveMode",
+                            "description" : "SEnables the local passive mode."
+                          },
+                          "name" : {
+                            "type" : "string",
+                            "title" : "Name",
+                            "description" : "The name of the endpoint"
+                          },
+                          "password" : {
+                            "type" : "string",
+                            "title" : "Password",
+                            "description" : "Sets the user password.",
+                            "$comment" : "group:security"
+                          },
+                          "pollingInterval" : {
+                            "type" : "integer",
+                            "title" : "PollingInterval",
+                            "description" : "Sets the polling interval when consuming messages."
+                          },
+                          "port" : {
+                            "type" : "integer",
+                            "title" : "Port",
+                            "description" : "The Ftp server port."
+                          },
+                          "preferredAuthentications" : {
+                            "type" : "string",
+                            "title" : "PreferredAuthentications",
+                            "description" : "Sets the preferred authentication mechanism.",
+                            "$comment" : "group:security"
+                          },
+                          "privateKeyPassword" : {
+                            "type" : "string",
+                            "title" : "PrivateKeyPassword",
+                            "description" : "Sets the private key password.",
+                            "$comment" : "group:security"
+                          },
+                          "privateKeyPath" : {
+                            "type" : "string",
+                            "title" : "PrivateKeyPath",
+                            "description" : "Sets the private key path.",
+                            "$comment" : "group:security"
+                          },
+                          "sessionConfigs" : {
+                            "type" : "object",
+                            "title" : "SessionConfigs",
+                            "description" : "The session configuration.",
+                            "additionalProperties" : {
+                              "type" : "string",
+                              "title" : "SessionConfigs",
+                              "description" : "The session configuration."
+                            }
+                          },
+                          "strictHostChecking" : {
+                            "type" : "boolean",
+                            "title" : "StrictHostChecking",
+                            "description" : "Enable strict host checking.",
+                            "$comment" : "group:security"
+                          },
+                          "timeout" : {
+                            "type" : "integer",
+                            "title" : "Timeout",
+                            "description" : "The endpoint timeout when waiting for messages."
+                          },
+                          "username" : {
+                            "type" : "string",
+                            "title" : "Username",
+                            "description" : "Sets the user name.",
+                            "$comment" : "group:security"
+                          }
+                        },
+                        "additionalProperties" : false,
+                        "title" : "Client",
+                        "description" : "Sets the sftp client endpoint."
+                      }
+                    },
+                    "required" : [ "client" ]
+                  }, {
+                    "type" : "object",
+                    "properties" : {
+                      "server" : {
+                        "type" : "object",
+                        "properties" : {
+                          "allowedKeyPath" : {
+                            "type" : "string",
+                            "title" : "AllowedKeyPath",
+                            "description" : "Sets the allowed key certificate path.",
+                            "$comment" : "group:security"
+                          },
+                          "autoConnect" : {
+                            "type" : "boolean",
+                            "title" : "AutoConnect",
+                            "description" : "When enabled the server uses automatic connect mode."
+                          },
+                          "autoLogin" : {
+                            "type" : "boolean",
+                            "title" : "AutoLogin",
+                            "description" : "When enabled the server uses automatic login mode."
+                          },
+                          "autoStart" : {
+                            "type" : "boolean",
+                            "title" : "AutoStart",
+                            "description" : "When enabled the server is automatically started after creation."
+                          },
+                          "debugLogging" : {
+                            "type" : "boolean",
+                            "title" : "DebugLogging",
+                            "description" : "When enabled the server prints debug logging output.",
+                            "$comment" : "group:advanced"
+                          },
+                          "endpointAdapter" : {
+                            "type" : "string",
+                            "title" : "EndpointAdapter",
+                            "description" : "Sets a custom endpoint adapter to handle requests.",
+                            "$comment" : "group:advanced"
+                          },
+                          "hostKeyPath" : {
+                            "type" : "string",
+                            "title" : "HostKeyPath",
+                            "description" : "Sets the host key certificate path.",
+                            "$comment" : "group:security"
+                          },
+                          "knownHosts" : {
+                            "type" : "string",
+                            "title" : "KnownHosts",
+                            "description" : "List of known hosts.",
+                            "$comment" : "group:security"
+                          },
+                          "name" : {
+                            "type" : "string",
+                            "title" : "Name",
+                            "description" : "The name of the endpoint"
+                          },
+                          "password" : {
+                            "type" : "string",
+                            "title" : "Password",
+                            "description" : "Sets the allowed user password.",
+                            "$comment" : "group:security"
+                          },
+                          "pollingInterval" : {
+                            "type" : "integer",
+                            "title" : "PollingInterval",
+                            "description" : "Sets the polling interval when consuming messages."
+                          },
+                          "port" : {
+                            "type" : "integer",
+                            "title" : "Port",
+                            "description" : "The Ftp server port."
+                          },
+                          "preferredAuthentications" : {
+                            "type" : "string",
+                            "title" : "PreferredAuthentications",
+                            "description" : "Sets the preferred authentication mechanism.",
+                            "$comment" : "group:security"
+                          },
+                          "privateKeyPassword" : {
+                            "type" : "string",
+                            "title" : "PrivateKeyPassword",
+                            "description" : "Sets the private key password.",
+                            "$comment" : "group:security"
+                          },
+                          "privateKeyPath" : {
+                            "type" : "string",
+                            "title" : "PrivateKeyPath",
+                            "description" : "Sets the private key certificate path.",
+                            "$comment" : "group:security"
+                          },
+                          "sessionConfigs" : {
+                            "type" : "object",
+                            "title" : "SessionConfigs",
+                            "description" : "The session configuration.",
+                            "additionalProperties" : {
+                              "type" : "string",
+                              "title" : "SessionConfigs",
+                              "description" : "The session configuration."
+                            }
+                          },
+                          "strictHostChecking" : {
+                            "type" : "boolean",
+                            "title" : "StrictHostChecking",
+                            "description" : "Enable strict host checking.",
+                            "$comment" : "group:security"
+                          },
+                          "timeout" : {
+                            "type" : "integer",
+                            "title" : "Timeout",
+                            "description" : "The server timeout.",
+                            "default" : "5000"
+                          },
+                          "user" : {
+                            "type" : "string",
+                            "title" : "User",
+                            "description" : "Sets the allowed user name."
+                          },
+                          "userHomePath" : {
+                            "type" : "string",
+                            "title" : "UserHomePath",
+                            "description" : "Sets the user home path directory."
+                          }
+                        },
+                        "additionalProperties" : false,
+                        "title" : "Server",
+                        "description" : "Sets the sftp server endpoint."
+                      }
+                    },
+                    "required" : [ "server" ]
+                  } ]
+                } ],
+                "title" : "Sftp",
+                "description" : "Sftp client and server endpoints"
+              }
+            },
+            "required" : [ "sftp" ]
+          }, {
+            "type" : "object",
+            "properties" : {
+              "scp" : {
+                "type" : "object",
+                "properties" : {
+                  "client" : { },
+                  "server" : { }
+                },
+                "additionalProperties" : false,
+                "anyOf" : [ {
+                  "oneOf" : [ {
+                    "type" : "object",
+                    "properties" : {
+                      "client" : {
+                        "type" : "object",
+                        "properties" : {
+                          "autoReadFiles" : {
+                            "type" : "boolean",
+                            "title" : "AutoReadFiles",
+                            "description" : "When enabled the client automatically reads new files."
+                          },
+                          "correlator" : {
+                            "type" : "string",
+                            "title" : "Correlator",
+                            "description" : "Sets the message correlator.",
+                            "$comment" : "group:advanced"
+                          },
+                          "errorHandlingStrategy" : {
+                            "allOf" : [ {
+                              "$ref" : "#/definitions/ErrorHandlingStrategy"
+                            }, {
+                              "title" : "ErrorHandlingStrategy",
+                              "description" : "Sets the error handling strategy.",
+                              "$comment" : "group:errorHandler"
+                            } ]
+                          },
+                          "host" : {
+                            "type" : "string",
+                            "title" : "Host",
+                            "description" : "The Ftp server host."
+                          },
+                          "knownHosts" : {
+                            "type" : "string",
+                            "title" : "KnownHosts",
+                            "description" : "List of known hosts.",
+                            "$comment" : "group:security"
+                          },
+                          "name" : {
+                            "type" : "string",
+                            "title" : "Name",
+                            "description" : "The name of the endpoint"
+                          },
+                          "password" : {
+                            "type" : "string",
+                            "title" : "Password",
+                            "description" : "Sets the user password.",
+                            "$comment" : "group:security"
+                          },
+                          "pollingInterval" : {
+                            "type" : "integer",
+                            "title" : "PollingInterval",
+                            "description" : "Sets the polling interval when consuming messages."
+                          },
+                          "port" : {
+                            "type" : "integer",
+                            "title" : "Port",
+                            "description" : "The Ftp server port."
+                          },
+                          "portOption" : {
+                            "type" : "string",
+                            "title" : "PortOption",
+                            "description" : "Sets the port option.",
+                            "$comment" : "group:advanced"
+                          },
+                          "privateKeyPassword" : {
+                            "type" : "string",
+                            "title" : "PrivateKeyPassword",
+                            "description" : "Sets the private key password.",
+                            "$comment" : "group:security"
+                          },
+                          "privateKeyPath" : {
+                            "type" : "string",
+                            "title" : "PrivateKeyPath",
+                            "description" : "Sets the private key path.",
+                            "$comment" : "group:security"
+                          },
+                          "strictHostChecking" : {
+                            "type" : "boolean",
+                            "title" : "StrictHostChecking",
+                            "description" : "Enable strict host checking.",
+                            "$comment" : "group:security"
+                          },
+                          "timeout" : {
+                            "type" : "integer",
+                            "title" : "Timeout",
+                            "description" : "The endpoint timeout when waiting for messages."
+                          },
+                          "username" : {
+                            "type" : "string",
+                            "title" : "Username",
+                            "description" : "Sets the user name.",
+                            "$comment" : "group:security"
+                          }
+                        },
+                        "additionalProperties" : false,
+                        "title" : "Client",
+                        "description" : "Sets the scp client endpoint."
+                      }
+                    },
+                    "required" : [ "client" ]
+                  }, {
+                    "type" : "object",
+                    "properties" : {
+                      "server" : {
+                        "type" : "object",
+                        "properties" : {
+                          "allowedKeyPath" : {
+                            "type" : "string",
+                            "title" : "AllowedKeyPath",
+                            "description" : "Sets the allowed key certificate path.",
+                            "$comment" : "group:security"
+                          },
+                          "autoConnect" : {
+                            "type" : "boolean",
+                            "title" : "AutoConnect",
+                            "description" : "When enabled the server uses automatic connect mode."
+                          },
+                          "autoLogin" : {
+                            "type" : "boolean",
+                            "title" : "AutoLogin",
+                            "description" : "When enabled the server uses automatic login mode."
+                          },
+                          "autoStart" : {
+                            "type" : "boolean",
+                            "title" : "AutoStart",
+                            "description" : "When enabled the server is automatically started after creation."
+                          },
+                          "debugLogging" : {
+                            "type" : "boolean",
+                            "title" : "DebugLogging",
+                            "description" : "When enabled the server prints debug logging output.",
+                            "$comment" : "group:advanced"
+                          },
+                          "endpointAdapter" : {
+                            "type" : "string",
+                            "title" : "EndpointAdapter",
+                            "description" : "Sets a custom endpoint adapter to handle requests.",
+                            "$comment" : "group:advanced"
+                          },
+                          "hostKeyPath" : {
+                            "type" : "string",
+                            "title" : "HostKeyPath",
+                            "description" : "Sets the host key certificate path.",
+                            "$comment" : "group:security"
+                          },
+                          "knownHosts" : {
+                            "type" : "string",
+                            "title" : "KnownHosts",
+                            "description" : "List of known hosts.",
+                            "$comment" : "group:security"
+                          },
+                          "name" : {
+                            "type" : "string",
+                            "title" : "Name",
+                            "description" : "The name of the endpoint"
+                          },
+                          "password" : {
+                            "type" : "string",
+                            "title" : "Password",
+                            "description" : "Sets the allowed user password.",
+                            "$comment" : "group:security"
+                          },
+                          "pollingInterval" : {
+                            "type" : "integer",
+                            "title" : "PollingInterval",
+                            "description" : "Sets the polling interval when consuming messages."
+                          },
+                          "port" : {
+                            "type" : "integer",
+                            "title" : "Port",
+                            "description" : "The Ftp server port."
+                          },
+                          "preferredAuthentications" : {
+                            "type" : "string",
+                            "title" : "PreferredAuthentications",
+                            "description" : "Sets the preferred authentication mechanism.",
+                            "$comment" : "group:security"
+                          },
+                          "privateKeyPassword" : {
+                            "type" : "string",
+                            "title" : "PrivateKeyPassword",
+                            "description" : "Sets the private key password.",
+                            "$comment" : "group:security"
+                          },
+                          "privateKeyPath" : {
+                            "type" : "string",
+                            "title" : "PrivateKeyPath",
+                            "description" : "Sets the private key certificate path.",
+                            "$comment" : "group:security"
+                          },
+                          "sessionConfigs" : {
+                            "type" : "object",
+                            "title" : "SessionConfigs",
+                            "description" : "The session configuration.",
+                            "additionalProperties" : {
+                              "type" : "string",
+                              "title" : "SessionConfigs",
+                              "description" : "The session configuration."
+                            }
+                          },
+                          "strictHostChecking" : {
+                            "type" : "boolean",
+                            "title" : "StrictHostChecking",
+                            "description" : "Enable strict host checking.",
+                            "$comment" : "group:security"
+                          },
+                          "timeout" : {
+                            "type" : "integer",
+                            "title" : "Timeout",
+                            "description" : "The server timeout.",
+                            "default" : "5000"
+                          },
+                          "user" : {
+                            "type" : "string",
+                            "title" : "User",
+                            "description" : "Sets the allowed user name."
+                          },
+                          "userHomePath" : {
+                            "type" : "string",
+                            "title" : "UserHomePath",
+                            "description" : "Sets the user home path directory."
+                          }
+                        },
+                        "additionalProperties" : false,
+                        "title" : "Server",
+                        "description" : "Sets the sftp server endpoint."
+                      }
+                    },
+                    "required" : [ "server" ]
+                  } ]
+                } ],
+                "title" : "Scp",
+                "description" : "Scp client and server endpoint"
+              }
+            },
+            "required" : [ "scp" ]
+          }, {
+            "type" : "object",
+            "properties" : {
+              "docker" : {
+                "type" : "object",
+                "properties" : {
+                  "client" : {
+                    "type" : "object",
+                    "properties" : {
+                      "certPath" : {
+                        "type" : "string",
+                        "title" : "CertPath",
+                        "description" : "Sets the path to the client certificate.",
+                        "$comment" : "group:security"
+                      },
+                      "configPath" : {
+                        "type" : "string",
+                        "title" : "ConfigPath",
+                        "description" : "Sets the path to the client configuration file.",
+                        "$comment" : "group:advanced"
+                      },
+                      "email" : {
+                        "type" : "string",
+                        "title" : "Email",
+                        "description" : "The Docker client email.",
+                        "$comment" : "group:security"
+                      },
+                      "name" : {
+                        "type" : "string",
+                        "title" : "Name",
+                        "description" : "The name of the endpoint"
+                      },
+                      "password" : {
+                        "type" : "string",
+                        "title" : "Password",
+                        "description" : "The Docker client password.",
+                        "$comment" : "group:security"
+                      },
+                      "registry" : {
+                        "type" : "string",
+                        "title" : "Registry",
+                        "description" : "The Docker registry URL."
+                      },
+                      "url" : {
+                        "type" : "string",
+                        "title" : "Url",
+                        "description" : "The Docker host engine URL."
+                      },
+                      "username" : {
+                        "type" : "string",
+                        "title" : "Username",
+                        "description" : "The Docker client username.",
+                        "$comment" : "group:security"
+                      },
+                      "verifyTls" : {
+                        "type" : "boolean",
+                        "title" : "VerifyTls",
+                        "description" : "When enabled the client verifies the Docker host TLS.",
+                        "$comment" : "group:security"
+                      },
+                      "version" : {
+                        "type" : "string",
+                        "title" : "Version",
+                        "description" : "The Docker client version."
+                      }
+                    },
+                    "additionalProperties" : false,
+                    "title" : "Client",
+                    "description" : "Sets the Docker client endpoint."
+                  }
+                },
+                "additionalProperties" : false,
+                "title" : "Docker",
+                "description" : "Docker client"
+              }
+            },
+            "required" : [ "docker" ]
+          }, {
+            "type" : "object",
+            "properties" : {
+              "kubernetes" : {
+                "type" : "object",
+                "properties" : {
+                  "client" : {
+                    "type" : "object",
+                    "properties" : {
+                      "certFile" : {
+                        "type" : "string",
+                        "title" : "CertFile",
+                        "description" : "Sets the client certificate.",
+                        "$comment" : "group:security"
+                      },
+                      "client" : {
+                        "type" : "string",
+                        "title" : "Client",
+                        "description" : "Sets the reference to the Kubernetes client implementation.",
+                        "$comment" : "group:advanced"
+                      },
+                      "messageConverter" : {
+                        "type" : "string",
+                        "title" : "MessageConverter",
+                        "description" : "Sets the message converter as a bean reference.",
+                        "$comment" : "group:advanced"
+                      },
+                      "name" : {
+                        "type" : "string",
+                        "title" : "Name",
+                        "description" : "The name of the endpoint"
+                      },
+                      "namespace" : {
+                        "type" : "string",
+                        "title" : "Namespace",
+                        "description" : "Sets the namespace on the cluster."
+                      },
+                      "oAuthToken" : {
+                        "type" : "string",
+                        "title" : "OAuthToken",
+                        "description" : "Sets the OAuth token used to connect to the Kubernetes cluster.",
+                        "$comment" : "group:security"
+                      },
+                      "objectMapper" : {
+                        "type" : "string",
+                        "title" : "ObjectMapper",
+                        "description" : "Sets the object mapper.",
+                        "$comment" : "group:advanced"
+                      },
+                      "password" : {
+                        "type" : "string",
+                        "title" : "Password",
+                        "description" : "Sets the user password used to connect to the Kubernetes cluster.",
+                        "$comment" : "group:security"
+                      },
+                      "url" : {
+                        "type" : "string",
+                        "title" : "Url",
+                        "description" : "Sets the master URL in the client configuration.",
+                        "$comment" : "group:advanced"
+                      },
+                      "username" : {
+                        "type" : "string",
+                        "title" : "Username",
+                        "description" : "Sets the user name used to connect to the Kubernetes cluster.",
+                        "$comment" : "group:security"
+                      },
+                      "version" : {
+                        "type" : "string",
+                        "title" : "Version",
+                        "description" : "Sets the Kubernetes client version.",
+                        "$comment" : "group:advanced"
+                      }
+                    },
+                    "additionalProperties" : false,
+                    "title" : "Client",
+                    "description" : "Sets the Kubernetes client endpoint."
+                  }
+                },
+                "additionalProperties" : false,
+                "title" : "Kubernetes",
+                "description" : "Kubernetes client"
+              }
+            },
+            "required" : [ "kubernetes" ]
+          }, {
+            "type" : "object",
+            "properties" : {
+              "jms" : {
+                "type" : "object",
+                "properties" : {
+                  "asynchronous" : { },
+                  "synchronous" : { }
+                },
+                "additionalProperties" : false,
+                "anyOf" : [ {
+                  "oneOf" : [ {
+                    "type" : "object",
+                    "properties" : {
+                      "asynchronous" : {
+                        "type" : "object",
+                        "properties" : {
+                          "autoStart" : {
+                            "type" : "boolean",
+                            "title" : "AutoStart",
+                            "description" : "When enabled the JMS consumer is started right after the endpoint is created.",
+                            "$comment" : "group:publishSubscribe"
+                          },
+                          "connectionFactory" : {
+                            "type" : "string",
+                            "title" : "ConnectionFactory",
+                            "description" : "The JMS connection factory."
+                          },
+                          "destination" : {
+                            "type" : "string",
+                            "title" : "Destination",
+                            "description" : "The JMS destination name."
+                          },
+                          "destinationNameResolver" : {
+                            "type" : "string",
+                            "title" : "DestinationNameResolver",
+                            "description" : "Sets the destination name resolver.",
+                            "$comment" : "group:advanced"
+                          },
+                          "destinationResolver" : {
+                            "type" : "string",
+                            "title" : "DestinationResolver",
+                            "description" : "Sets the destination resolver.",
+                            "$comment" : "group:advanced"
+                          },
+                          "durableSubscriberName" : {
+                            "type" : "string",
+                            "title" : "DurableSubscriberName",
+                            "description" : "Sets the durable subscriber name.",
+                            "$comment" : "group:publishSubscribe"
+                          },
+                          "durableSubscription" : {
+                            "type" : "boolean",
+                            "title" : "DurableSubscription",
+                            "description" : "Enables/disables durable subscription mode.",
+                            "$comment" : "group:publishSubscribe"
+                          },
+                          "filterInternalHeaders" : {
+                            "type" : "boolean",
+                            "title" : "FilterInternalHeaders",
+                            "description" : "Filter internal headers.",
+                            "$comment" : "group:advanced"
+                          },
+                          "jmsTemplate" : {
+                            "type" : "string",
+                            "title" : "JmsTemplate",
+                            "description" : "Sets the JMS template.",
+                            "$comment" : "group:advanced"
+                          },
+                          "messageConverter" : {
+                            "type" : "string",
+                            "title" : "MessageConverter",
+                            "description" : "Sets the message converter bean reference.",
+                            "$comment" : "group:advanced"
+                          },
+                          "name" : {
+                            "type" : "string",
+                            "title" : "Name",
+                            "description" : "The name of the endpoint"
+                          },
+                          "pubSubDomain" : {
+                            "type" : "boolean",
+                            "title" : "PubSubDomain",
+                            "description" : "When enabled the endpoint uses publish/subscribe mode.",
+                            "$comment" : "group:publishSubscribe"
+                          },
+                          "timeout" : {
+                            "type" : "integer",
+                            "title" : "Timeout",
+                            "description" : "Sets the receive timeout when the consumer waits for messages to arrive.",
+                            "default" : "5000"
+                          },
+                          "useObjectMessages" : {
+                            "type" : "boolean",
+                            "title" : "UseObjectMessages",
+                            "description" : "When enabled the endpoint uses object messages.",
+                            "$comment" : "group:advanced"
+                          }
+                        },
+                        "additionalProperties" : false,
+                        "title" : "Asynchronous",
+                        "description" : "Sets the Jms endpoint."
+                      }
+                    },
+                    "required" : [ "asynchronous" ]
+                  }, {
+                    "type" : "object",
+                    "properties" : {
+                      "synchronous" : {
+                        "type" : "object",
+                        "properties" : {
+                          "connectionFactory" : {
+                            "type" : "string",
+                            "title" : "ConnectionFactory",
+                            "description" : "The JMS connection factory."
+                          },
+                          "correlator" : {
+                            "type" : "string",
+                            "title" : "Correlator",
+                            "description" : "Sets the message correlator.",
+                            "$comment" : "group:advanced"
+                          },
+                          "destination" : {
+                            "type" : "string",
+                            "title" : "Destination",
+                            "description" : "The JMS destination name."
+                          },
+                          "destinationNameResolver" : {
+                            "type" : "string",
+                            "title" : "DestinationNameResolver",
+                            "description" : "Sets the destination name resolver.",
+                            "$comment" : "group:advanced"
+                          },
+                          "destinationResolver" : {
+                            "type" : "string",
+                            "title" : "DestinationResolver",
+                            "description" : "Sets the destination resolver.",
+                            "$comment" : "group:advanced"
+                          },
+                          "filterInternalHeaders" : {
+                            "type" : "boolean",
+                            "title" : "FilterInternalHeaders",
+                            "description" : "When enabled the endpoint removes all internal headers before sending a message.",
+                            "$comment" : "group:advanced"
+                          },
+                          "jmsTemplate" : {
+                            "type" : "string",
+                            "title" : "JmsTemplate",
+                            "description" : "Sets the JMS template.",
+                            "$comment" : "group:advanced"
+                          },
+                          "messageConverter" : {
+                            "type" : "string",
+                            "title" : "MessageConverter",
+                            "description" : "Sets the message converter bean reference.",
+                            "$comment" : "group:advanced"
+                          },
+                          "name" : {
+                            "type" : "string",
+                            "title" : "Name",
+                            "description" : "The name of the endpoint"
+                          },
+                          "pollingInterval" : {
+                            "type" : "integer",
+                            "title" : "PollingInterval",
+                            "description" : "Sets the polling interval.",
+                            "$comment" : "group:advanced"
+                          },
+                          "pubSubDomain" : {
+                            "type" : "boolean",
+                            "title" : "PubSubDomain",
+                            "description" : "When enabled the endpoint uses publish/subscribe mode.",
+                            "$comment" : "group:advanced"
+                          },
+                          "replyDestination" : {
+                            "type" : "string",
+                            "title" : "ReplyDestination",
+                            "description" : "Sets the reply destination name."
+                          },
+                          "timeout" : {
+                            "type" : "integer",
+                            "title" : "Timeout",
+                            "description" : "Sets the receive timeout when the consumer waits for messages to arrive."
+                          },
+                          "useObjectMessages" : {
+                            "type" : "boolean",
+                            "title" : "UseObjectMessages",
+                            "description" : "When enabled the endpoint uses object messages.",
+                            "$comment" : "group:advanced"
+                          }
+                        },
+                        "additionalProperties" : false,
+                        "title" : "Synchronous",
+                        "description" : "Sets the synchronous Jms endpoint."
+                      }
+                    },
+                    "required" : [ "synchronous" ]
+                  } ]
+                } ],
+                "title" : "JMS",
+                "description" : "JMS endpoint"
+              }
+            },
+            "required" : [ "jms" ]
+          }, {
+            "type" : "object",
+            "properties" : {
+              "vertx" : {
+                "type" : "object",
+                "properties" : {
+                  "asynchronous" : { },
+                  "synchronous" : { }
+                },
+                "additionalProperties" : false,
+                "anyOf" : [ {
+                  "oneOf" : [ {
+                    "type" : "object",
+                    "properties" : {
+                      "asynchronous" : {
+                        "type" : "object",
+                        "properties" : {
+                          "address" : {
+                            "type" : "string",
+                            "title" : "Address",
+                            "description" : "The event bus address."
+                          },
+                          "host" : {
+                            "type" : "string",
+                            "title" : "Host",
+                            "description" : "The Vert.x event bus host."
+                          },
+                          "messageConverter" : {
+                            "type" : "string",
+                            "title" : "MessageConverter",
+                            "description" : "Sets the message converter as a bean reference.",
+                            "$comment" : "group:advanced"
+                          },
+                          "name" : {
+                            "type" : "string",
+                            "title" : "Name",
+                            "description" : "The name of the endpoint"
+                          },
+                          "pollingInterval" : {
+                            "type" : "integer",
+                            "title" : "PollingInterval",
+                            "description" : "Sets the polling interval when consuming messages."
+                          },
+                          "port" : {
+                            "type" : "integer",
+                            "title" : "Port",
+                            "description" : "The Vert.x event bus port."
+                          },
+                          "pubSubDomain" : {
+                            "type" : "boolean",
+                            "title" : "PubSubDomain",
+                            "description" : "When enabled the endpoint uses publish/subscribe mode.",
+                            "$comment" : "group:advanced"
+                          },
+                          "timeout" : {
+                            "type" : "integer",
+                            "title" : "Timeout",
+                            "description" : "The endpoint timeout when waiting for messages."
+                          },
+                          "vertxFactory" : {
+                            "type" : "string",
+                            "title" : "VertxFactory",
+                            "description" : "Sets a custom Vert.x factory.",
+                            "$comment" : "group:advanced"
+                          }
+                        },
+                        "additionalProperties" : false,
+                        "title" : "Asynchronous",
+                        "description" : "Sets the Vert.x endpoint."
+                      }
+                    },
+                    "required" : [ "asynchronous" ]
+                  }, {
+                    "type" : "object",
+                    "properties" : {
+                      "synchronous" : {
+                        "type" : "object",
+                        "properties" : {
+                          "address" : {
+                            "type" : "string",
+                            "title" : "Address",
+                            "description" : "The event bus address."
+                          },
+                          "correlator" : {
+                            "type" : "string",
+                            "title" : "Correlator",
+                            "description" : "Sets the message correlator.",
+                            "$comment" : "group:advanced"
+                          },
+                          "host" : {
+                            "type" : "string",
+                            "title" : "Host",
+                            "description" : "The Vert.x event bus host."
+                          },
+                          "messageConverter" : {
+                            "type" : "string",
+                            "title" : "MessageConverter",
+                            "description" : "Sets the message converter as a bean reference.",
+                            "$comment" : "group:advanced"
+                          },
+                          "name" : {
+                            "type" : "string",
+                            "title" : "Name",
+                            "description" : "The name of the endpoint"
+                          },
+                          "pollingInterval" : {
+                            "type" : "integer",
+                            "title" : "PollingInterval",
+                            "description" : "Sets the polling interval when consuming messages."
+                          },
+                          "port" : {
+                            "type" : "integer",
+                            "title" : "Port",
+                            "description" : "The Vert.x event bus port."
+                          },
+                          "pubSubDomain" : {
+                            "type" : "boolean",
+                            "title" : "PubSubDomain",
+                            "description" : "When enabled the endpoint uses publish/subscribe mode.",
+                            "$comment" : "group:advanced"
+                          },
+                          "timeout" : {
+                            "type" : "integer",
+                            "title" : "Timeout",
+                            "description" : "The endpoint timeout when waiting for messages."
+                          },
+                          "vertxFactory" : {
+                            "type" : "string",
+                            "title" : "VertxFactory",
+                            "description" : "Sets a custom Vert.x factory.",
+                            "$comment" : "group:advanced"
+                          }
+                        },
+                        "additionalProperties" : false,
+                        "title" : "Synchronous",
+                        "description" : "Sets the synchronous Vert.x endpoint."
+                      }
+                    },
+                    "required" : [ "synchronous" ]
+                  } ]
+                } ],
+                "title" : "Vert.x",
+                "description" : "Vert.x endpoint."
+              }
+            },
+            "required" : [ "vertx" ]
+          }, {
+            "type" : "object",
+            "properties" : {
+              "direct" : {
+                "type" : "object",
+                "properties" : {
+                  "asynchronous" : { },
+                  "synchronous" : { }
+                },
+                "additionalProperties" : false,
+                "anyOf" : [ {
+                  "oneOf" : [ {
+                    "type" : "object",
+                    "properties" : {
+                      "asynchronous" : {
+                        "type" : "object",
+                        "properties" : {
+                          "autoCreateQueue" : {
+                            "type" : "boolean",
+                            "title" : "AutoCreateQueue",
+                            "description" : "When set the queue is automatically created when it does not exist in bean registry."
+                          },
+                          "name" : {
+                            "type" : "string",
+                            "title" : "Name",
+                            "description" : "The name of the endpoint"
+                          },
+                          "queue" : {
+                            "type" : "string",
+                            "title" : "Queue",
+                            "description" : "The queue name."
+                          },
+                          "timeout" : {
+                            "type" : "integer",
+                            "title" : "Timeout",
+                            "description" : "The timeout when receiving messages from the queue."
+                          }
+                        },
+                        "additionalProperties" : false,
+                        "title" : "Asynchronous",
+                        "description" : "Sets the direct endpoint."
+                      }
+                    },
+                    "required" : [ "asynchronous" ]
+                  }, {
+                    "type" : "object",
+                    "properties" : {
+                      "synchronous" : {
+                        "type" : "object",
+                        "properties" : {
+                          "autoCreateQueue" : {
+                            "type" : "boolean",
+                            "title" : "AutoCreateQueue",
+                            "description" : "When set the queue is automatically created when it does not exist in bean registry."
+                          },
+                          "correlator" : {
+                            "type" : "string",
+                            "title" : "Correlator",
+                            "description" : "Sets the message correlator.",
+                            "$comment" : "group:advanced"
+                          },
+                          "name" : {
+                            "type" : "string",
+                            "title" : "Name",
+                            "description" : "The name of the endpoint"
+                          },
+                          "pollingInterval" : {
+                            "type" : "integer",
+                            "title" : "PollingInterval",
+                            "description" : "Sets the polling interval when consuming messages."
+                          },
+                          "queue" : {
+                            "type" : "string",
+                            "title" : "Queue",
+                            "description" : "The queue name."
+                          },
+                          "timeout" : {
+                            "type" : "integer",
+                            "title" : "Timeout",
+                            "description" : "The timeout when receiving messages from the queue."
+                          }
+                        },
+                        "additionalProperties" : false,
+                        "title" : "Synchronous",
+                        "description" : "Sets the synchronous direct endpoint."
+                      }
+                    },
+                    "required" : [ "synchronous" ]
+                  } ]
+                } ],
+                "title" : "Direct",
+                "description" : "Direct endpoint."
+              }
+            },
+            "required" : [ "direct" ]
+          }, {
+            "type" : "object",
+            "properties" : {
+              "kafka" : {
+                "type" : "object",
+                "properties" : {
+                  "asynchronous" : { },
+                  "synchronous" : { }
+                },
+                "additionalProperties" : false,
+                "anyOf" : [ {
+                  "oneOf" : [ {
+                    "type" : "object",
+                    "properties" : {
+                      "asynchronous" : {
+                        "type" : "object",
+                        "properties" : {
+                          "autoCommit" : {
+                            "type" : "boolean",
+                            "title" : "AutoCommit",
+                            "description" : "Sets auto commit handling for this endpoint.",
+                            "$comment" : "group:consume"
+                          },
+                          "autoCommitInterval" : {
+                            "type" : "integer",
+                            "title" : "AutoCommitInterval",
+                            "description" : "Sets the auto commit interval.",
+                            "$comment" : "group:consume"
+                          },
+                          "clientId" : {
+                            "type" : "string",
+                            "title" : "ClientId",
+                            "description" : "Sets the client id used to connect to the Kafka server.",
+                            "$comment" : "group:advanced"
+                          },
+                          "consumerGroup" : {
+                            "type" : "string",
+                            "title" : "ConsumerGroup",
+                            "description" : "Sets the consumer group used by the endpoint.",
+                            "$comment" : "group:consume"
+                          },
+                          "consumerProperties" : {
+                            "type" : "object",
+                            "title" : "ConsumerProperties",
+                            "description" : "Sets the Kafka consumer properties.",
+                            "$comment" : "group:consume"
+                          },
+                          "headerMapper" : {
+                            "type" : "string",
+                            "title" : "HeaderMapper",
+                            "description" : "Sets the Kafka header mapper.",
+                            "$comment" : "group:advanced"
+                          },
+                          "keyDeserializer" : {
+                            "type" : "string",
+                            "title" : "KeyDeserializer",
+                            "description" : "Sets the fully qualified key deserializer type class name.",
+                            "$comment" : "group:deserialize"
+                          },
+                          "keySerializer" : {
+                            "type" : "string",
+                            "title" : "KeySerializer",
+                            "description" : "Sets the fully qualified key serializer type class name.",
+                            "$comment" : "group:serialize"
+                          },
+                          "messageConverter" : {
+                            "type" : "string",
+                            "title" : "MessageConverter",
+                            "description" : "Sets the message converter as a bean reference.",
+                            "$comment" : "group:advanced"
+                          },
+                          "name" : {
+                            "type" : "string",
+                            "title" : "Name",
+                            "description" : "The name of the endpoint"
+                          },
+                          "offsetReset" : {
+                            "type" : "string",
+                            "title" : "OffsetReset",
+                            "description" : "Sets the offset reset.",
+                            "$comment" : "group:consume"
+                          },
+                          "partition" : {
+                            "type" : "integer",
+                            "title" : "Partition",
+                            "description" : "Sets the Kafka topic partition."
+                          },
+                          "producerProperties" : {
+                            "type" : "object",
+                            "title" : "ProducerProperties",
+                            "description" : "Sets the Kafka producer properties.",
+                            "$comment" : "group:produce"
+                          },
+                          "server" : {
+                            "type" : "string",
+                            "title" : "Server",
+                            "description" : "Sets the Kafka bootstrap server."
+                          },
+                          "timeout" : {
+                            "type" : "integer",
+                            "title" : "Timeout",
+                            "description" : "Sets the Kafka consumer timeout.",
+                            "$comment" : "group:consume"
+                          },
+                          "topic" : {
+                            "type" : "string",
+                            "title" : "Topic",
+                            "description" : "Sets the Kafka topic."
+                          },
+                          "valueDeserializer" : {
+                            "type" : "string",
+                            "title" : "ValueDeserializer",
+                            "description" : "Sets the fully qualified value deserializer type class name.",
+                            "$comment" : "group:deserialize"
+                          },
+                          "valueSerializer" : {
+                            "type" : "string",
+                            "title" : "ValueSerializer",
+                            "description" : "Sets the fully qualified value serializer type class name.",
+                            "$comment" : "group:serialize"
+                          }
+                        },
+                        "additionalProperties" : false,
+                        "title" : "Asynchronous",
+                        "description" : "Sets the Kafka endpoint."
+                      }
+                    },
+                    "required" : [ "asynchronous" ]
+                  }, {
+                    "type" : "object",
+                    "properties" : {
+                      "synchronous" : {
+                        "type" : "object",
+                        "properties" : {
+                          "autoCommit" : {
+                            "type" : "boolean",
+                            "title" : "AutoCommit",
+                            "description" : "Sets auto commit handling for this endpoint.",
+                            "$comment" : "group:consume"
+                          },
+                          "autoCommitInterval" : {
+                            "type" : "integer",
+                            "title" : "AutoCommitInterval",
+                            "description" : "Sets the auto commit interval.",
+                            "$comment" : "group:consume"
+                          },
+                          "clientId" : {
+                            "type" : "string",
+                            "title" : "ClientId",
+                            "description" : "Sets the client id used to connect to the Kafka server.",
+                            "$comment" : "group:advanced"
+                          },
+                          "consumerGroup" : {
+                            "type" : "string",
+                            "title" : "ConsumerGroup",
+                            "description" : "Sets the consumer group used by the endpoint.",
+                            "$comment" : "group:consume"
+                          },
+                          "consumerProperties" : {
+                            "type" : "object",
+                            "title" : "ConsumerProperties",
+                            "description" : "Sets the Kafka consumer properties.",
+                            "$comment" : "group:consume"
+                          },
+                          "headerMapper" : {
+                            "type" : "string",
+                            "title" : "HeaderMapper",
+                            "description" : "Sets the Kafka header mapper.",
+                            "$comment" : "group:advanced"
+                          },
+                          "keyDeserializer" : {
+                            "type" : "string",
+                            "title" : "KeyDeserializer",
+                            "description" : "Sets the fully qualified key deserializer type class name.",
+                            "$comment" : "group:deserialize"
+                          },
+                          "keySerializer" : {
+                            "type" : "string",
+                            "title" : "KeySerializer",
+                            "description" : "Sets the fully qualified key serializer type class name.",
+                            "$comment" : "group:serialize"
+                          },
+                          "messageConverter" : {
+                            "type" : "string",
+                            "title" : "MessageConverter",
+                            "description" : "Sets the message converter as a bean reference.",
+                            "$comment" : "group:advanced"
+                          },
+                          "name" : {
+                            "type" : "string",
+                            "title" : "Name",
+                            "description" : "The name of the endpoint"
+                          },
+                          "offsetReset" : {
+                            "type" : "string",
+                            "title" : "OffsetReset",
+                            "description" : "Sets the offset reset.",
+                            "$comment" : "group:consume"
+                          },
+                          "partition" : {
+                            "type" : "integer",
+                            "title" : "Partition",
+                            "description" : "Sets the Kafka topic partition."
+                          },
+                          "producerProperties" : {
+                            "type" : "object",
+                            "title" : "ProducerProperties",
+                            "description" : "Sets the Kafka producer properties.",
+                            "$comment" : "group:produce"
+                          },
+                          "server" : {
+                            "type" : "string",
+                            "title" : "Server",
+                            "description" : "Sets the Kafka bootstrap server."
+                          },
+                          "timeout" : {
+                            "type" : "integer",
+                            "title" : "Timeout",
+                            "description" : "Sets the Kafka consumer timeout.",
+                            "$comment" : "group:consume"
+                          },
+                          "topic" : {
+                            "type" : "string",
+                            "title" : "Topic",
+                            "description" : "Sets the Kafka topic."
+                          },
+                          "valueDeserializer" : {
+                            "type" : "string",
+                            "title" : "ValueDeserializer",
+                            "description" : "Sets the fully qualified value deserializer type class name.",
+                            "$comment" : "group:deserialize"
+                          },
+                          "valueSerializer" : {
+                            "type" : "string",
+                            "title" : "ValueSerializer",
+                            "description" : "Sets the fully qualified value serializer type class name.",
+                            "$comment" : "group:serialize"
+                          }
+                        },
+                        "additionalProperties" : false,
+                        "title" : "Synchronous",
+                        "description" : "Sets the synchronous Kafka endpoint."
+                      }
+                    },
+                    "required" : [ "synchronous" ]
+                  } ]
+                } ],
+                "title" : "Kafka",
+                "description" : "Kafka endpoint."
+              }
+            },
+            "required" : [ "kafka" ]
+          }, {
+            "type" : "object",
+            "properties" : {
+              "camel" : {
+                "type" : "object",
+                "properties" : {
+                  "asynchronous" : { },
+                  "synchronous" : { }
+                },
+                "additionalProperties" : false,
+                "anyOf" : [ {
+                  "oneOf" : [ {
+                    "type" : "object",
+                    "properties" : {
+                      "asynchronous" : {
+                        "type" : "object",
+                        "properties" : {
+                          "camelContext" : {
+                            "type" : "string",
+                            "title" : "CamelContext",
+                            "description" : "The Camel context to use."
+                          },
+                          "endpointUri" : {
+                            "type" : "string",
+                            "title" : "EndpointUri",
+                            "description" : "The Camel endpoint uri."
+                          },
+                          "messageConverter" : {
+                            "type" : "string",
+                            "title" : "MessageConverter",
+                            "description" : "Sets the message converter as a bean reference.",
+                            "$comment" : "group:advanced"
+                          },
+                          "name" : {
+                            "type" : "string",
+                            "title" : "Name",
+                            "description" : "The name of the endpoint"
+                          },
+                          "timeout" : {
+                            "type" : "integer",
+                            "title" : "Timeout",
+                            "description" : "The endpoint timeout when waiting for messages."
+                          }
+                        },
+                        "additionalProperties" : false,
+                        "title" : "Asynchronous",
+                        "description" : "Sets the Camel endpoint."
+                      }
+                    },
+                    "required" : [ "asynchronous" ]
+                  }, {
+                    "type" : "object",
+                    "properties" : {
+                      "synchronous" : {
+                        "type" : "object",
+                        "properties" : {
+                          "camelContext" : {
+                            "type" : "string",
+                            "title" : "CamelContext",
+                            "description" : "The Camel context to use."
+                          },
+                          "correlator" : {
+                            "type" : "string",
+                            "title" : "Correlator",
+                            "description" : "Sets the message correlator.",
+                            "$comment" : "group:advanced"
+                          },
+                          "endpointUri" : {
+                            "type" : "string",
+                            "title" : "EndpointUri",
+                            "description" : "The Camel endpoint uri."
+                          },
+                          "messageConverter" : {
+                            "type" : "string",
+                            "title" : "MessageConverter",
+                            "description" : "Sets the message converter as a bean reference.",
+                            "$comment" : "group:advanced"
+                          },
+                          "name" : {
+                            "type" : "string",
+                            "title" : "Name",
+                            "description" : "The name of the endpoint"
+                          },
+                          "pollingInterval" : {
+                            "type" : "integer",
+                            "title" : "PollingInterval",
+                            "description" : "Sets the polling interval when consuming messages."
+                          },
+                          "timeout" : {
+                            "type" : "integer",
+                            "title" : "Timeout",
+                            "description" : "The endpoint timeout when waiting for messages."
+                          }
+                        },
+                        "additionalProperties" : false,
+                        "title" : "Synchronous",
+                        "description" : "Sets the synchronous Camel endpoint."
+                      }
+                    },
+                    "required" : [ "synchronous" ]
+                  } ]
+                } ],
+                "title" : "Camel",
+                "description" : "Camel endpoint."
+              }
+            },
+            "required" : [ "camel" ]
+          }, {
+            "type" : "object",
+            "properties" : {
+              "channel" : {
+                "type" : "object",
+                "properties" : {
+                  "asynchronous" : { },
+                  "synchronous" : { }
+                },
+                "additionalProperties" : false,
+                "anyOf" : [ {
+                  "oneOf" : [ {
+                    "type" : "object",
+                    "properties" : {
+                      "asynchronous" : {
+                        "type" : "object",
+                        "properties" : {
+                          "channel" : {
+                            "type" : "string",
+                            "title" : "Channel",
+                            "description" : "The Spring message channel name."
+                          },
+                          "channelResolver" : {
+                            "type" : "string",
+                            "title" : "ChannelResolver",
+                            "description" : "The channel destination resolver.",
+                            "$comment" : "group:advanced"
+                          },
+                          "filterInternalHeaders" : {
+                            "type" : "boolean",
+                            "title" : "FilterInternalHeaders",
+                            "description" : "When enabled the endpoint removes all internal headers before sending a message.",
+                            "$comment" : "group:advanced"
+                          },
+                          "messageConverter" : {
+                            "type" : "string",
+                            "title" : "MessageConverter",
+                            "description" : "Sets the message converter as a bean reference.",
+                            "$comment" : "group:advanced"
+                          },
+                          "messagingTemplate" : {
+                            "type" : "string",
+                            "title" : "MessagingTemplate",
+                            "description" : "Sets a custom messaging template.",
+                            "$comment" : "group:advanced"
+                          },
+                          "name" : {
+                            "type" : "string",
+                            "title" : "Name",
+                            "description" : "The name of the endpoint"
+                          },
+                          "timeout" : {
+                            "type" : "integer",
+                            "title" : "Timeout",
+                            "description" : "Sets the receive timeout when waiting for messages.",
+                            "default" : "5000"
+                          },
+                          "useObjectMessages" : {
+                            "type" : "boolean",
+                            "title" : "UseObjectMessages",
+                            "description" : "When enabled the endpoint uses object messages.",
+                            "$comment" : "group:advanced"
+                          }
+                        },
+                        "additionalProperties" : false,
+                        "title" : "Asynchronous",
+                        "description" : "Sets the Spring message channel endpoint."
+                      }
+                    },
+                    "required" : [ "asynchronous" ]
+                  }, {
+                    "type" : "object",
+                    "properties" : {
+                      "synchronous" : {
+                        "type" : "object",
+                        "properties" : {
+                          "channel" : {
+                            "type" : "string",
+                            "title" : "Channel",
+                            "description" : "The Spring message channel name."
+                          },
+                          "channelResolver" : {
+                            "type" : "string",
+                            "title" : "ChannelResolver",
+                            "description" : "The channel destination resolver.",
+                            "$comment" : "group:advanced"
+                          },
+                          "correlator" : {
+                            "type" : "string",
+                            "title" : "Correlator",
+                            "description" : "Sets the message correlator.",
+                            "$comment" : "group:advanced"
+                          },
+                          "filterInternalHeaders" : {
+                            "type" : "boolean",
+                            "title" : "FilterInternalHeaders",
+                            "description" : "When enabled the endpoint removes all internal headers before sending a message.",
+                            "$comment" : "group:advanced"
+                          },
+                          "messageConverter" : {
+                            "type" : "string",
+                            "title" : "MessageConverter",
+                            "description" : "Sets the message converter as a bean reference.",
+                            "$comment" : "group:advanced"
+                          },
+                          "messagingTemplate" : {
+                            "type" : "string",
+                            "title" : "MessagingTemplate",
+                            "description" : "Sets a custom messaging template.",
+                            "$comment" : "group:advanced"
+                          },
+                          "name" : {
+                            "type" : "string",
+                            "title" : "Name",
+                            "description" : "The name of the endpoint"
+                          },
+                          "pollingInterval" : {
+                            "type" : "integer",
+                            "title" : "PollingInterval",
+                            "description" : "Sets the polling interval.",
+                            "$comment" : "group:advanced"
+                          },
+                          "timeout" : {
+                            "type" : "integer",
+                            "title" : "Timeout",
+                            "description" : "Sets the receive timeout when waiting for messages.",
+                            "default" : "5000"
+                          },
+                          "useObjectMessages" : {
+                            "type" : "boolean",
+                            "title" : "UseObjectMessages",
+                            "description" : "When enabled the endpoint uses object messages.",
+                            "$comment" : "group:advanced"
+                          }
+                        },
+                        "additionalProperties" : false,
+                        "title" : "Synchronous",
+                        "description" : "Sets the synchronous Spring message channel endpoint."
+                      }
+                    },
+                    "required" : [ "synchronous" ]
+                  } ]
+                } ],
+                "title" : "Spring channel",
+                "description" : "Spring channel endpoint."
+              }
+            },
+            "required" : [ "channel" ]
+          }, {
+            "type" : "object",
+            "properties" : {
+              "selenium" : {
+                "type" : "object",
+                "properties" : {
+                  "browser" : {
+                    "type" : "object",
+                    "properties" : {
+                      "eventListeners" : {
+                        "title" : "EventListeners",
+                        "description" : "Sets the list of event listeners.",
+                        "$comment" : "group:advanced",
+                        "type" : "array",
+                        "items" : {
+                          "type" : "string",
+                          "title" : "EventListeners",
+                          "description" : "Sets the list of event listeners.",
+                          "$comment" : "group:advanced"
+                        }
+                      },
+                      "javaScript" : {
+                        "type" : "boolean",
+                        "title" : "JavaScript",
+                        "description" : "When enabled the browser supports JavaScript."
+                      },
+                      "name" : {
+                        "type" : "string",
+                        "title" : "Name",
+                        "description" : "The name of the endpoint"
+                      },
+                      "profile" : {
+                        "type" : "string",
+                        "title" : "Profile",
+                        "description" : "The Firefox profile.",
+                        "$comment" : "group:firefox"
+                      },
+                      "remoteServerUrl" : {
+                        "type" : "string",
+                        "title" : "RemoteServerUrl",
+                        "description" : "The remote server URL."
+                      },
+                      "startPage" : {
+                        "type" : "string",
+                        "title" : "StartPage",
+                        "description" : "The URL to the start page."
+                      },
+                      "timeout" : {
+                        "type" : "integer",
+                        "title" : "Timeout",
+                        "description" : "The browser timeout."
+                      },
+                      "type" : {
+                        "type" : "string",
+                        "title" : "Type",
+                        "description" : "The Selenium browser type.",
+                        "default" : "htmlunit"
+                      },
+                      "version" : {
+                        "type" : "string",
+                        "title" : "Version",
+                        "description" : "The browser version.",
+                        "$comment" : "group:advanced"
+                      },
+                      "webDriver" : {
+                        "type" : "string",
+                        "title" : "WebDriver",
+                        "description" : "Sets a custom web driver as a bean reference.",
+                        "$comment" : "group:advanced"
+                      }
+                    },
+                    "additionalProperties" : false,
+                    "title" : "Browser",
+                    "description" : "Sets the Selenium browser endpoint."
+                  }
+                },
+                "additionalProperties" : false,
+                "title" : "Selenium",
+                "description" : "Selenium endpoint."
+              }
+            },
+            "required" : [ "selenium" ]
+          } ]
+        } ],
+        "title" : "Endpoints",
+        "description" : "List of endpoints for this test.",
+        "$comment" : "group:endpoints"
+      }
+    },
+    "finally" : {
+      "title" : "Finally",
+      "description" : "The final test actions.",
+      "$comment" : "group:finally",
+      "type" : "array",
+      "items" : {
+        "allOf" : [ {
+          "$ref" : "#/definitions/TestActions"
+        }, {
+          "title" : "Finally",
+          "description" : "The final test actions.",
+          "$comment" : "group:finally"
+        } ]
+      }
+    },
+    "name" : {
+      "type" : "string",
+      "title" : "Name",
+      "description" : "The test name."
+    },
+    "status" : {
+      "type" : "string",
+      "enum" : [ "DRAFT", "READY_FOR_REVIEW", "FINAL", "DISABLED" ],
+      "title" : "Status",
+      "description" : "The test status.",
+      "$comment" : "group:metaData"
+    },
+    "variables" : {
+      "title" : "Variables",
+      "description" : "The test variables.",
+      "type" : "array",
+      "items" : {
+        "type" : "object",
+        "properties" : {
+          "name" : {
+            "type" : "string",
+            "title" : "Name",
+            "description" : "The test variable name."
+          },
+          "script" : {
+            "type" : "object",
+            "properties" : {
+              "charset" : {
+                "type" : "string",
+                "title" : "Charset",
+                "description" : "The charset used to load the file resource.",
+                "$comment" : "group:advanced"
+              },
+              "content" : {
+                "type" : "string",
+                "title" : "Content",
+                "description" : "The script content as inline data."
+              },
+              "file" : {
+                "type" : "string",
+                "title" : "File",
+                "description" : "The script content loaded as a file resource."
+              },
+              "type" : {
+                "type" : "string",
+                "title" : "Type",
+                "description" : "The script type.",
+                "default" : "groovy"
+              }
+            },
+            "additionalProperties" : false,
+            "title" : "Script",
+            "description" : "Script that sets the test variable value.",
+            "$comment" : "group:script"
+          },
+          "value" : {
+            "type" : "string",
+            "title" : "Value",
+            "description" : "The test variable value."
+          }
+        },
+        "required" : [ "name" ],
+        "additionalProperties" : false,
+        "title" : "Variables",
+        "description" : "The test variables."
+      }
+    }
+  },
+  "required" : [ "name" ],
+  "additionalProperties" : false
+}

--- a/catalog/citrus/4.10.1/citrus-testcase.xsd
+++ b/catalog/citrus/4.10.1/citrus-testcase.xsd
@@ -1,0 +1,2970 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<!--
+  ~ Copyright the original author or authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<xs:schema elementFormDefault="qualified" version="1.0" targetNamespace="http://citrusframework.org/schema/xml/testcase"
+           xmlns:tns="http://citrusframework.org/schema/xml/testcase" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+
+  <xs:complexType name="ScriptType">
+    <xs:simpleContent>
+      <xs:extension base="xs:string">
+        <xs:attribute name="type" type="xs:string" use="required"/>
+        <xs:attribute name="file" type="xs:string"/>
+        <xs:attribute name="charset" type="xs:string"/>
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+
+  <xs:complexType name="VariableType">
+    <xs:sequence>
+      <xs:element name="value" minOccurs="0">
+        <xs:complexType>
+          <xs:choice>
+            <xs:element name="data" type="xs:string"/>
+            <xs:element name="script" type="ScriptType"/>
+          </xs:choice>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+    <xs:attribute name="name" type="xs:string" use="required"/>
+    <xs:attribute name="value" type="xs:string"/>
+  </xs:complexType>
+
+  <xs:complexType name="PropertyType">
+    <xs:attribute name="name" type="xs:string" use="required"/>
+    <xs:attribute name="value" type="xs:string" use="required"/>
+  </xs:complexType>
+
+  <xs:simpleType name="StatusType">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="DRAFT"/>
+      <xs:enumeration value="READY_FOR_REVIEW"/>
+      <xs:enumeration value="FINAL"/>
+      <xs:enumeration value="DISABLED"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:complexType name="MessageType">
+    <xs:sequence>
+      <xs:element name="headers" minOccurs="0">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="header" minOccurs="0" maxOccurs="unbounded">
+              <xs:complexType>
+                <xs:choice minOccurs="0">
+                  <xs:element name="data" type="xs:string" minOccurs="0"/>
+                  <xs:element name="resource" minOccurs="0">
+                    <xs:complexType>
+                      <xs:sequence/>
+                      <xs:attribute name="file" type="xs:string" use="required"/>
+                      <xs:attribute name="charset" type="xs:string"/>
+                    </xs:complexType>
+                  </xs:element>
+                  <xs:element name="fragment" minOccurs="0">
+                    <xs:complexType>
+                      <xs:sequence>
+                        <xs:any processContents="skip" namespace="##other" minOccurs="0" maxOccurs="unbounded"/>
+                      </xs:sequence>
+                    </xs:complexType>
+                  </xs:element>
+                </xs:choice>
+                <xs:attribute name="name" type="xs:string"/>
+                <xs:attribute name="value" type="xs:string"/>
+                <xs:attribute name="type" type="xs:string"/>
+              </xs:complexType>
+            </xs:element>
+          </xs:sequence>
+          <xs:attribute name="ignore-case" type="xs:string"/>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="body" minOccurs="0">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="builder" type="tns:ScriptType" minOccurs="0"/>
+            <xs:element name="resource" minOccurs="0">
+              <xs:complexType>
+                <xs:sequence/>
+                <xs:attribute name="file" type="xs:string" use="required"/>
+                <xs:attribute name="charset" type="xs:string"/>
+              </xs:complexType>
+            </xs:element>
+            <xs:element name="data" type="xs:string" minOccurs="0"/>
+            <xs:element name="payload" minOccurs="0">
+              <xs:complexType>
+                <xs:sequence>
+                  <xs:any processContents="skip" namespace="##other" minOccurs="0" maxOccurs="unbounded"/>
+                </xs:sequence>
+              </xs:complexType>
+            </xs:element>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="expression" minOccurs="0" maxOccurs="unbounded">
+        <xs:complexType>
+          <xs:sequence/>
+          <xs:attribute name="path" type="xs:string" use="required"/>
+          <xs:attribute name="value" type="xs:string" use="required"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+    <xs:attribute name="data-dictionary" type="xs:string"/>
+    <xs:attribute name="schema-validation" type="xs:boolean"/>
+    <xs:attribute name="schema" type="xs:string"/>
+    <xs:attribute name="schema-repository" type="xs:string"/>
+    <xs:attribute name="name" type="xs:string"/>
+    <xs:attribute name="type" type="xs:string"/>
+  </xs:complexType>
+
+  <xs:complexType name="TestCaseType">
+    <xs:sequence>
+      <xs:element name="description" type="xs:string" minOccurs="0"/>
+      <xs:element name="variables" minOccurs="0">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="variable" maxOccurs="unbounded">
+              <xs:complexType>
+                <xs:sequence>
+                  <xs:element name="value" minOccurs="0">
+                    <xs:complexType>
+                      <xs:sequence>
+                        <xs:element name="script" type="tns:ScriptType" minOccurs="0"/>
+                        <xs:element name="data" type="xs:string" minOccurs="0"/>
+                      </xs:sequence>
+                    </xs:complexType>
+                  </xs:element>
+                </xs:sequence>
+                <xs:attribute name="name" type="xs:string" use="required"/>
+                <xs:attribute name="value" type="xs:string"/>
+              </xs:complexType>
+            </xs:element>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="actions" type="tns:TestActions" minOccurs="0"/>
+      <xs:element name="finally" type="tns:TestActions" minOccurs="0"/>
+    </xs:sequence>
+    <xs:attribute name="author" type="xs:string"/>
+    <xs:attribute name="name" type="xs:string"/>
+    <xs:attribute name="status" type="tns:StatusType"/>
+  </xs:complexType>
+
+  <xs:complexType name="TestActions">
+    <xs:sequence>
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="tns:action"/>
+        <xs:element ref="tns:echo"/>
+        <xs:element ref="tns:print"/>
+        <xs:element ref="tns:sleep"/>
+        <xs:element ref="tns:delay"/>
+        <xs:element ref="tns:receive"/>
+        <xs:element ref="tns:create-variables"/>
+        <xs:element ref="tns:create-endpoint"/>
+        <xs:element ref="tns:load"/>
+        <xs:element ref="tns:expect-timeout"/>
+        <xs:element ref="tns:fail"/>
+        <xs:element ref="tns:iterate"/>
+        <xs:element ref="tns:sequential"/>
+        <xs:element ref="tns:finally"/>
+        <xs:element ref="tns:parallel"/>
+        <xs:element ref="tns:repeat"/>
+        <xs:element ref="tns:repeat-on-error"/>
+        <xs:element ref="tns:conditional"/>
+        <xs:element ref="tns:assert"/>
+        <xs:element ref="tns:catch"/>
+        <xs:element ref="tns:wait-for"/>
+        <xs:element ref="tns:async"/>
+        <xs:element ref="tns:timer"/>
+        <xs:element ref="tns:stop-timer"/>
+        <xs:element ref="tns:stop-time"/>
+        <xs:element ref="tns:start"/>
+        <xs:element ref="tns:stop"/>
+        <xs:element ref="tns:trace-variables"/>
+        <xs:element ref="tns:trace"/>
+        <xs:element ref="tns:purge-endpoint"/>
+        <xs:element ref="tns:transform"/>
+        <xs:element ref="tns:apply-template"/>
+        <xs:any processContents="lax"/>
+      </xs:choice>
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="Template">
+    <xs:sequence>
+      <xs:element name="description" type="xs:string" minOccurs="0"/>
+      <xs:element name="parameters" minOccurs="0">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="parameter" minOccurs="0" maxOccurs="unbounded">
+              <xs:complexType>
+                <xs:sequence>
+                  <xs:element name="value" type="xs:string" minOccurs="0"/>
+                </xs:sequence>
+                <xs:attribute name="name" type="xs:string" use="required"/>
+                <xs:attribute name="value" type="xs:string"/>
+              </xs:complexType>
+            </xs:element>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="actions" type="tns:TestActions" minOccurs="0"/>
+    </xs:sequence>
+    <xs:attribute name="global-context" type="xs:boolean" use="required"/>
+    <xs:attribute name="name" type="xs:string"/>
+  </xs:complexType>
+
+  <xs:complexType name="Action">
+    <xs:sequence/>
+    <xs:attribute name="reference" type="xs:string" use="required"/>
+  </xs:complexType>
+
+  <xs:complexType name="Echo">
+    <xs:sequence>
+      <xs:element name="description" type="xs:string" minOccurs="0"/>
+      <xs:element name="message" type="xs:string" minOccurs="0"/>
+    </xs:sequence>
+    <xs:attribute name="message" type="xs:string"/>
+  </xs:complexType>
+
+  <xs:complexType name="Print">
+    <xs:complexContent>
+      <xs:extension base="tns:Echo">
+        <xs:sequence/>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+
+  <xs:complexType name="Sleep">
+    <xs:sequence>
+      <xs:element name="description" type="xs:string" minOccurs="0"/>
+    </xs:sequence>
+    <xs:attribute name="milliseconds" type="xs:string"/>
+    <xs:attribute name="seconds" type="xs:string"/>
+    <xs:attribute name="time" type="xs:string"/>
+  </xs:complexType>
+
+  <xs:complexType name="Receive">
+    <xs:sequence>
+      <xs:element name="description" type="xs:string" minOccurs="0"/>
+      <xs:element name="selector" minOccurs="0">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="element" minOccurs="0" maxOccurs="unbounded">
+              <xs:complexType>
+                <xs:sequence/>
+                <xs:attribute name="name" type="xs:string" use="required"/>
+                <xs:attribute name="value" type="xs:string" use="required"/>
+              </xs:complexType>
+            </xs:element>
+            <xs:element name="value" type="xs:string" minOccurs="0"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="message" type="tns:MessageType" minOccurs="0"/>
+      <xs:element name="ignore" minOccurs="0" maxOccurs="unbounded">
+        <xs:complexType>
+          <xs:sequence/>
+          <xs:attribute name="path" type="xs:string" use="required"/>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="namespace" minOccurs="0" maxOccurs="unbounded">
+        <xs:complexType>
+          <xs:sequence/>
+          <xs:attribute name="prefix" type="xs:string" use="required"/>
+          <xs:attribute name="value" type="xs:string" use="required"/>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="validate" minOccurs="0" maxOccurs="unbounded" type="tns:Validate"/>
+      <xs:element name="extract" minOccurs="0" maxOccurs="unbounded" type="tns:Extract"/>
+    </xs:sequence>
+    <xs:attribute name="actor" type="xs:string"/>
+    <xs:attribute name="endpoint" type="xs:string"/>
+    <xs:attribute name="header-validator" type="xs:string"/>
+    <xs:attribute name="header-validators" type="xs:string"/>
+    <xs:attribute name="select" type="xs:string"/>
+    <xs:attribute name="timeout" type="xs:int"/>
+    <xs:attribute name="validator" type="xs:string"/>
+    <xs:attribute name="validators" type="xs:string"/>
+  </xs:complexType>
+
+  <xs:complexType name="Send">
+    <xs:sequence>
+      <xs:element name="description" type="xs:string" minOccurs="0"/>
+      <xs:element name="message" type="tns:MessageType"/>
+      <xs:element name="extract" minOccurs="0" maxOccurs="unbounded" type="tns:Extract"/>
+    </xs:sequence>
+    <xs:attribute name="actor" type="xs:string"/>
+    <xs:attribute name="endpoint" type="xs:string"/>
+    <xs:attribute name="fork" type="xs:boolean"/>
+  </xs:complexType>
+
+  <xs:complexType name="Validate">
+    <xs:sequence>
+      <xs:element name="script" type="tns:ScriptType" minOccurs="0"/>
+      <xs:element name="xpath" minOccurs="0" maxOccurs="unbounded">
+        <xs:complexType>
+          <xs:sequence/>
+          <xs:attribute name="expression" type="xs:string" use="required"/>
+          <xs:attribute name="value" type="xs:string" use="required"/>
+          <xs:attribute name="result-type" type="xs:string"/>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="json-path" minOccurs="0" maxOccurs="unbounded">
+        <xs:complexType>
+          <xs:sequence/>
+          <xs:attribute name="expression" type="xs:string" use="required"/>
+          <xs:attribute name="value" type="xs:string" use="required"/>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="namespace" minOccurs="0" maxOccurs="unbounded">
+        <xs:complexType>
+          <xs:sequence/>
+          <xs:attribute name="prefix" type="xs:string" use="required"/>
+          <xs:attribute name="value" type="xs:string" use="required"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+    <xs:attribute name="path" type="xs:string"/>
+    <xs:attribute name="value" type="xs:string"/>
+    <xs:attribute name="result-type" type="xs:string"/>
+  </xs:complexType>
+
+  <xs:complexType name="Extract">
+    <xs:sequence>
+      <xs:element name="header" minOccurs="0" maxOccurs="unbounded">
+        <xs:complexType>
+          <xs:sequence/>
+          <xs:attribute name="name" type="xs:string" use="required"/>
+          <xs:attribute name="variable" type="xs:string" use="required"/>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="body" minOccurs="0" maxOccurs="unbounded">
+        <xs:complexType>
+          <xs:simpleContent>
+            <xs:extension base="xs:string">
+              <xs:attribute name="path" type="xs:string" use="required"/>
+              <xs:attribute name="variable" type="xs:string" use="required"/>
+              <xs:attribute name="result-type" type="xs:string"/>
+            </xs:extension>
+          </xs:simpleContent>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="Delay">
+    <xs:complexContent>
+      <xs:extension base="tns:Sleep">
+        <xs:sequence/>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+
+  <xs:complexType name="CreateVariables">
+    <xs:sequence>
+      <xs:element name="description" type="xs:string" minOccurs="0"/>
+      <xs:element name="variable" type="tns:VariableType" maxOccurs="unbounded"/>
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="CreateEndpoint">
+    <xs:sequence>
+      <xs:element name="description" type="xs:string" minOccurs="0"/>
+      <xs:element name="properties" minOccurs="0">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="property" type="tns:PropertyType" maxOccurs="unbounded"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+    <xs:attribute name="name" type="xs:string"/>
+    <xs:attribute name="uri" type="xs:string"/>
+    <xs:attribute name="type" type="xs:string"/>
+  </xs:complexType>
+
+  <xs:complexType name="StopTimer">
+    <xs:sequence>
+      <xs:element name="description" type="xs:string" minOccurs="0"/>
+    </xs:sequence>
+    <xs:attribute name="id" type="xs:string"/>
+  </xs:complexType>
+
+  <xs:complexType name="LoadProperties">
+    <xs:sequence>
+      <xs:element name="properties" minOccurs="0">
+        <xs:complexType>
+          <xs:sequence/>
+          <xs:attribute name="file" type="xs:string" use="required"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="StopTime">
+    <xs:sequence>
+      <xs:element name="description" type="xs:string" minOccurs="0"/>
+    </xs:sequence>
+    <xs:attribute name="id" type="xs:string"/>
+    <xs:attribute name="suffix" type="xs:string"/>
+  </xs:complexType>
+
+  <xs:complexType name="Start">
+    <xs:sequence>
+      <xs:element name="servers" minOccurs="0">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="server" minOccurs="0" maxOccurs="unbounded">
+              <xs:complexType>
+                <xs:sequence/>
+                <xs:attribute name="name" type="xs:string" use="required"/>
+              </xs:complexType>
+            </xs:element>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+    <xs:attribute name="server" type="xs:string"/>
+  </xs:complexType>
+
+  <xs:complexType name="Stop">
+    <xs:sequence>
+      <xs:element name="servers" minOccurs="0">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="server" minOccurs="0" maxOccurs="unbounded">
+              <xs:complexType>
+                <xs:sequence/>
+                <xs:attribute name="name" type="xs:string" use="required"/>
+              </xs:complexType>
+            </xs:element>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+    <xs:attribute name="server" type="xs:string"/>
+  </xs:complexType>
+
+  <xs:complexType name="TraceVariables">
+    <xs:sequence>
+      <xs:element name="variable" minOccurs="0" maxOccurs="unbounded">
+        <xs:complexType>
+          <xs:sequence/>
+          <xs:attribute name="name" type="xs:string" use="required"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+    <xs:attribute name="variable" type="xs:string"/>
+  </xs:complexType>
+
+  <xs:complexType name="PurgeEndpoint">
+    <xs:sequence>
+      <xs:element name="selector" minOccurs="0">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="element" minOccurs="0" maxOccurs="unbounded">
+              <xs:complexType>
+                <xs:sequence/>
+                <xs:attribute name="name" type="xs:string" use="required"/>
+                <xs:attribute name="value" type="xs:string" use="required"/>
+              </xs:complexType>
+            </xs:element>
+            <xs:element name="value" type="xs:string" minOccurs="0"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="endpoint" minOccurs="0" maxOccurs="unbounded">
+        <xs:complexType>
+          <xs:sequence/>
+          <xs:attribute name="name" type="xs:string"/>
+          <xs:attribute name="ref" type="xs:string"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+    <xs:attribute name="endpoint" type="xs:string"/>
+    <xs:attribute name="select" type="xs:string"/>
+    <xs:attribute name="sleep" type="xs:long"/>
+    <xs:attribute name="timeout" type="xs:long"/>
+  </xs:complexType>
+
+  <xs:complexType name="ExpectTimeout">
+    <xs:sequence>
+      <xs:element name="selector" minOccurs="0">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="element" minOccurs="0" maxOccurs="unbounded">
+              <xs:complexType>
+                <xs:sequence/>
+                <xs:attribute name="name" type="xs:string" use="required"/>
+                <xs:attribute name="value" type="xs:string" use="required"/>
+              </xs:complexType>
+            </xs:element>
+            <xs:element name="value" type="xs:string" minOccurs="0"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+    <xs:attribute name="endpoint" type="xs:string" use="required"/>
+    <xs:attribute name="select" type="xs:string"/>
+    <xs:attribute name="wait" type="xs:long"/>
+  </xs:complexType>
+
+  <xs:complexType name="Fail">
+    <xs:sequence>
+      <xs:element name="description" type="xs:string" minOccurs="0"/>
+      <xs:element name="message" type="xs:string" minOccurs="0"/>
+    </xs:sequence>
+    <xs:attribute name="message" type="xs:string"/>
+  </xs:complexType>
+
+  <xs:complexType name="Iterate">
+    <xs:sequence>
+      <xs:element name="description" type="xs:string" minOccurs="0"/>
+      <xs:element name="actions" type="tns:TestActions" minOccurs="0"/>
+    </xs:sequence>
+    <xs:attribute name="condition" type="xs:string" use="required"/>
+    <xs:attribute name="index" type="xs:string"/>
+    <xs:attribute name="startsWith" type="xs:int"/>
+    <xs:attribute name="step" type="xs:int"/>
+  </xs:complexType>
+
+  <xs:complexType name="Sequential">
+    <xs:sequence>
+      <xs:element name="description" type="xs:string" minOccurs="0"/>
+      <xs:element name="actions" type="tns:TestActions" minOccurs="0"/>
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="DoFinally">
+    <xs:sequence>
+      <xs:element name="description" type="xs:string" minOccurs="0"/>
+      <xs:element name="actions" type="tns:TestActions" minOccurs="0"/>
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="Parallel">
+    <xs:sequence>
+      <xs:element name="description" type="xs:string" minOccurs="0"/>
+      <xs:element name="actions" type="tns:TestActions" minOccurs="0"/>
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="Repeat">
+    <xs:sequence>
+      <xs:element name="description" type="xs:string" minOccurs="0"/>
+      <xs:element name="actions" type="tns:TestActions" minOccurs="0"/>
+    </xs:sequence>
+    <xs:attribute name="index" type="xs:string"/>
+    <xs:attribute name="startsWith" type="xs:int"/>
+    <xs:attribute name="until" type="xs:string" use="required"/>
+  </xs:complexType>
+
+  <xs:complexType name="RepeatOnError">
+    <xs:sequence>
+      <xs:element name="description" type="xs:string" minOccurs="0"/>
+      <xs:element name="actions" type="tns:TestActions" minOccurs="0"/>
+    </xs:sequence>
+    <xs:attribute name="autoSleep" type="xs:long"/>
+    <xs:attribute name="auto-sleep" type="xs:long"/>
+    <xs:attribute name="index" type="xs:string"/>
+    <xs:attribute name="startsWith" type="xs:int"/>
+    <xs:attribute name="until" type="xs:string" use="required"/>
+  </xs:complexType>
+
+  <xs:complexType name="Conditional">
+    <xs:sequence>
+      <xs:element name="description" type="xs:string" minOccurs="0"/>
+      <xs:element name="actions" type="tns:TestActions" minOccurs="0"/>
+    </xs:sequence>
+    <xs:attribute name="when" type="xs:string" use="required"/>
+  </xs:complexType>
+
+  <xs:complexType name="Assert">
+    <xs:sequence>
+      <xs:element name="description" type="xs:string" minOccurs="0"/>
+      <xs:element name="when" type="tns:TestActions"/>
+    </xs:sequence>
+    <xs:attribute name="exception" type="xs:string"/>
+    <xs:attribute name="message" type="xs:string"/>
+  </xs:complexType>
+
+  <xs:complexType name="Catch">
+    <xs:sequence>
+      <xs:element name="description" type="xs:string" minOccurs="0"/>
+      <xs:element name="when" type="tns:TestActions"/>
+    </xs:sequence>
+    <xs:attribute name="exception" type="xs:string"/>
+  </xs:complexType>
+
+  <xs:complexType name="WaitFor">
+    <xs:sequence>
+      <xs:element name="description" type="xs:string" minOccurs="0"/>
+      <xs:choice>
+        <xs:element name="action" type="tns:TestActions"/>
+        <xs:element name="file">
+          <xs:complexType>
+            <xs:sequence/>
+            <xs:attribute name="path" type="xs:string" use="required"/>
+          </xs:complexType>
+        </xs:element>
+        <xs:element name="http">
+          <xs:complexType>
+            <xs:sequence/>
+            <xs:attribute name="url" type="xs:string"/>
+            <xs:attribute name="method" type="xs:string"/>
+            <xs:attribute name="status" type="xs:string"/>
+            <xs:attribute name="timeout" type="xs:string"/>
+          </xs:complexType>
+        </xs:element>
+        <xs:element name="message">
+          <xs:complexType>
+            <xs:sequence/>
+            <xs:attribute name="name" type="xs:string" use="required"/>
+          </xs:complexType>
+        </xs:element>
+      </xs:choice>
+    </xs:sequence>
+    <xs:attribute name="interval" type="xs:string"/>
+    <xs:attribute name="timeout" type="xs:string"/>
+  </xs:complexType>
+
+  <xs:complexType name="Async">
+    <xs:sequence>
+      <xs:element name="description" type="xs:string" minOccurs="0"/>
+      <xs:element name="actions" type="tns:TestActions"/>
+      <xs:element name="error" type="tns:TestActions" minOccurs="0"/>
+      <xs:element name="success" type="tns:TestActions" minOccurs="0"/>
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="Timer">
+    <xs:sequence>
+      <xs:element name="description" type="xs:string" minOccurs="0"/>
+      <xs:element name="actions" type="tns:TestActions"/>
+    </xs:sequence>
+    <xs:attribute name="id" type="xs:string"/>
+    <xs:attribute name="delay" type="xs:long"/>
+    <xs:attribute name="fork" type="xs:boolean"/>
+    <xs:attribute name="auto-stop" type="xs:boolean"/>
+    <xs:attribute name="interval" type="xs:long"/>
+    <xs:attribute name="repeatCount" type="xs:int"/>
+  </xs:complexType>
+
+  <xs:complexType name="Transform">
+    <xs:sequence>
+      <xs:element name="description" type="xs:string" minOccurs="0"/>
+      <xs:element name="source">
+        <xs:complexType>
+          <xs:simpleContent>
+            <xs:extension base="xs:string">
+              <xs:attribute name="file" type="xs:string"/>
+              <xs:attribute name="charset" type="xs:string"/>
+            </xs:extension>
+          </xs:simpleContent>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="xslt">
+        <xs:complexType>
+          <xs:simpleContent>
+            <xs:extension base="xs:string">
+              <xs:attribute name="file" type="xs:string"/>
+              <xs:attribute name="charset" type="xs:string"/>
+            </xs:extension>
+          </xs:simpleContent>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+    <xs:attribute name="result" type="xs:string"/>
+    <xs:attribute name="variable" type="xs:string"/>
+  </xs:complexType>
+
+  <xs:complexType name="ApplyTemplate">
+    <xs:sequence>
+      <xs:element name="parameters" minOccurs="0">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="parameter" minOccurs="0" maxOccurs="unbounded">
+              <xs:complexType>
+                <xs:sequence>
+                  <xs:element name="value" type="xs:string" minOccurs="0"/>
+                </xs:sequence>
+                <xs:attribute name="name" type="xs:string" use="required"/>
+                <xs:attribute name="value" type="xs:string"/>
+              </xs:complexType>
+            </xs:element>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+    <xs:attribute name="file" type="xs:string"/>
+    <xs:attribute name="name" type="xs:string"/>
+  </xs:complexType>
+
+  <xs:element name="test" type="tns:TestCaseType"/>
+  <xs:element name="template" type="tns:Template"/>
+
+  <xs:element name="action" type="tns:Action"/>
+  <xs:element name="apply-template" type="tns:ApplyTemplate"/>
+  <xs:element name="assert" type="tns:Assert"/>
+  <xs:element name="async" type="tns:Async"/>
+  <xs:element name="catch" type="tns:Catch"/>
+  <xs:element name="conditional" type="tns:Conditional"/>
+  <xs:element name="create-variables" type="tns:CreateVariables"/>
+  <xs:element name="create-endpoint" type="tns:CreateEndpoint"/>
+  <xs:element name="delay" type="tns:Delay"/>
+  <xs:element name="echo" type="tns:Echo"/>
+  <xs:element name="expect-timeout" type="tns:ExpectTimeout"/>
+  <xs:element name="fail" type="tns:Fail"/>
+  <xs:element name="iterate" type="tns:Iterate"/>
+  <xs:element name="load" type="tns:LoadProperties"/>
+  <xs:element name="parallel" type="tns:Parallel"/>
+  <xs:element name="print" type="tns:Print"/>
+  <xs:element name="purge-endpoint" type="tns:PurgeEndpoint"/>
+  <xs:element name="receive" type="tns:Receive"/>
+  <xs:element name="repeat" type="tns:Repeat"/>
+  <xs:element name="repeat-on-error" type="tns:RepeatOnError"/>
+  <xs:element name="send" type="tns:Send"/>
+  <xs:element name="sequential" type="tns:Sequential"/>
+  <xs:element name="finally" type="tns:DoFinally"/>
+  <xs:element name="sleep" type="tns:Sleep"/>
+  <xs:element name="start" type="tns:Start"/>
+  <xs:element name="stop" type="tns:Stop"/>
+  <xs:element name="stop-time" type="tns:StopTime"/>
+  <xs:element name="stop-timer" type="tns:StopTimer"/>
+  <xs:element name="timer" type="tns:Timer"/>
+  <xs:element name="trace" type="tns:TraceVariables"/>
+  <xs:element name="trace-variables" type="tns:TraceVariables"/>
+  <xs:element name="transform" type="tns:Transform"/>
+  <xs:element name="wait-for" type="tns:WaitFor"/>
+
+  <!-- Additional modules -->
+  <xs:element name="plsql" type="tns:Plsql"/>
+  <xs:element name="sql" type="tns:Sql"/>
+  <xs:element name="purge-jms-queues" type="tns:PurgeQueues"/>
+  <xs:element name="purge-channels" type="tns:PurgeChannels"/>
+  <xs:element name="groovy" type="tns:Groovy"/>
+  <xs:element name="http" type="tns:Http"/>
+  <xs:element name="openapi" type="tns:OpenApi"/>
+  <xs:element name="soap" type="tns:Soap"/>
+  <xs:element name="camel" type="tns:Camel"/>
+  <xs:element name="selenium" type="tns:Selenium"/>
+  <xs:element name="agent" type="tns:Agent"/>
+  <xs:element name="jbang" type="tns:JBang"/>
+  <xs:element name="kubernetes" type="tns:Kubernetes"/>
+  <xs:element name="knative" type="tns:Knative"/>
+  <xs:element name="testcontainers" type="tns:Testcontainers"/>
+
+  <xs:complexType name="Plsql">
+    <xs:sequence>
+      <xs:element name="description" type="xs:string" minOccurs="0"/>
+      <xs:element name="transaction" minOccurs="0">
+        <xs:complexType>
+          <xs:sequence/>
+          <xs:attribute name="manager" type="xs:string"/>
+          <xs:attribute name="timeout" type="xs:string"/>
+          <xs:attribute name="isolation-level" type="xs:string"/>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="statements">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="statement" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element name="script" type="xs:string" minOccurs="0"/>
+          </xs:sequence>
+          <xs:attribute name="file" type="xs:string"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+    <xs:attribute name="datasource" type="xs:string" use="required"/>
+    <xs:attribute name="ignore-errors" type="xs:boolean"/>
+  </xs:complexType>
+
+  <xs:complexType name="Sql">
+    <xs:sequence>
+      <xs:element name="description" type="xs:string" minOccurs="0"/>
+      <xs:element name="transaction" minOccurs="0">
+        <xs:complexType>
+          <xs:sequence/>
+          <xs:attribute name="manager" type="xs:string"/>
+          <xs:attribute name="timeout" type="xs:string"/>
+          <xs:attribute name="isolation-level" type="xs:string"/>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="statements">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="statement" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+          </xs:sequence>
+          <xs:attribute name="file" type="xs:string"/>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="validate" minOccurs="0" maxOccurs="unbounded">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="values" minOccurs="0">
+              <xs:complexType>
+                <xs:sequence>
+                  <xs:element name="value" type="xs:string" maxOccurs="unbounded"/>
+                </xs:sequence>
+              </xs:complexType>
+            </xs:element>
+            <xs:element name="script" minOccurs="0">
+              <xs:complexType>
+                <xs:simpleContent>
+                  <xs:extension base="xs:string">
+                    <xs:attribute name="type" type="xs:string" use="required"/>
+                    <xs:attribute name="file" type="xs:string"/>
+                    <xs:attribute name="charset" type="xs:string"/>
+                  </xs:extension>
+                </xs:simpleContent>
+              </xs:complexType>
+            </xs:element>
+          </xs:sequence>
+          <xs:attribute name="column" type="xs:string"/>
+          <xs:attribute name="value" type="xs:string"/>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="extract" minOccurs="0" maxOccurs="unbounded">
+        <xs:complexType>
+          <xs:sequence/>
+          <xs:attribute name="column" type="xs:string" use="required"/>
+          <xs:attribute name="variable" type="xs:string" use="required"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+    <xs:attribute name="datasource" type="xs:string"/>
+    <xs:attribute name="ignore-errors" type="xs:boolean"/>
+  </xs:complexType>
+
+  <xs:complexType name="PurgeQueues">
+    <xs:annotation>
+      <xs:documentation>Continuously receives messages from a destination until no more messages are left - emulating the purge operation</xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="description" type="xs:string" minOccurs="0"/>
+      <xs:element name="queue" maxOccurs="unbounded">
+        <xs:complexType>
+          <xs:attribute name="name" type="xs:string"/>
+          <xs:attribute name="ref" type="xs:string"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+    <xs:attribute name="connection-factory" type="xs:string"/>
+    <xs:attribute name="timeout" type="xs:int"/>
+    <xs:attribute name="sleep" type="xs:int"/>
+  </xs:complexType>
+
+  <xs:complexType name="PurgeChannels">
+    <xs:annotation>
+      <xs:documentation>Continuously receives messages from a Spring Integration message channel destination until no more messages are left - emulating the purge operation</xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="description" type="xs:string" minOccurs="0"/>
+      <xs:element name="channel" maxOccurs="unbounded">
+        <xs:complexType>
+          <xs:attribute name="name" type="xs:string"/>
+          <xs:attribute name="ref" type="xs:string"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+    <xs:attribute name="channel-resolver" type="xs:string"/>
+    <xs:attribute name="message-selector" type="xs:string"/>
+  </xs:complexType>
+
+  <xs:complexType name="Groovy">
+    <xs:sequence>
+      <xs:element name="description" type="xs:string" minOccurs="0"/>
+      <xs:choice>
+        <xs:element name="script">
+          <xs:complexType>
+            <xs:simpleContent>
+              <xs:extension base="xs:string">
+                <xs:attribute name="file" type="xs:string"/>
+                <xs:attribute name="script-template" type="xs:string"/>
+                <xs:attribute name="use-script-template" type="xs:boolean"/>
+              </xs:extension>
+            </xs:simpleContent>
+          </xs:complexType>
+        </xs:element>
+        <xs:element name="endpoints">
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element name="script">
+                <xs:complexType>
+                  <xs:simpleContent>
+                    <xs:extension base="xs:string">
+                      <xs:attribute name="file" type="xs:string"/>
+                    </xs:extension>
+                  </xs:simpleContent>
+                </xs:complexType>
+              </xs:element>
+            </xs:sequence>
+          </xs:complexType>
+        </xs:element>
+        <xs:element name="beans">
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element name="script">
+                <xs:complexType>
+                  <xs:simpleContent>
+                    <xs:extension base="xs:string">
+                      <xs:attribute name="file" type="xs:string"/>
+                    </xs:extension>
+                  </xs:simpleContent>
+                </xs:complexType>
+              </xs:element>
+            </xs:sequence>
+          </xs:complexType>
+        </xs:element>
+      </xs:choice>
+    </xs:sequence>
+    <xs:attribute name="actor" type="xs:string"/>
+  </xs:complexType>
+
+  <xs:complexType name="Camel">
+    <xs:sequence>
+      <xs:element name="description" type="xs:string" minOccurs="0"/>
+      <xs:choice>
+        <xs:element name="create-component">
+          <xs:annotation>
+            <xs:documentation>Creates new Camel component and binds to Camel registry</xs:documentation>
+          </xs:annotation>
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element name="script" type="xs:string" minOccurs="0"/>
+            </xs:sequence>
+            <xs:attribute name="name" use="required" type="xs:string"/>
+            <xs:attribute name="file" type="xs:string"/>
+          </xs:complexType>
+        </xs:element>
+        <xs:element name="create-context">
+          <xs:annotation>
+            <xs:documentation>Creates new Camel context on the fly</xs:documentation>
+          </xs:annotation>
+          <xs:complexType>
+            <xs:sequence>
+              <xs:any processContents="skip" namespace="http://camel.apache.org/schema/spring"/>
+            </xs:sequence>
+            <xs:attribute name="name" use="required" type="xs:string"/>
+            <xs:attribute name="autoStart" type="xs:boolean"/>
+          </xs:complexType>
+        </xs:element>
+        <xs:element name="start-context">
+          <xs:annotation>
+            <xs:documentation>Starts Camel context</xs:documentation>
+          </xs:annotation>
+          <xs:complexType>
+            <xs:attribute name="name" use="required" type="xs:string"/>
+          </xs:complexType>
+        </xs:element>
+        <xs:element name="stop-context">
+          <xs:annotation>
+            <xs:documentation>Stops Camel context</xs:documentation>
+          </xs:annotation>
+          <xs:complexType>
+            <xs:attribute name="name" use="required" type="xs:string"/>
+          </xs:complexType>
+        </xs:element>
+        <xs:element name="create-routes">
+          <xs:annotation>
+            <xs:documentation>Creates new Camel routes on the fly</xs:documentation>
+          </xs:annotation>
+          <xs:complexType>
+            <xs:choice>
+              <xs:any processContents="skip" namespace="http://camel.apache.org/schema/spring"/>
+              <xs:element name="route">
+                <xs:complexType>
+                  <xs:complexContent>
+                    <xs:extension base="xs:string">
+                      <xs:attribute name="id" type="xs:string"/>
+                      <xs:attribute name="file" type="xs:string"/>
+                    </xs:extension>
+                  </xs:complexContent>
+                </xs:complexType>
+              </xs:element>
+            </xs:choice>
+          </xs:complexType>
+        </xs:element>
+        <xs:element name="start-routes">
+          <xs:annotation>
+            <xs:documentation>Start Camel routes on context</xs:documentation>
+          </xs:annotation>
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element name="route" minOccurs="1" maxOccurs="unbounded">
+                <xs:complexType>
+                  <xs:attribute name="id" use="required"/>
+                </xs:complexType>
+              </xs:element>
+            </xs:sequence>
+          </xs:complexType>
+        </xs:element>
+        <xs:element name="stop-routes">
+          <xs:annotation>
+            <xs:documentation>Start Camel routes on context</xs:documentation>
+          </xs:annotation>
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element name="route" minOccurs="1" maxOccurs="unbounded">
+                <xs:complexType>
+                  <xs:attribute name="id" use="required"/>
+                </xs:complexType>
+              </xs:element>
+            </xs:sequence>
+          </xs:complexType>
+        </xs:element>
+        <xs:element name="remove-routes">
+          <xs:annotation>
+            <xs:documentation>Start Camel routes on context</xs:documentation>
+          </xs:annotation>
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element name="route" minOccurs="1" maxOccurs="unbounded">
+                <xs:complexType>
+                  <xs:attribute name="id" use="required"/>
+                </xs:complexType>
+              </xs:element>
+            </xs:sequence>
+          </xs:complexType>
+        </xs:element>
+        <xs:element name="control-bus">
+          <xs:annotation>
+            <xs:documentation>Executes operations on Camel control bus</xs:documentation>
+          </xs:annotation>
+          <xs:complexType>
+            <xs:sequence>
+              <xs:choice>
+                <xs:element name="route">
+                  <xs:complexType>
+                    <xs:attribute name="id" type="xs:string" use="required"/>
+                    <xs:attribute name="action" use="required">
+                      <xs:simpleType>
+                        <xs:restriction base="xs:string">
+                          <xs:enumeration value="start"/>
+                          <xs:enumeration value="stop"/>
+                          <xs:enumeration value="suspend"/>
+                          <xs:enumeration value="resume"/>
+                          <xs:enumeration value="status"/>
+                          <xs:enumeration value="stats"/>
+                        </xs:restriction>
+                      </xs:simpleType>
+                    </xs:attribute>
+                  </xs:complexType>
+                </xs:element>
+                <xs:element name="language">
+                  <xs:complexType>
+                    <xs:simpleContent>
+                      <xs:extension base="xs:string">
+                        <xs:attribute name="type" type="xs:string" default="simple"/>
+                      </xs:extension>
+                    </xs:simpleContent>
+                  </xs:complexType>
+                </xs:element>
+              </xs:choice>
+              <xs:element name="result" type="xs:string" minOccurs="0"/>
+            </xs:sequence>
+          </xs:complexType>
+        </xs:element>
+        <xs:element name="infra">
+          <xs:annotation>
+            <xs:documentation>Creates new Camel infra actions</xs:documentation>
+          </xs:annotation>
+          <xs:complexType>
+            <xs:choice>
+              <xs:element name="run">
+                <xs:complexType>
+                  <xs:attribute name="service" use="required" type="xs:string"/>
+                  <xs:attribute name="implementation" type="xs:string"/>
+                  <xs:attribute name="catalog" type="xs:string"/>
+                  <xs:attribute name="auto-remove" type="xs:boolean"/>
+                </xs:complexType>
+              </xs:element>
+              <xs:element name="stop">
+                <xs:complexType>
+                  <xs:attribute name="service" use="required" type="xs:string"/>
+                  <xs:attribute name="implementation" type="xs:string"/>
+                </xs:complexType>
+              </xs:element>
+            </xs:choice>
+          </xs:complexType>
+        </xs:element>
+        <xs:element name="jbang">
+          <xs:annotation>
+            <xs:documentation>Creates new Camel JBang action</xs:documentation>
+          </xs:annotation>
+          <xs:complexType>
+            <xs:choice>
+              <xs:element name="cmd">
+                <xs:complexType>
+                  <xs:choice>
+                    <xs:element name="send">
+                      <xs:complexType>
+                        <xs:annotation>
+                          <xs:documentation>Sends a message via Camel JBang.</xs:documentation>
+                        </xs:annotation>
+                        <xs:sequence>
+                          <xs:element name="headers" minOccurs="0">
+                            <xs:complexType>
+                              <xs:sequence>
+                                <xs:element name="header" maxOccurs="unbounded">
+                                  <xs:complexType>
+                                    <xs:attribute name="name" type="xs:string" use="required"/>
+                                    <xs:attribute name="value" type="xs:string" use="required"/>
+                                  </xs:complexType>
+                                </xs:element>
+                              </xs:sequence>
+                            </xs:complexType>
+                          </xs:element>
+                          <xs:element name="body">
+                            <xs:complexType>
+                              <xs:sequence>
+                                <xs:element name="data" type="xs:string" minOccurs="0"/>
+                              </xs:sequence>
+                              <xs:attribute name="file" type="xs:string"/>
+                            </xs:complexType>
+                          </xs:element>
+                        </xs:sequence>
+                        <xs:attribute name="integration" type="xs:string"/>
+                        <xs:attribute name="endpoint" type="xs:string"/>
+                        <xs:attribute name="timeout" type="xs:string" default="20000"/>
+                        <xs:attribute name="uri" type="xs:string"/>
+                        <xs:attribute name="reply" type="xs:boolean"/>
+                        <xs:attribute name="args" type="xs:string"/>
+                      </xs:complexType>
+                    </xs:element>
+                    <xs:element name="receive">
+                      <xs:complexType>
+                        <xs:annotation>
+                          <xs:documentation>Receive a message via Camel JBang.</xs:documentation>
+                        </xs:annotation>
+                        <xs:attribute name="integration" type="xs:string"/>
+                        <xs:attribute name="endpoint" type="xs:string"/>
+                        <xs:attribute name="uri" type="xs:string"/>
+                        <xs:attribute name="logging-color" type="xs:boolean"/>
+                        <xs:attribute name="args" type="xs:string"/>
+                        <xs:attribute name="grep" type="xs:string"/>
+                        <xs:attribute name="since" type="xs:string"/>
+                        <xs:attribute name="tail" type="xs:string"/>
+                        <xs:attribute name="max-attempts" type="xs:int"/>
+                        <xs:attribute name="delay-between-attempts" type="xs:int"/>
+                        <xs:attribute name="print-logs" type="xs:boolean"/>
+                        <xs:attribute name="stop-on-error-status" type="xs:boolean"/>
+                      </xs:complexType>
+                    </xs:element>
+                  </xs:choice>
+                </xs:complexType>
+              </xs:element>
+              <xs:element name="plugin">
+                <xs:complexType>
+                  <xs:choice>
+                    <xs:element name="add">
+                      <xs:complexType>
+                        <xs:annotation>
+                          <xs:documentation>Add a Camel JBang plugin.</xs:documentation>
+                        </xs:annotation>
+                        <xs:attribute name="name" type="xs:string" use="required"/>
+                        <xs:attribute name="args" type="xs:string"/>
+                      </xs:complexType>
+                    </xs:element>
+                  </xs:choice>
+                </xs:complexType>
+              </xs:element>
+              <xs:element name="kubernetes">
+                <xs:complexType>
+                  <xs:choice>
+                    <xs:element name="run">
+                      <xs:complexType>
+                        <xs:annotation>
+                          <xs:documentation>Run a Camel integration in Kubernetes.</xs:documentation>
+                        </xs:annotation>
+                        <xs:sequence>
+                          <xs:element name="integration">
+                            <xs:complexType>
+                              <xs:sequence>
+                                <xs:element name="source" type="xs:string" minOccurs="0"/>
+                              </xs:sequence>
+                              <xs:attribute name="file" type="xs:string"/>
+                            </xs:complexType>
+                          </xs:element>
+                          <xs:element name="args" minOccurs="0">
+                            <xs:complexType>
+                              <xs:sequence>
+                                <xs:element name="argument" type="xs:string" maxOccurs="unbounded"/>
+                              </xs:sequence>
+                            </xs:complexType>
+                          </xs:element>
+                          <xs:element name="build-properties" minOccurs="0">
+                            <xs:complexType>
+                              <xs:sequence>
+                                <xs:element name="property" maxOccurs="unbounded">
+                                  <xs:complexType>
+                                    <xs:attribute name="name" use="required" type="xs:string"/>
+                                    <xs:attribute name="value" use="required" type="xs:string"/>
+                                  </xs:complexType>
+                                </xs:element>
+                              </xs:sequence>
+                            </xs:complexType>
+                          </xs:element>
+                          <xs:element name="properties" minOccurs="0">
+                            <xs:complexType>
+                              <xs:sequence>
+                                <xs:element name="property" maxOccurs="unbounded">
+                                  <xs:complexType>
+                                    <xs:attribute name="name" use="required" type="xs:string"/>
+                                    <xs:attribute name="value" use="required" type="xs:string"/>
+                                  </xs:complexType>
+                                </xs:element>
+                              </xs:sequence>
+                            </xs:complexType>
+                          </xs:element>
+                          <xs:element name="traits" minOccurs="0">
+                            <xs:complexType>
+                              <xs:sequence>
+                                <xs:element name="trait" maxOccurs="unbounded">
+                                  <xs:complexType>
+                                    <xs:attribute name="name" use="required" type="xs:string"/>
+                                    <xs:attribute name="value" use="required" type="xs:string"/>
+                                  </xs:complexType>
+                                </xs:element>
+                              </xs:sequence>
+                            </xs:complexType>
+                          </xs:element>
+                        </xs:sequence>
+                        <xs:attribute name="args" type="xs:string"/>
+                        <xs:attribute name="verbose" type="xs:boolean"/>
+                        <xs:attribute name="auto-remove" type="xs:boolean"/>
+                        <xs:attribute name="wait-for-running-state" type="xs:boolean"/>
+                        <xs:attribute name="runtime" type="xs:string"/>
+                        <xs:attribute name="image-registry" type="xs:string"/>
+                        <xs:attribute name="image-builder" type="xs:string"/>
+                        <xs:attribute name="cluster-type" type="xs:string"/>
+                      </xs:complexType>
+                    </xs:element>
+                    <xs:element name="verify">
+                      <xs:annotation>
+                        <xs:documentation>Verifies a Camel integration in kubernetes, for instance its status or the presence of a log message</xs:documentation>
+                      </xs:annotation>
+                      <xs:complexType>
+                        <xs:sequence>
+                          <xs:element name="args" minOccurs="0">
+                            <xs:complexType>
+                              <xs:sequence>
+                                <xs:element name="argument" type="xs:string" maxOccurs="unbounded"/>
+                              </xs:sequence>
+                            </xs:complexType>
+                          </xs:element>
+                        </xs:sequence>
+                        <xs:attribute name="integration" type="xs:string"/>
+                        <xs:attribute name="label" type="xs:string"/>
+                        <xs:attribute name="namespace" type="xs:string"/>
+                        <xs:attribute name="log-message" type="xs:string"/>
+                        <xs:attribute name="max-attempts" type="xs:int"/>
+                        <xs:attribute name="delay-between-attempts" type="xs:int"/>
+                        <xs:attribute name="print-logs" type="xs:boolean"/>
+                      </xs:complexType>
+                    </xs:element>
+                    <xs:element name="delete">
+                      <xs:complexType>
+                        <xs:annotation>
+                          <xs:documentation>Delete kubernetes resources deployed from a Camel project or Camel integration.</xs:documentation>
+                        </xs:annotation>
+                        <xs:sequence>
+                          <xs:element name="integration">
+                            <xs:complexType>
+                              <xs:attribute type="xs:string" name="file"/>
+                              <xs:attribute type="xs:string" name="name"/>
+                            </xs:complexType>
+                          </xs:element>
+                        </xs:sequence>
+                        <xs:attribute name="cluster-type" type="xs:string"/>
+                        <xs:attribute name="namespace" type="xs:string"/>
+                        <xs:attribute name="working-dir" type="xs:string"/>
+                      </xs:complexType>
+                    </xs:element>
+                  </xs:choice>
+                </xs:complexType>
+              </xs:element>
+              <xs:element name="run">
+                <xs:annotation>
+                  <xs:documentation>Runs a Camel integration via JBang</xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                  <xs:sequence>
+                    <xs:element name="args" minOccurs="0">
+                      <xs:complexType>
+                        <xs:sequence>
+                          <xs:element name="argument" type="xs:string" maxOccurs="unbounded"/>
+                        </xs:sequence>
+                      </xs:complexType>
+                    </xs:element>
+                    <xs:element name="integration">
+                      <xs:complexType>
+                        <xs:sequence>
+                          <xs:element name="environment" minOccurs="0">
+                            <xs:complexType>
+                              <xs:sequence>
+                                <xs:element name="variable" maxOccurs="unbounded">
+                                  <xs:complexType>
+                                    <xs:attribute name="name" use="required" type="xs:string"/>
+                                    <xs:attribute name="value" use="required" type="xs:string"/>
+                                  </xs:complexType>
+                                </xs:element>
+                              </xs:sequence>
+                              <xs:attribute name="file" type="xs:string"/>
+                            </xs:complexType>
+                          </xs:element>
+                          <xs:element name="system-properties" minOccurs="0">
+                            <xs:complexType>
+                              <xs:sequence>
+                                <xs:element name="property" maxOccurs="unbounded">
+                                  <xs:complexType>
+                                    <xs:attribute name="name" use="required" type="xs:string"/>
+                                    <xs:attribute name="value" use="required" type="xs:string"/>
+                                  </xs:complexType>
+                                </xs:element>
+                              </xs:sequence>
+                              <xs:attribute name="file" type="xs:string"/>
+                            </xs:complexType>
+                          </xs:element>
+                          <xs:element name="source" type="xs:string" minOccurs="0"/>
+                        </xs:sequence>
+                        <xs:attribute name="name" type="xs:string"/>
+                        <xs:attribute name="file" type="xs:string"/>
+                      </xs:complexType>
+                    </xs:element>
+                    <xs:element name="resources" minOccurs="0">
+                      <xs:complexType>
+                        <xs:sequence>
+                          <xs:element name="resource" type="xs:string" maxOccurs="unbounded"/>
+                        </xs:sequence>
+                      </xs:complexType>
+                    </xs:element>
+                    <xs:element name="stubs" minOccurs="0">
+                      <xs:complexType>
+                        <xs:sequence>
+                          <xs:element name="stub" type="xs:string" maxOccurs="unbounded"/>
+                        </xs:sequence>
+                      </xs:complexType>
+                    </xs:element>
+                  </xs:sequence>
+                  <xs:attribute name="stub" type="xs:string"/>
+                  <xs:attribute name="args" type="xs:string"/>
+                  <xs:attribute name="auto-remove" type="xs:boolean"/>
+                  <xs:attribute name="wait-for-running-state" type="xs:boolean"/>
+                  <xs:attribute name="dump-integration-output" type="xs:boolean"/>
+                </xs:complexType>
+              </xs:element>
+              <xs:element name="stop">
+                <xs:annotation>
+                  <xs:documentation>Stops a Camel integration identified by its name</xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                  <xs:sequence/>
+                  <xs:attribute name="integration" type="xs:string"/>
+                </xs:complexType>
+              </xs:element>
+              <xs:element name="custom">
+                <xs:annotation>
+                  <xs:documentation>Runs a Camel (custom parameterized) integration via JBang</xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                  <xs:sequence>
+                    <xs:element name="commands" minOccurs="0">
+                      <xs:complexType>
+                        <xs:sequence>
+                          <xs:element name="command" type="xs:string" maxOccurs="unbounded"/>
+                        </xs:sequence>
+                      </xs:complexType>
+                    </xs:element>
+                    <xs:element name="args" minOccurs="0">
+                      <xs:complexType>
+                        <xs:sequence>
+                          <xs:element name="argument" type="xs:string" maxOccurs="unbounded"/>
+                        </xs:sequence>
+                      </xs:complexType>
+                    </xs:element>
+                    <xs:element name="integration">
+                      <xs:complexType>
+                        <xs:sequence>
+                          <xs:element name="environment" minOccurs="0">
+                            <xs:complexType>
+                              <xs:sequence>
+                                <xs:element name="variable" maxOccurs="unbounded">
+                                  <xs:complexType>
+                                    <xs:attribute name="name" use="required" type="xs:string"/>
+                                    <xs:attribute name="value" use="required" type="xs:string"/>
+                                  </xs:complexType>
+                                </xs:element>
+                              </xs:sequence>
+                              <xs:attribute name="file" type="xs:string"/>
+                            </xs:complexType>
+                          </xs:element>
+                          <xs:element name="system-properties" minOccurs="0">
+                            <xs:complexType>
+                              <xs:sequence>
+                                <xs:element name="property" maxOccurs="unbounded">
+                                  <xs:complexType>
+                                    <xs:attribute name="name" use="required" type="xs:string"/>
+                                    <xs:attribute name="value" use="required" type="xs:string"/>
+                                  </xs:complexType>
+                                </xs:element>
+                              </xs:sequence>
+                              <xs:attribute name="file" type="xs:string"/>
+                            </xs:complexType>
+                          </xs:element>
+                        </xs:sequence>
+                        <xs:attribute name="name" type="xs:string"/>
+                        <xs:attribute name="file" type="xs:string"/>
+                      </xs:complexType>
+                    </xs:element>
+                    <xs:element name="resources" minOccurs="0">
+                      <xs:complexType>
+                        <xs:sequence>
+                          <xs:element name="resource" type="xs:string" maxOccurs="unbounded"/>
+                        </xs:sequence>
+                      </xs:complexType>
+                    </xs:element>
+                  </xs:sequence>
+                  <xs:attribute name="commands" type="xs:string"/>
+                  <xs:attribute name="workDir" type="xs:string"/>
+                  <xs:attribute name="processName" type="xs:string"/>
+                  <xs:attribute name="args" type="xs:string"/>
+                  <xs:attribute name="auto-remove" type="xs:boolean"/>
+                  <xs:attribute name="wait-for-running-state" type="xs:boolean"/>
+                  <xs:attribute name="dump-integration-output" type="xs:boolean"/>
+                </xs:complexType>
+              </xs:element>
+              <xs:element name="verify">
+                <xs:annotation>
+                  <xs:documentation>Verifies a Camel integration, for instance its status or the presence of a log message</xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                  <xs:sequence/>
+                  <xs:attribute name="integration" type="xs:string"/>
+                  <xs:attribute name="log-message" type="xs:string"/>
+                  <xs:attribute name="phase" type="xs:string"/>
+                  <xs:attribute name="max-attempts" type="xs:int"/>
+                  <xs:attribute name="delay-between-attempts" type="xs:int"/>
+                  <xs:attribute name="print-logs" type="xs:boolean"/>
+                  <xs:attribute name="stop-on-error-status" type="xs:boolean"/>
+                </xs:complexType>
+              </xs:element>
+            </xs:choice>
+            <xs:attribute name="camel-version" type="xs:string"/>
+            <xs:attribute name="kamelets-version" type="xs:string"/>
+          </xs:complexType>
+        </xs:element>
+      </xs:choice>
+    </xs:sequence>
+    <xs:attribute name="actor" type="xs:string"/>
+    <xs:attribute name="camel-context" type="xs:string"/>
+  </xs:complexType>
+
+  <xs:complexType name="Http">
+    <xs:sequence>
+      <xs:element name="description" type="xs:string" minOccurs="0"/>
+      <xs:choice>
+        <xs:element name="receive-request">
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element name="selector" type="xs:string" minOccurs="0"/>
+              <xs:choice>
+                <xs:element name="GET" type="tns:HttpRequest"/>
+                <xs:element name="POST" type="tns:HttpRequest"/>
+                <xs:element name="PUT" type="tns:HttpRequest"/>
+                <xs:element name="DELETE" type="tns:HttpRequest"/>
+                <xs:element name="HEAD" type="tns:HttpRequest"/>
+                <xs:element name="OPTIONS" type="tns:HttpRequest"/>
+                <xs:element name="PATCH" type="tns:HttpRequest"/>
+                <xs:element name="TRACE" type="tns:HttpRequest"/>
+              </xs:choice>
+              <xs:element name="validate" minOccurs="0" maxOccurs="unbounded" type="tns:Validate"/>
+              <xs:element name="extract" minOccurs="0" maxOccurs="unbounded" type="tns:Extract"/>
+            </xs:sequence>
+            <xs:attribute name="timeout" type="xs:int"/>
+            <xs:attribute name="select" type="xs:string"/>
+            <xs:attribute name="validator" type="xs:string"/>
+            <xs:attribute name="validators" type="xs:string"/>
+            <xs:attribute name="header-validator" type="xs:string"/>
+            <xs:attribute name="header-validators" type="xs:string"/>
+          </xs:complexType>
+        </xs:element>
+        <xs:element name="receive-response">
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element name="selector" type="xs:string" minOccurs="0"/>
+              <xs:element name="response" type="tns:HttpResponse"/>
+              <xs:element name="validate" minOccurs="0" maxOccurs="unbounded" type="tns:Validate"/>
+              <xs:element name="extract" minOccurs="0" maxOccurs="unbounded" type="tns:Extract"/>
+            </xs:sequence>
+            <xs:attribute name="timeout" type="xs:int"/>
+            <xs:attribute name="select" type="xs:string"/>
+            <xs:attribute name="validator" type="xs:string"/>
+            <xs:attribute name="validators" type="xs:string"/>
+            <xs:attribute name="header-validator" type="xs:string"/>
+            <xs:attribute name="header-validators" type="xs:string"/>
+          </xs:complexType>
+        </xs:element>
+        <xs:element name="send-request">
+          <xs:complexType>
+            <xs:sequence>
+              <xs:choice>
+                <xs:element name="GET" type="tns:HttpRequest"/>
+                <xs:element name="POST" type="tns:HttpRequest"/>
+                <xs:element name="PUT" type="tns:HttpRequest"/>
+                <xs:element name="DELETE" type="tns:HttpRequest"/>
+                <xs:element name="HEAD" type="tns:HttpRequest"/>
+                <xs:element name="OPTIONS" type="tns:HttpRequest"/>
+                <xs:element name="PATCH" type="tns:HttpRequest"/>
+                <xs:element name="TRACE" type="tns:HttpRequest"/>
+              </xs:choice>
+              <xs:element name="extract" minOccurs="0" maxOccurs="unbounded" type="tns:Extract"/>
+            </xs:sequence>
+            <xs:attribute name="uri" type="xs:string"/>
+            <xs:attribute name="fork" type="xs:boolean"/>
+          </xs:complexType>
+        </xs:element>
+        <xs:element name="send-response">
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element name="response" type="tns:HttpResponse"/>
+              <xs:element name="extract" minOccurs="0" maxOccurs="unbounded" type="tns:Extract"/>
+            </xs:sequence>
+          </xs:complexType>
+        </xs:element>
+      </xs:choice>
+    </xs:sequence>
+    <xs:attribute name="actor" type="xs:string"/>
+    <xs:attribute name="client" type="xs:string"/>
+    <xs:attribute name="server" type="xs:string"/>
+  </xs:complexType>
+
+  <xs:complexType name="HttpRequest">
+    <xs:complexContent>
+      <xs:extension base="tns:MessageType">
+        <xs:sequence>
+          <xs:element name="param" minOccurs="0" maxOccurs="unbounded">
+            <xs:complexType>
+              <xs:sequence/>
+              <xs:attribute name="name" type="xs:string" use="required"/>
+              <xs:attribute name="value" type="xs:string"/>
+            </xs:complexType>
+          </xs:element>
+        </xs:sequence>
+        <xs:attribute name="path" type="xs:string"/>
+        <xs:attribute name="content-type" type="xs:string"/>
+        <xs:attribute name="accept" type="xs:string"/>
+        <xs:attribute name="version" type="xs:string"/>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+
+  <xs:complexType name="HttpResponse">
+    <xs:complexContent>
+      <xs:extension base="tns:MessageType">
+        <xs:attribute name="status" type="xs:string"/>
+        <xs:attribute name="reason-phrase" type="xs:string"/>
+        <xs:attribute name="version" type="xs:string"/>
+        <xs:attribute name="content-type" type="xs:string"/>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+
+  <xs:complexType name="Soap">
+    <xs:sequence>
+      <xs:element name="description" type="xs:string" minOccurs="0"/>
+      <xs:choice>
+        <xs:element name="receive-request">
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element name="selector" type="xs:string" minOccurs="0"/>
+              <xs:element name="message" type="tns:SoapRequest"/>
+              <xs:element name="validate" minOccurs="0" maxOccurs="unbounded" type="tns:Validate"/>
+              <xs:element name="extract" minOccurs="0" maxOccurs="unbounded" type="tns:Extract"/>
+            </xs:sequence>
+            <xs:attribute name="timeout" type="xs:int"/>
+            <xs:attribute name="select" type="xs:string"/>
+            <xs:attribute name="validator" type="xs:string"/>
+            <xs:attribute name="validators" type="xs:string"/>
+            <xs:attribute name="header-validator" type="xs:string"/>
+            <xs:attribute name="header-validators" type="xs:string"/>
+            <xs:attribute name="attachment-validator" type="xs:string"/>
+          </xs:complexType>
+        </xs:element>
+        <xs:element name="receive-response">
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element name="selector" type="xs:string" minOccurs="0"/>
+              <xs:element name="message" type="tns:SoapResponse"/>
+              <xs:element name="validate" minOccurs="0" maxOccurs="unbounded" type="tns:Validate"/>
+              <xs:element name="extract" minOccurs="0" maxOccurs="unbounded" type="tns:Extract"/>
+            </xs:sequence>
+            <xs:attribute name="timeout" type="xs:int"/>
+            <xs:attribute name="select" type="xs:string"/>
+            <xs:attribute name="validator" type="xs:string"/>
+            <xs:attribute name="validators" type="xs:string"/>
+            <xs:attribute name="header-validator" type="xs:string"/>
+            <xs:attribute name="header-validators" type="xs:string"/>
+            <xs:attribute name="attachment-validator" type="xs:string"/>
+          </xs:complexType>
+        </xs:element>
+        <xs:element name="send-request">
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element name="message" type="tns:SoapRequest"/>
+              <xs:element name="extract" minOccurs="0" maxOccurs="unbounded" type="tns:Extract"/>
+            </xs:sequence>
+            <xs:attribute name="uri" type="xs:string"/>
+            <xs:attribute name="fork" type="xs:boolean"/>
+          </xs:complexType>
+        </xs:element>
+        <xs:element name="send-response">
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element name="message" type="tns:SoapResponse"/>
+              <xs:element name="extract" minOccurs="0" maxOccurs="unbounded" type="tns:Extract"/>
+            </xs:sequence>
+          </xs:complexType>
+        </xs:element>
+        <xs:element name="send-fault">
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element name="message" type="tns:SoapFault"/>
+              <xs:element name="extract" minOccurs="0" maxOccurs="unbounded" type="tns:Extract"/>
+            </xs:sequence>
+          </xs:complexType>
+        </xs:element>
+        <xs:element name="assert-fault">
+          <xs:complexType>
+            <xs:complexContent>
+              <xs:extension base="tns:SoapFault">
+                <xs:sequence>
+                  <xs:element name="when" type="tns:TestActions"/>
+                </xs:sequence>
+                <xs:attribute name="validator" type="xs:string"/>
+              </xs:extension>
+            </xs:complexContent>
+          </xs:complexType>
+        </xs:element>
+      </xs:choice>
+    </xs:sequence>
+    <xs:attribute name="actor" type="xs:string"/>
+    <xs:attribute name="client" type="xs:string"/>
+    <xs:attribute name="server" type="xs:string"/>
+  </xs:complexType>
+
+  <xs:complexType name="SoapMessageType">
+    <xs:complexContent>
+      <xs:extension base="tns:MessageType">
+        <xs:sequence>
+          <xs:element name="attachment" minOccurs="0" maxOccurs="unbounded">
+            <xs:complexType>
+              <xs:choice>
+                <xs:element name="content" type="xs:string"/>
+                <xs:element name="resource">
+                  <xs:complexType>
+                    <xs:attribute name="file" use="required" type="xs:string"/>
+                  </xs:complexType>
+                </xs:element>
+              </xs:choice>
+              <xs:attribute name="content-id" type="xs:string"/>
+              <xs:attribute name="content-type" type="xs:string"/>
+              <xs:attribute name="charset" type="xs:string"/>
+            </xs:complexType>
+          </xs:element>
+        </xs:sequence>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+
+  <xs:complexType name="SoapRequest">
+    <xs:complexContent>
+      <xs:extension base="tns:SoapMessageType">
+        <xs:attribute name="soap-action" type="xs:string"/>
+        <xs:attribute name="mtom-enabled" type="xs:boolean"/>
+        <xs:attribute name="path" type="xs:string"/>
+        <xs:attribute name="content-type" type="xs:string"/>
+        <xs:attribute name="accept" type="xs:string"/>
+        <xs:attribute name="version" type="xs:string"/>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+
+  <xs:complexType name="SoapResponse">
+    <xs:complexContent>
+      <xs:extension base="tns:SoapMessageType">
+        <xs:attribute name="status" type="xs:string"/>
+        <xs:attribute name="reason-phrase" type="xs:string"/>
+        <xs:attribute name="version" type="xs:string"/>
+        <xs:attribute name="content-type" type="xs:string"/>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+
+  <xs:complexType name="SoapFault">
+    <xs:complexContent>
+      <xs:extension base="tns:SoapResponse">
+        <xs:sequence>
+          <xs:element name="fault-detail" minOccurs="0" maxOccurs="unbounded">
+            <xs:complexType>
+              <xs:choice>
+                <xs:element name="content" type="xs:string"/>
+                <xs:element name="resource">
+                  <xs:complexType>
+                    <xs:attribute name="file" use="required" type="xs:string"/>
+                  </xs:complexType>
+                </xs:element>
+              </xs:choice>
+            </xs:complexType>
+          </xs:element>
+        </xs:sequence>
+        <xs:attribute name="fault-code" type="xs:string"/>
+        <xs:attribute name="fault-string" type="xs:string"/>
+        <xs:attribute name="fault-actor" type="xs:string"/>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+
+  <xs:simpleType name="AutofillType">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="REQUIRED"/>
+      <xs:enumeration value="ALL"/>
+      <xs:enumeration value="NONE"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:complexType name="OpenApi">
+    <xs:sequence>
+      <xs:element name="description" type="xs:string" minOccurs="0"/>
+      <xs:choice>
+        <xs:element name="receive-request">
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element name="selector" type="xs:string" minOccurs="0"/>
+              <xs:element name="validate" minOccurs="0" maxOccurs="unbounded" type="tns:Validate"/>
+              <xs:element name="extract" minOccurs="0" maxOccurs="unbounded" type="tns:Extract"/>
+            </xs:sequence>
+            <xs:attribute name="operation" type="xs:string" use="required"/>
+            <xs:attribute name="timeout" type="xs:int"/>
+            <xs:attribute name="select" type="xs:string"/>
+            <xs:attribute name="validator" type="xs:string"/>
+            <xs:attribute name="validators" type="xs:string"/>
+            <xs:attribute name="header-validator" type="xs:string"/>
+            <xs:attribute name="header-validators" type="xs:string"/>
+            <xs:attribute name="schemaValidation" type="xs:boolean"/>
+          </xs:complexType>
+        </xs:element>
+        <xs:element name="receive-response">
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element name="selector" type="xs:string" minOccurs="0"/>
+              <xs:element name="validate" minOccurs="0" maxOccurs="unbounded" type="tns:Validate"/>
+              <xs:element name="extract" minOccurs="0" maxOccurs="unbounded" type="tns:Extract"/>
+            </xs:sequence>
+            <xs:attribute name="operation" type="xs:string" use="required"/>
+            <xs:attribute name="status" type="xs:string"/>
+            <xs:attribute name="timeout" type="xs:int"/>
+            <xs:attribute name="select" type="xs:string"/>
+            <xs:attribute name="validator" type="xs:string"/>
+            <xs:attribute name="validators" type="xs:string"/>
+            <xs:attribute name="header-validator" type="xs:string"/>
+            <xs:attribute name="header-validators" type="xs:string"/>
+            <xs:attribute name="schemaValidation" type="xs:boolean"/>
+          </xs:complexType>
+        </xs:element>
+        <xs:element name="send-request">
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element name="extract" minOccurs="0" maxOccurs="unbounded" type="tns:Extract"/>
+            </xs:sequence>
+            <xs:attribute name="operation" type="xs:string" use="required"/>
+            <xs:attribute name="uri" type="xs:string"/>
+            <xs:attribute name="fork" type="xs:boolean"/>
+            <xs:attribute name="schemaValidation" type="xs:boolean"/>
+            <xs:attribute name="autofill" type="tns:AutofillType" default="REQUIRED"/>
+          </xs:complexType>
+        </xs:element>
+        <xs:element name="send-response">
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element name="extract" minOccurs="0" maxOccurs="unbounded" type="tns:Extract"/>
+            </xs:sequence>
+            <xs:attribute name="operation" type="xs:string" use="required"/>
+            <xs:attribute name="status" type="xs:string"/>
+            <xs:attribute name="schemaValidation" type="xs:boolean"/>
+            <xs:attribute name="autofill" type="tns:AutofillType" default="REQUIRED"/>
+          </xs:complexType>
+        </xs:element>
+      </xs:choice>
+    </xs:sequence>
+    <xs:attribute name="specification" type="xs:string" use="required"/>
+    <xs:attribute name="actor" type="xs:string"/>
+    <xs:attribute name="client" type="xs:string"/>
+    <xs:attribute name="server" type="xs:string"/>
+  </xs:complexType>
+
+  <xs:complexType name="Agent">
+    <xs:annotation>
+      <xs:documentation>Connect with Citrus Agent to run test actions on foreign platforms such as Docker or Kubernetes.</xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="description" type="xs:string" minOccurs="0"/>
+      <xs:choice>
+        <xs:element name="connect">
+          <xs:complexType>
+            <xs:attribute name="url" type="xs:string"/>
+            <xs:attribute name="port" type="xs:int"/>
+          </xs:complexType>
+        </xs:element>
+        <xs:element name="run">
+          <xs:complexType>
+            <xs:choice>
+              <xs:element name="source">
+                <xs:complexType>
+                  <xs:sequence>
+                    <xs:element name="code" minOccurs="0" type="xs:string"/>
+                  </xs:sequence>
+                  <xs:attribute name="file" type="xs:string"/>
+                </xs:complexType>
+              </xs:element>
+              <xs:element name="actions">
+                <xs:complexType>
+                  <xs:sequence>
+                    <xs:any processContents="lax"/>
+                  </xs:sequence>
+                </xs:complexType>
+              </xs:element>
+            </xs:choice>
+          </xs:complexType>
+        </xs:element>
+      </xs:choice>
+    </xs:sequence>
+    <xs:attribute name="name" type="xs:string"/>
+  </xs:complexType>
+
+  <xs:complexType name="JBang">
+    <xs:annotation>
+      <xs:documentation>Connect with JBang to run scripts as spawned processes</xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="description" type="xs:string" minOccurs="0"/>
+      <xs:element name="system-properties" minOccurs="0">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="system-property" minOccurs="1" maxOccurs="unbounded">
+              <xs:complexType>
+                <xs:attribute name="name" use="required" type="xs:string"/>
+                <xs:attribute name="value" use="required" type="xs:string"/>
+              </xs:complexType>
+            </xs:element>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="args" minOccurs="0">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="arg" minOccurs="1" maxOccurs="unbounded">
+              <xs:complexType>
+                <xs:attribute name="name" type="xs:string"/>
+                <xs:attribute name="value" use="required" type="xs:string"/>
+              </xs:complexType>
+            </xs:element>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="output" type="xs:string" minOccurs="0"/>
+    </xs:sequence>
+    <xs:attribute name="app" type="xs:string"/>
+    <xs:attribute name="command" type="xs:string"/>
+    <xs:attribute name="file" type="xs:string"/>
+    <xs:attribute name="args" type="xs:string"/>
+    <xs:attribute name="exit-code" type="xs:string"/>
+    <xs:attribute name="print-output" type="xs:boolean"/>
+    <xs:attribute name="save-pid" type="xs:string"/>
+    <xs:attribute name="save-output" type="xs:string"/>
+  </xs:complexType>
+
+  <xs:complexType name="Kubernetes">
+    <xs:annotation>
+      <xs:documentation>Connect with Kubernetes to manage resources on the cluster</xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="description" type="xs:string" minOccurs="0"/>
+      <xs:choice>
+        <xs:element name="agent">
+          <xs:complexType>
+            <xs:choice>
+              <xs:element name="connect">
+                <xs:complexType>
+                  <xs:attribute name="name" type="xs:string"/>
+                  <xs:attribute name="image-registry" type="xs:string"/>
+                  <xs:attribute name="image" type="xs:string"/>
+                  <xs:attribute name="port" type="xs:string"/>
+                  <xs:attribute name="test-jar" type="xs:string"/>
+                  <xs:attribute name="local-port" type="xs:string"/>
+                  <xs:attribute name="wait-for-running-state" type="xs:boolean"/>
+                  <xs:attribute name="timeout" type="xs:string"/>
+                </xs:complexType>
+              </xs:element>
+              <xs:element name="disconnect">
+                <xs:complexType>
+                  <xs:attribute name="name" type="xs:string"/>
+                </xs:complexType>
+              </xs:element>
+            </xs:choice>
+          </xs:complexType>
+        </xs:element>
+        <xs:element name="connect">
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element name="service" minOccurs="0">
+                <xs:complexType>
+                  <xs:attribute name="name" use="required" type="xs:string"/>
+                  <xs:attribute name="port" use="required" type="xs:string"/>
+                  <xs:attribute name="local-port" type="xs:string"/>
+                </xs:complexType>
+              </xs:element>
+            </xs:sequence>
+          </xs:complexType>
+        </xs:element>
+        <xs:element name="disconnect">
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element name="service" minOccurs="0">
+                <xs:complexType>
+                  <xs:attribute name="name" use="required" type="xs:string"/>
+                </xs:complexType>
+              </xs:element>
+            </xs:sequence>
+          </xs:complexType>
+        </xs:element>
+        <xs:element name="connect-service">
+          <xs:complexType>
+            <xs:attribute name="name" use="required" type="xs:string"/>
+            <xs:attribute name="port" use="required" type="xs:string"/>
+            <xs:attribute name="local-port" type="xs:string"/>
+          </xs:complexType>
+        </xs:element>
+        <xs:element name="disconnect-service">
+          <xs:complexType>
+            <xs:attribute name="name" use="required" type="xs:string"/>
+          </xs:complexType>
+        </xs:element>
+        <xs:element name="create-service">
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element name="ports" minOccurs="0">
+                <xs:complexType>
+                  <xs:sequence>
+                    <xs:element name="port-mapping" maxOccurs="unbounded">
+                      <xs:complexType>
+                        <xs:attribute name="port" use="required" type="xs:string"/>
+                        <xs:attribute name="target-port" use="required" type="xs:string"/>
+                      </xs:complexType>
+                    </xs:element>
+                  </xs:sequence>
+                </xs:complexType>
+              </xs:element>
+              <xs:element name="selector" minOccurs="0">
+                <xs:complexType>
+                  <xs:sequence>
+                    <xs:element name="label" maxOccurs="unbounded">
+                      <xs:complexType>
+                        <xs:attribute name="name" use="required" type="xs:string"/>
+                        <xs:attribute name="value" use="required" type="xs:string"/>
+                      </xs:complexType>
+                    </xs:element>
+                  </xs:sequence>
+                </xs:complexType>
+              </xs:element>
+            </xs:sequence>
+            <xs:attribute name="name" use="required" type="xs:string"/>
+            <xs:attribute name="server" type="xs:string"/>
+            <xs:attribute name="auto-create-server-binding" type="xs:boolean"/>
+            <xs:attribute name="protocol" type="xs:string"/>
+          </xs:complexType>
+        </xs:element>
+        <xs:element name="create-secret">
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element name="properties" minOccurs="0">
+                <xs:complexType>
+                  <xs:sequence>
+                    <xs:element name="property" maxOccurs="unbounded">
+                      <xs:complexType>
+                        <xs:attribute name="name" use="required" type="xs:string"/>
+                        <xs:attribute name="value" use="required" type="xs:string"/>
+                      </xs:complexType>
+                    </xs:element>
+                  </xs:sequence>
+                </xs:complexType>
+              </xs:element>
+            </xs:sequence>
+            <xs:attribute name="name" use="required" type="xs:string"/>
+            <xs:attribute name="file" type="xs:string"/>
+          </xs:complexType>
+        </xs:element>
+        <xs:element name="create-config-map">
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element name="properties" minOccurs="0">
+                <xs:complexType>
+                  <xs:sequence>
+                    <xs:element name="property" maxOccurs="unbounded">
+                      <xs:complexType>
+                        <xs:attribute name="name" use="required" type="xs:string"/>
+                        <xs:attribute name="value" use="required" type="xs:string"/>
+                      </xs:complexType>
+                    </xs:element>
+                  </xs:sequence>
+                </xs:complexType>
+              </xs:element>
+            </xs:sequence>
+            <xs:attribute name="name" use="required" type="xs:string"/>
+            <xs:attribute name="file" type="xs:string"/>
+          </xs:complexType>
+        </xs:element>
+        <xs:element name="create-resource">
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element name="data" type="xs:string" minOccurs="0"/>
+            </xs:sequence>
+            <xs:attribute name="file" type="xs:string"/>
+          </xs:complexType>
+        </xs:element>
+        <xs:element name="create-custom-resource">
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element name="data" type="xs:string" minOccurs="0"/>
+            </xs:sequence>
+            <xs:attribute name="file" type="xs:string"/>
+            <xs:attribute name="type" type="xs:string"/>
+            <xs:attribute name="kind" type="xs:string"/>
+            <xs:attribute name="group" type="xs:string"/>
+            <xs:attribute name="version" type="xs:string"/>
+            <xs:attribute name="api-version" type="xs:string"/>
+          </xs:complexType>
+        </xs:element>
+        <xs:element name="create-labels">
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element name="labels">
+                <xs:complexType>
+                  <xs:sequence>
+                    <xs:element name="label" maxOccurs="unbounded">
+                      <xs:complexType>
+                        <xs:attribute name="name" use="required" type="xs:string"/>
+                        <xs:attribute name="value" use="required" type="xs:string"/>
+                      </xs:complexType>
+                    </xs:element>
+                  </xs:sequence>
+                </xs:complexType>
+              </xs:element>
+            </xs:sequence>
+            <xs:attribute name="resource" use="required" type="xs:string"/>
+            <xs:attribute name="type" use="required" default="DEPLOYMENT">
+              <xs:simpleType>
+                <xs:restriction base="xs:string">
+                  <xs:enumeration value="POD"/>
+                  <xs:enumeration value="DEPLOYMENT"/>
+                  <xs:enumeration value="SERVICE"/>
+                  <xs:enumeration value="SECRET"/>
+                </xs:restriction>
+              </xs:simpleType>
+            </xs:attribute>
+          </xs:complexType>
+        </xs:element>
+        <xs:element name="create-annotations">
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element name="annotations">
+                <xs:complexType>
+                  <xs:sequence>
+                    <xs:element name="annotation" maxOccurs="unbounded">
+                      <xs:complexType>
+                        <xs:attribute name="name" use="required" type="xs:string"/>
+                        <xs:attribute name="value" use="required" type="xs:string"/>
+                      </xs:complexType>
+                    </xs:element>
+                  </xs:sequence>
+                </xs:complexType>
+              </xs:element>
+            </xs:sequence>
+            <xs:attribute name="resource" use="required" type="xs:string"/>
+            <xs:attribute name="type" use="required" default="DEPLOYMENT">
+              <xs:simpleType>
+                <xs:restriction base="xs:string">
+                  <xs:enumeration value="POD"/>
+                  <xs:enumeration value="DEPLOYMENT"/>
+                  <xs:enumeration value="SERVICE"/>
+                  <xs:enumeration value="SECRET"/>
+                </xs:restriction>
+              </xs:simpleType>
+            </xs:attribute>
+          </xs:complexType>
+        </xs:element>
+        <xs:element name="delete-service">
+          <xs:complexType>
+            <xs:attribute name="name" use="required" type="xs:string"/>
+          </xs:complexType>
+        </xs:element>
+        <xs:element name="delete-secret">
+          <xs:complexType>
+            <xs:attribute name="name" use="required" type="xs:string"/>
+          </xs:complexType>
+        </xs:element>
+        <xs:element name="delete-config-map">
+          <xs:complexType>
+            <xs:attribute name="name" use="required" type="xs:string"/>
+          </xs:complexType>
+        </xs:element>
+        <xs:element name="delete-resource">
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element name="data" type="xs:string" minOccurs="0"/>
+            </xs:sequence>
+            <xs:attribute name="file" type="xs:string"/>
+          </xs:complexType>
+        </xs:element>
+        <xs:element name="delete-custom-resource">
+          <xs:complexType>
+            <xs:attribute name="name" use="required" type="xs:string"/>
+            <xs:attribute name="type" type="xs:string"/>
+            <xs:attribute name="kind" type="xs:string"/>
+            <xs:attribute name="group" type="xs:string"/>
+            <xs:attribute name="version" type="xs:string"/>
+            <xs:attribute name="api-version" type="xs:string"/>
+          </xs:complexType>
+        </xs:element>
+        <xs:element name="verify-pod">
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element name="labels" minOccurs="0">
+                <xs:complexType>
+                  <xs:sequence>
+                    <xs:element name="label" maxOccurs="unbounded">
+                      <xs:complexType>
+                        <xs:attribute name="name" use="required" type="xs:string"/>
+                        <xs:attribute name="value" use="required" type="xs:string"/>
+                      </xs:complexType>
+                    </xs:element>
+                  </xs:sequence>
+                </xs:complexType>
+              </xs:element>
+            </xs:sequence>
+            <xs:attribute name="name" type="xs:string"/>
+            <xs:attribute name="label" type="xs:string"/>
+            <xs:attribute name="phase" type="xs:string"/>
+            <xs:attribute name="log-message" type="xs:string"/>
+            <xs:attribute name="print-logs" type="xs:boolean"/>
+            <xs:attribute name="max-attempts" type="xs:int"/>
+            <xs:attribute name="delay-between-attempts" type="xs:long"/>
+          </xs:complexType>
+        </xs:element>
+        <xs:element name="verify-custom-resource">
+          <xs:complexType>
+            <xs:attribute name="name" type="xs:string"/>
+            <xs:attribute name="type" type="xs:string"/>
+            <xs:attribute name="kind" type="xs:string"/>
+            <xs:attribute name="group" type="xs:string"/>
+            <xs:attribute name="version" type="xs:string"/>
+            <xs:attribute name="api-version" type="xs:string"/>
+            <xs:attribute name="condition" type="xs:string"/>
+            <xs:attribute name="label" type="xs:string"/>
+            <xs:attribute name="max-attempts" type="xs:int"/>
+            <xs:attribute name="delay-between-attempts" type="xs:long"/>
+          </xs:complexType>
+        </xs:element>
+        <xs:element name="watch-pod-logs">
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element name="labels" minOccurs="0">
+                <xs:complexType>
+                  <xs:sequence>
+                    <xs:element name="label" maxOccurs="unbounded">
+                      <xs:complexType>
+                        <xs:attribute name="name" use="required" type="xs:string"/>
+                        <xs:attribute name="value" use="required" type="xs:string"/>
+                      </xs:complexType>
+                    </xs:element>
+                  </xs:sequence>
+                </xs:complexType>
+              </xs:element>
+            </xs:sequence>
+            <xs:attribute name="name" type="xs:string"/>
+            <xs:attribute name="label" type="xs:string"/>
+            <xs:attribute name="timeout" type="xs:string"/>
+          </xs:complexType>
+        </xs:element>
+      </xs:choice>
+    </xs:sequence>
+    <xs:attribute name="client" type="xs:string"/>
+    <xs:attribute name="namespace" type="xs:string"/>
+    <xs:attribute name="auto-remove" type="xs:boolean"/>
+    <xs:attribute name="actor" type="xs:string"/>
+  </xs:complexType>
+
+  <xs:complexType name="Knative">
+    <xs:annotation>
+      <xs:documentation>Connect with Knative to manage resources on the cluster</xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="description" type="xs:string" minOccurs="0"/>
+      <xs:choice>
+        <xs:element name="create-broker">
+          <xs:complexType>
+            <xs:attribute name="name" use="required" type="xs:string"/>
+          </xs:complexType>
+        </xs:element>
+        <xs:element name="delete-broker">
+          <xs:complexType>
+            <xs:attribute name="name" use="required" type="xs:string"/>
+          </xs:complexType>
+        </xs:element>
+        <xs:element name="verify-broker">
+          <xs:complexType>
+            <xs:attribute name="name" use="required" type="xs:string"/>
+          </xs:complexType>
+        </xs:element>
+        <xs:element name="create-trigger">
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element name="filter" minOccurs="0">
+                <xs:complexType>
+                  <xs:sequence>
+                    <xs:element name="attribute" maxOccurs="unbounded">
+                      <xs:complexType>
+                        <xs:attribute name="name" use="required" type="xs:string"/>
+                        <xs:attribute name="value" use="required" type="xs:string"/>
+                      </xs:complexType>
+                    </xs:element>
+                  </xs:sequence>
+                </xs:complexType>
+              </xs:element>
+            </xs:sequence>
+            <xs:attribute name="name" use="required" type="xs:string"/>
+            <xs:attribute name="broker" use="required" type="xs:string"/>
+            <xs:attribute name="channel" type="xs:string"/>
+            <xs:attribute name="service" type="xs:string"/>
+          </xs:complexType>
+        </xs:element>
+        <xs:element name="delete-trigger">
+          <xs:complexType>
+            <xs:attribute name="name" use="required" type="xs:string"/>
+          </xs:complexType>
+        </xs:element>
+        <xs:element name="create-channel">
+          <xs:complexType>
+            <xs:attribute name="name" use="required" type="xs:string"/>
+          </xs:complexType>
+        </xs:element>
+        <xs:element name="delete-channel">
+          <xs:complexType>
+            <xs:attribute name="name" use="required" type="xs:string"/>
+          </xs:complexType>
+        </xs:element>
+        <xs:element name="create-subscription">
+          <xs:complexType>
+            <xs:attribute name="name" use="required" type="xs:string"/>
+            <xs:attribute name="channel" use="required" type="xs:string"/>
+            <xs:attribute name="service" use="required" type="xs:string"/>
+          </xs:complexType>
+        </xs:element>
+        <xs:element name="delete-subscription">
+          <xs:complexType>
+            <xs:attribute name="name" use="required" type="xs:string"/>
+          </xs:complexType>
+        </xs:element>
+        <xs:element name="send-event">
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element name="event">
+                <xs:complexType>
+                  <xs:sequence>
+                    <xs:element name="ce-attributes" minOccurs="0">
+                      <xs:complexType>
+                        <xs:sequence>
+                          <xs:element name="ce-attribute" maxOccurs="unbounded">
+                            <xs:complexType>
+                              <xs:attribute name="name" use="required" type="xs:string"/>
+                              <xs:attribute name="value" use="required" type="xs:string"/>
+                            </xs:complexType>
+                          </xs:element>
+                        </xs:sequence>
+                      </xs:complexType>
+                    </xs:element>
+                    <xs:element name="data" type="xs:string"/>
+                  </xs:sequence>
+                </xs:complexType>
+              </xs:element>
+            </xs:sequence>
+            <xs:attribute name="broker" use="required" type="xs:string"/>
+            <xs:attribute name="fork" type="xs:boolean"/>
+            <xs:attribute name="timeout" type="xs:int"/>
+          </xs:complexType>
+        </xs:element>
+        <xs:element name="receive-event">
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element name="event">
+                <xs:complexType>
+                  <xs:sequence>
+                    <xs:element name="ce-attributes" minOccurs="0">
+                      <xs:complexType>
+                        <xs:sequence>
+                          <xs:element name="ce-attribute" maxOccurs="unbounded">
+                            <xs:complexType>
+                              <xs:attribute name="name" use="required" type="xs:string"/>
+                              <xs:attribute name="value" use="required" type="xs:string"/>
+                            </xs:complexType>
+                          </xs:element>
+                        </xs:sequence>
+                      </xs:complexType>
+                    </xs:element>
+                    <xs:element name="data" type="xs:string"/>
+                  </xs:sequence>
+                </xs:complexType>
+              </xs:element>
+            </xs:sequence>
+            <xs:attribute name="service" use="required" type="xs:string"/>
+            <xs:attribute name="port" type="xs:int"/>
+            <xs:attribute name="timeout" type="xs:int"/>
+          </xs:complexType>
+        </xs:element>
+        <xs:element name="delete-resource">
+          <xs:complexType>
+            <xs:attribute name="component" use="required" type="xs:string"/>
+            <xs:attribute name="kind" use="required" type="xs:string"/>
+            <xs:attribute name="name" use="required" type="xs:string"/>
+          </xs:complexType>
+        </xs:element>
+      </xs:choice>
+    </xs:sequence>
+    <xs:attribute name="kubernetes-client" type="xs:string"/>
+    <xs:attribute name="client" type="xs:string"/>
+    <xs:attribute name="namespace" type="xs:string"/>
+    <xs:attribute name="auto-remove" type="xs:boolean"/>
+    <xs:attribute name="cluster-type" type="xs:string"/>
+    <xs:attribute name="actor" type="xs:string"/>
+  </xs:complexType>
+
+  <xs:complexType name="Testcontainers">
+    <xs:annotation>
+      <xs:documentation>Start and stop Docker containers via Testcontainers</xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="description" type="xs:string" minOccurs="0"/>
+      <xs:choice>
+        <xs:element name="compose">
+          <xs:complexType>
+            <xs:choice>
+              <xs:element name="up">
+                <xs:complexType>
+                  <xs:sequence>
+                    <xs:element name="exposedService" minOccurs="0" maxOccurs="unbounded">
+                      <xs:complexType>
+                        <xs:sequence>
+                          <xs:element name="wait-for" minOccurs="0">
+                            <xs:complexType>
+                              <xs:attribute name="log-message" type="xs:string"/>
+                              <xs:attribute name="url" type="xs:string"/>
+                              <xs:attribute name="disabled" type="xs:boolean"/>
+                            </xs:complexType>
+                          </xs:element>
+                        </xs:sequence>
+                        <xs:attribute name="name" use="required" type="xs:string"/>
+                        <xs:attribute name="port" use="required" type="xs:string"/>
+                      </xs:complexType>
+                    </xs:element>
+                  </xs:sequence>
+                  <xs:attribute name="name" type="xs:string"/>
+                  <xs:attribute name="file" type="xs:string"/>
+                  <xs:attribute name="auto-remove" type="xs:boolean"/>
+                  <xs:attribute name="startup-timeout" type="xs:int"/>
+                </xs:complexType>
+              </xs:element>
+              <xs:element name="down">
+                <xs:complexType>
+                  <xs:attribute name="name" type="xs:string"/>
+                </xs:complexType>
+              </xs:element>
+            </xs:choice>
+          </xs:complexType>
+        </xs:element>
+        <xs:element name="start">
+          <xs:complexType>
+            <xs:choice>
+              <xs:element name="container">
+                <xs:complexType>
+                  <xs:sequence>
+                    <xs:element name="labels" minOccurs="0">
+                      <xs:complexType>
+                        <xs:sequence>
+                          <xs:element name="label" maxOccurs="unbounded">
+                            <xs:complexType>
+                              <xs:attribute name="name" use="required" type="xs:string"/>
+                              <xs:attribute name="value" use="required" type="xs:string"/>
+                            </xs:complexType>
+                          </xs:element>
+                        </xs:sequence>
+                      </xs:complexType>
+                    </xs:element>
+                    <xs:element name="env" minOccurs="0">
+                      <xs:complexType>
+                        <xs:sequence>
+                          <xs:element name="variable" maxOccurs="unbounded">
+                            <xs:complexType>
+                              <xs:attribute name="name" use="required" type="xs:string"/>
+                              <xs:attribute name="value" use="required" type="xs:string"/>
+                            </xs:complexType>
+                          </xs:element>
+                        </xs:sequence>
+                      </xs:complexType>
+                    </xs:element>
+                    <xs:element name="exposed-ports" minOccurs="0">
+                      <xs:complexType>
+                        <xs:sequence>
+                          <xs:element name="port" maxOccurs="unbounded" type="xs:int"/>
+                        </xs:sequence>
+                      </xs:complexType>
+                    </xs:element>
+                    <xs:element name="port-bindings" minOccurs="0">
+                      <xs:complexType>
+                        <xs:sequence>
+                          <xs:element name="binding" maxOccurs="unbounded" type="xs:string"/>
+                        </xs:sequence>
+                      </xs:complexType>
+                    </xs:element>
+                    <xs:element name="wait-for" minOccurs="0">
+                      <xs:complexType>
+                        <xs:attribute name="log-message" type="xs:string"/>
+                        <xs:attribute name="url" type="xs:string"/>
+                        <xs:attribute name="disabled" type="xs:boolean"/>
+                      </xs:complexType>
+                    </xs:element>
+                    <xs:element name="volume-mounts" minOccurs="0">
+                      <xs:complexType>
+                        <xs:sequence>
+                          <xs:element name="mount" maxOccurs="unbounded">
+                            <xs:complexType>
+                              <xs:attribute name="file" use="required" type="xs:string"/>
+                              <xs:attribute name="mount-path" use="required" type="xs:string"/>
+                            </xs:complexType>
+                          </xs:element>
+                        </xs:sequence>
+                      </xs:complexType>
+                    </xs:element>
+                  </xs:sequence>
+                  <xs:attribute name="name" type="xs:string"/>
+                  <xs:attribute name="service-name" type="xs:string"/>
+                  <xs:attribute name="image" type="xs:string"/>
+                  <xs:attribute name="auto-remove" type="xs:boolean"/>
+                  <xs:attribute name="command" type="xs:string"/>
+                  <xs:attribute name="startup-timeout" type="xs:int"/>
+                </xs:complexType>
+              </xs:element>
+              <xs:element name="localstack">
+                <xs:complexType>
+                  <xs:sequence>
+                    <xs:element name="labels" minOccurs="0">
+                      <xs:complexType>
+                        <xs:sequence>
+                          <xs:element name="label" maxOccurs="unbounded">
+                            <xs:complexType>
+                              <xs:attribute name="name" use="required" type="xs:string"/>
+                              <xs:attribute name="value" use="required" type="xs:string"/>
+                            </xs:complexType>
+                          </xs:element>
+                        </xs:sequence>
+                      </xs:complexType>
+                    </xs:element>
+                    <xs:element name="env" minOccurs="0">
+                      <xs:complexType>
+                        <xs:sequence>
+                          <xs:element name="variable" maxOccurs="unbounded">
+                            <xs:complexType>
+                              <xs:attribute name="name" use="required" type="xs:string"/>
+                              <xs:attribute name="value" use="required" type="xs:string"/>
+                            </xs:complexType>
+                          </xs:element>
+                        </xs:sequence>
+                      </xs:complexType>
+                    </xs:element>
+                    <xs:element name="services" minOccurs="0">
+                      <xs:complexType>
+                        <xs:sequence>
+                          <xs:element name="service" maxOccurs="unbounded" type="xs:string"/>
+                        </xs:sequence>
+                      </xs:complexType>
+                    </xs:element>
+                    <xs:element name="options" minOccurs="0">
+                      <xs:complexType>
+                        <xs:sequence>
+                          <xs:element name="option" maxOccurs="unbounded">
+                            <xs:complexType>
+                              <xs:attribute name="name" use="required" type="xs:string"/>
+                              <xs:attribute name="value" use="required" type="xs:string"/>
+                            </xs:complexType>
+                          </xs:element>
+                        </xs:sequence>
+                      </xs:complexType>
+                    </xs:element>
+                  </xs:sequence>
+                  <xs:attribute name="name" type="xs:string"/>
+                  <xs:attribute name="service-name" type="xs:string"/>
+                  <xs:attribute name="version" type="xs:string"/>
+                  <xs:attribute name="auto-remove" type="xs:boolean"/>
+                  <xs:attribute name="auto-create-clients" type="xs:boolean"/>
+                  <xs:attribute name="services" type="xs:string"/>
+                  <xs:attribute name="image" type="xs:string"/>
+                  <xs:attribute name="command" type="xs:string"/>
+                  <xs:attribute name="startup-timeout" type="xs:int"/>
+                </xs:complexType>
+              </xs:element>
+              <xs:element name="mongodb">
+                <xs:complexType>
+                  <xs:sequence>
+                    <xs:element name="labels" minOccurs="0">
+                      <xs:complexType>
+                        <xs:sequence>
+                          <xs:element name="label" maxOccurs="unbounded">
+                            <xs:complexType>
+                              <xs:attribute name="name" use="required" type="xs:string"/>
+                              <xs:attribute name="value" use="required" type="xs:string"/>
+                            </xs:complexType>
+                          </xs:element>
+                        </xs:sequence>
+                      </xs:complexType>
+                    </xs:element>
+                    <xs:element name="env" minOccurs="0">
+                      <xs:complexType>
+                        <xs:sequence>
+                          <xs:element name="variable" maxOccurs="unbounded">
+                            <xs:complexType>
+                              <xs:attribute name="name" use="required" type="xs:string"/>
+                              <xs:attribute name="value" use="required" type="xs:string"/>
+                            </xs:complexType>
+                          </xs:element>
+                        </xs:sequence>
+                      </xs:complexType>
+                    </xs:element>
+                  </xs:sequence>
+                  <xs:attribute name="name" type="xs:string"/>
+                  <xs:attribute name="service-name" type="xs:string"/>
+                  <xs:attribute name="version" type="xs:string"/>
+                  <xs:attribute name="auto-remove" type="xs:boolean"/>
+                  <xs:attribute name="image" type="xs:string"/>
+                  <xs:attribute name="command" type="xs:string"/>
+                  <xs:attribute name="startup-timeout" type="xs:int"/>
+                </xs:complexType>
+              </xs:element>
+              <xs:element name="kafka">
+                <xs:complexType>
+                  <xs:sequence>
+                    <xs:element name="labels" minOccurs="0">
+                      <xs:complexType>
+                        <xs:sequence>
+                          <xs:element name="label" maxOccurs="unbounded">
+                            <xs:complexType>
+                              <xs:attribute name="name" use="required" type="xs:string"/>
+                              <xs:attribute name="value" use="required" type="xs:string"/>
+                            </xs:complexType>
+                          </xs:element>
+                        </xs:sequence>
+                      </xs:complexType>
+                    </xs:element>
+                    <xs:element name="env" minOccurs="0">
+                      <xs:complexType>
+                        <xs:sequence>
+                          <xs:element name="variable" maxOccurs="unbounded">
+                            <xs:complexType>
+                              <xs:attribute name="name" use="required" type="xs:string"/>
+                              <xs:attribute name="value" use="required" type="xs:string"/>
+                            </xs:complexType>
+                          </xs:element>
+                        </xs:sequence>
+                      </xs:complexType>
+                    </xs:element>
+                  </xs:sequence>
+                  <xs:attribute name="name" type="xs:string"/>
+                  <xs:attribute name="service-name" type="xs:string"/>
+                  <xs:attribute name="version" type="xs:string"/>
+                  <xs:attribute name="auto-remove" type="xs:boolean"/>
+                  <xs:attribute name="image" type="xs:string"/>
+                  <xs:attribute name="command" type="xs:string"/>
+                  <xs:attribute name="startup-timeout" type="xs:int"/>
+                </xs:complexType>
+              </xs:element>
+              <xs:element name="redpanda">
+                <xs:complexType>
+                  <xs:sequence>
+                    <xs:element name="labels" minOccurs="0">
+                      <xs:complexType>
+                        <xs:sequence>
+                          <xs:element name="label" maxOccurs="unbounded">
+                            <xs:complexType>
+                              <xs:attribute name="name" use="required" type="xs:string"/>
+                              <xs:attribute name="value" use="required" type="xs:string"/>
+                            </xs:complexType>
+                          </xs:element>
+                        </xs:sequence>
+                      </xs:complexType>
+                    </xs:element>
+                    <xs:element name="env" minOccurs="0">
+                      <xs:complexType>
+                        <xs:sequence>
+                          <xs:element name="variable" maxOccurs="unbounded">
+                            <xs:complexType>
+                              <xs:attribute name="name" use="required" type="xs:string"/>
+                              <xs:attribute name="value" use="required" type="xs:string"/>
+                            </xs:complexType>
+                          </xs:element>
+                        </xs:sequence>
+                      </xs:complexType>
+                    </xs:element>
+                  </xs:sequence>
+                  <xs:attribute name="name" type="xs:string"/>
+                  <xs:attribute name="service-name" type="xs:string"/>
+                  <xs:attribute name="version" type="xs:string"/>
+                  <xs:attribute name="auto-remove" type="xs:boolean"/>
+                  <xs:attribute name="image" type="xs:string"/>
+                  <xs:attribute name="command" type="xs:string"/>
+                  <xs:attribute name="startup-timeout" type="xs:int"/>
+                </xs:complexType>
+              </xs:element>
+              <xs:element name="postgresql">
+                <xs:complexType>
+                  <xs:sequence>
+                    <xs:element name="labels" minOccurs="0">
+                      <xs:complexType>
+                        <xs:sequence>
+                          <xs:element name="label" maxOccurs="unbounded">
+                            <xs:complexType>
+                              <xs:attribute name="name" use="required" type="xs:string"/>
+                              <xs:attribute name="value" use="required" type="xs:string"/>
+                            </xs:complexType>
+                          </xs:element>
+                        </xs:sequence>
+                      </xs:complexType>
+                    </xs:element>
+                    <xs:element name="env" minOccurs="0">
+                      <xs:complexType>
+                        <xs:sequence>
+                          <xs:element name="variable" maxOccurs="unbounded">
+                            <xs:complexType>
+                              <xs:attribute name="name" use="required" type="xs:string"/>
+                              <xs:attribute name="value" use="required" type="xs:string"/>
+                            </xs:complexType>
+                          </xs:element>
+                        </xs:sequence>
+                      </xs:complexType>
+                    </xs:element>
+                    <xs:element name="init-script" minOccurs="0">
+                      <xs:complexType>
+                        <xs:complexContent>
+                          <xs:extension base="xs:string">
+                            <xs:attribute name="file" type="xs:string"/>
+                          </xs:extension>
+                        </xs:complexContent>
+                      </xs:complexType>
+                    </xs:element>
+                  </xs:sequence>
+                  <xs:attribute name="name" type="xs:string"/>
+                  <xs:attribute name="service-name" type="xs:string"/>
+                  <xs:attribute name="version" type="xs:string"/>
+                  <xs:attribute name="auto-remove" type="xs:boolean"/>
+                  <xs:attribute name="datasource-name" type="xs:string"/>
+                  <xs:attribute name="database" type="xs:string"/>
+                  <xs:attribute name="username" type="xs:string"/>
+                  <xs:attribute name="password" type="xs:string"/>
+                  <xs:attribute name="image" type="xs:string"/>
+                  <xs:attribute name="command" type="xs:string"/>
+                  <xs:attribute name="startup-timeout" type="xs:int"/>
+                </xs:complexType>
+              </xs:element>
+            </xs:choice>
+          </xs:complexType>
+        </xs:element>
+        <xs:element name="stop">
+          <xs:complexType>
+            <xs:attribute name="name" use="required" type="xs:string"/>
+          </xs:complexType>
+        </xs:element>
+      </xs:choice>
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="Selenium">
+    <xs:sequence>
+      <xs:element name="description" type="xs:string" minOccurs="0"/>
+      <xs:choice>
+        <xs:element name="start">
+          <xs:complexType>
+            <xs:attribute name="browser" type="xs:string"/>
+          </xs:complexType>
+        </xs:element>
+        <xs:element name="stop">
+          <xs:complexType>
+            <xs:attribute name="browser" type="xs:string"/>
+          </xs:complexType>
+        </xs:element>
+
+        <xs:element name="clear-cache"/>
+
+        <xs:element name="find">
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element name="element" type="WebElementType"/>
+              <xs:element name="validate">
+                <xs:complexType>
+                  <xs:sequence>
+                    <xs:element name="attributes" minOccurs="0">
+                      <xs:complexType>
+                        <xs:sequence>
+                          <xs:element name="attribute" minOccurs="1" maxOccurs="unbounded">
+                            <xs:complexType>
+                              <xs:attribute name="name" type="xs:string" use="required"/>
+                              <xs:attribute name="value" type="xs:string" use="required"/>
+                            </xs:complexType>
+                          </xs:element>
+                        </xs:sequence>
+                      </xs:complexType>
+                    </xs:element>
+                    <xs:element name="styles" minOccurs="0">
+                      <xs:complexType>
+                        <xs:sequence>
+                          <xs:element name="style" minOccurs="1" maxOccurs="unbounded">
+                            <xs:complexType>
+                              <xs:attribute name="name" type="xs:string" use="required"/>
+                              <xs:attribute name="value" type="xs:string" use="required"/>
+                            </xs:complexType>
+                          </xs:element>
+                        </xs:sequence>
+                      </xs:complexType>
+                    </xs:element>
+                  </xs:sequence>
+                  <xs:attribute name="text" type="xs:string"/>
+                  <xs:attribute name="tag-name" type="xs:string"/>
+                  <xs:attribute name="displayed" type="xs:boolean"/>
+                  <xs:attribute name="enabled" type="xs:boolean"/>
+                </xs:complexType>
+              </xs:element>
+            </xs:sequence>
+          </xs:complexType>
+        </xs:element>
+
+        <xs:element name="page">
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element name="arguments" minOccurs="0">
+                <xs:complexType>
+                  <xs:sequence>
+                    <xs:element name="argument" type="xs:string" maxOccurs="unbounded"/>
+                  </xs:sequence>
+                </xs:complexType>
+              </xs:element>
+            </xs:sequence>
+            <xs:attribute name="name" type="xs:string"/>
+            <xs:attribute name="type" type="xs:string"/>
+            <xs:attribute name="validator" type="xs:string"/>
+            <xs:attribute name="action" type="xs:string"/>
+          </xs:complexType>
+        </xs:element>
+
+        <xs:element name="click">
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element name="element" type="WebElementType"/>
+            </xs:sequence>
+          </xs:complexType>
+        </xs:element>
+
+        <xs:element name="hover">
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element name="element" type="WebElementType"/>
+            </xs:sequence>
+          </xs:complexType>
+        </xs:element>
+
+        <xs:element name="set-input">
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element name="element" type="WebElementType"/>
+            </xs:sequence>
+            <xs:attribute name="value" type="xs:string" use="required"/>
+          </xs:complexType>
+        </xs:element>
+
+        <xs:element name="check-input">
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element name="element" type="WebElementType"/>
+            </xs:sequence>
+            <xs:attribute name="checked" type="xs:boolean" use="required"/>
+          </xs:complexType>
+        </xs:element>
+
+        <xs:element name="fill-form">
+          <xs:complexType>
+            <xs:choice>
+              <xs:element name="fields">
+                <xs:complexType>
+                  <xs:sequence>
+                    <xs:element name="field" maxOccurs="unbounded">
+                      <xs:complexType>
+                        <xs:sequence>
+                          <xs:element name="value" type="xs:string" minOccurs="0"/>
+                        </xs:sequence>
+                        <xs:attribute name="id" type="xs:string" use="required"/>
+                        <xs:attribute name="value" type="xs:string"/>
+                      </xs:complexType>
+                    </xs:element>
+                  </xs:sequence>
+                </xs:complexType>
+              </xs:element>
+              <xs:element name="json" type="xs:string"/>
+            </xs:choice>
+            <xs:attribute name="submit" type="xs:string"/>
+          </xs:complexType>
+        </xs:element>
+
+        <xs:element name="dropdown-select">
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element name="element" type="WebElementType"/>
+              <xs:element name="options" minOccurs="0">
+                <xs:complexType>
+                  <xs:sequence>
+                    <xs:element name="option" type="xs:string" minOccurs="1" maxOccurs="unbounded"/>
+                  </xs:sequence>
+                </xs:complexType>
+              </xs:element>
+            </xs:sequence>
+            <xs:attribute name="option" type="xs:string"/>
+          </xs:complexType>
+        </xs:element>
+
+        <xs:element name="wait">
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element name="element" type="WebElementType"/>
+            </xs:sequence>
+            <xs:attribute name="until" type="xs:string" use="required"/>
+          </xs:complexType>
+        </xs:element>
+
+        <xs:element name="javascript">
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element name="script"/>
+              <xs:element name="arguments" minOccurs="0">
+                <xs:complexType>
+                  <xs:sequence>
+                    <xs:element name="argument" type="xs:string" minOccurs="1" maxOccurs="unbounded"/>
+                  </xs:sequence>
+                </xs:complexType>
+              </xs:element>
+              <xs:element name="errors" minOccurs="0">
+                <xs:complexType>
+                  <xs:sequence>
+                    <xs:element name="error" type="xs:string" minOccurs="1" maxOccurs="unbounded"/>
+                  </xs:sequence>
+                </xs:complexType>
+              </xs:element>
+            </xs:sequence>
+            <xs:attribute name="argument" type="xs:string"/>
+            <xs:attribute name="error" type="xs:string"/>
+          </xs:complexType>
+        </xs:element>
+
+        <xs:element name="screenshot">
+          <xs:complexType>
+            <xs:attribute name="output-dir" type="xs:string"/>
+          </xs:complexType>
+        </xs:element>
+
+        <xs:element name="navigate">
+          <xs:complexType>
+            <xs:attribute name="page" type="xs:string" use="required"/>
+          </xs:complexType>
+        </xs:element>
+
+        <xs:element name="open-window">
+          <xs:complexType>
+            <xs:attribute name="name" type="xs:string" use="required"/>
+          </xs:complexType>
+        </xs:element>
+
+        <xs:element name="close-window">
+          <xs:complexType>
+            <xs:attribute name="name" type="xs:string" use="required"/>
+          </xs:complexType>
+        </xs:element>
+
+        <xs:element name="switch-window">
+          <xs:complexType>
+            <xs:attribute name="name" type="xs:string" use="required"/>
+          </xs:complexType>
+        </xs:element>
+
+        <xs:element name="store-file">
+          <xs:complexType>
+            <xs:attribute name="file-path" type="xs:string" use="required"/>
+          </xs:complexType>
+        </xs:element>
+
+        <xs:element name="get-stored-file">
+          <xs:complexType>
+            <xs:attribute name="file-name" type="xs:string" use="required"/>
+          </xs:complexType>
+        </xs:element>
+
+        <xs:element name="alert">
+          <xs:annotation>
+            <xs:documentation>Access current alert dialog and perform action (accept, dismiss)</xs:documentation>
+          </xs:annotation>
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element name="text" type="xs:string" minOccurs="0"/>
+            </xs:sequence>
+            <xs:attribute name="text" type="xs:string"/>
+            <xs:attribute name="accept" type="xs:boolean" use="required"/>
+          </xs:complexType>
+        </xs:element>
+      </xs:choice>
+    </xs:sequence>
+    <xs:attribute name="browser" type="xs:string"/>
+  </xs:complexType>
+
+  <xs:complexType name="WebElementType">
+    <xs:sequence>
+      <xs:element name="property" minOccurs="0">
+        <xs:complexType>
+          <xs:attribute name="name" type="xs:string" use="required"/>
+          <xs:attribute name="value" type="xs:string" use="required"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+    <xs:attribute name="id" type="xs:string"/>
+    <xs:attribute name="name" type="xs:string"/>
+    <xs:attribute name="tag-name" type="xs:string"/>
+    <xs:attribute name="class-name" type="xs:string"/>
+    <xs:attribute name="css-selector" type="xs:string"/>
+    <xs:attribute name="link-text" type="xs:string"/>
+    <xs:attribute name="xpath" type="xs:string"/>
+  </xs:complexType>
+
+</xs:schema>

--- a/catalog/citrus/4.10.1/index.json
+++ b/catalog/citrus/4.10.1/index.json
@@ -1,0 +1,51 @@
+{
+  "name" : "Citrus 4.10.1",
+  "version" : "4.10.1",
+  "runtime" : "Citrus",
+  "catalogs" : {
+    "actions" : {
+      "name" : "actions",
+      "description" : "Aggregated Citrus catalog for test actions",
+      "version" : "4.10.1",
+      "file" : "citrus-catalog-aggregate-test-actions.json"
+    },
+    "containers" : {
+      "name" : "containers",
+      "description" : "Aggregated Citrus catalog for test action containers",
+      "version" : "4.10.1",
+      "file" : "citrus-catalog-aggregate-test-containers.json"
+    },
+    "endpoints" : {
+      "name" : "endpoints",
+      "description" : "Aggregated Citrus catalog for endpoints",
+      "version" : "4.10.1",
+      "file" : "citrus-catalog-aggregate-endpoints.json"
+    },
+    "functions" : {
+      "name" : "functions",
+      "description" : "Aggregated Citrus catalog for functions",
+      "version" : "4.10.1",
+      "file" : "citrus-catalog-aggregate-functions.json"
+    },
+    "validationMatcher" : {
+      "name" : "validationMatcher",
+      "description" : "Aggregated Citrus catalog for validation matcher",
+      "version" : "4.10.1",
+      "file" : "citrus-catalog-aggregate-validation-matcher.json"
+    }
+  },
+  "schemas" : {
+    "citrus-yaml" : {
+      "name" : "citrus-yaml",
+      "description" : "Citrus Json schema for tests",
+      "version" : "4.10.1",
+      "file" : "citrus-testcase.json"
+    },
+    "citrus-xml-io" : {
+      "name" : "citrus-xml",
+      "description" : "Citrus XSD schema for tests",
+      "version" : "4.10.1",
+      "file" : "citrus-testcase.xsd"
+    }
+  }
+}

--- a/catalog/index.json
+++ b/catalog/index.json
@@ -113,6 +113,12 @@
 			"version" : "4.10.0",
 			"runtime" : "Citrus",
 			"fileName" : "citrus/4.10.0/index.json"
+		},
+		{
+			"name" : "Citrus 4.10.1",
+			"version" : "4.10.1",
+			"runtime" : "Citrus",
+			"fileName" : "citrus/4.10.1/index.json"
 		}
 	],
 	"version" : 3,

--- a/index.js
+++ b/index.js
@@ -39,7 +39,7 @@ const CATALOGS = {
     '4.4.0.redhat-00039',
   ],
   // https://repo1.maven.org/maven2/org/citrusframework/citrus-catalog-schema/
-  Citrus: ['4.10.0'],
+  Citrus: ['4.10.0', '4.10.1'],
 };
 
 const KAMELETS_VERSION = '4.18.0';


### PR DESCRIPTION
- Includes updated field schema descriptions for Citrus custom fields (such as EndpointField)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Citrus 4.10.1 framework support with comprehensive catalogs for agent configuration, test functions, test containers, and validation matchers.
  * Added support for Red Hat Camel Spring Boot 4.4.0.redhat-00039.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->